### PR TITLE
Rounded borders in the browser window are now always 1px wide

### DIFF
--- a/kupfer/ui/browser.py
+++ b/kupfer/ui/browser.py
@@ -1800,7 +1800,7 @@ class KupferWindow (gtk.Window):
 			cr.fill()
 
 		c = widget.style.dark[gtk.STATE_SELECTED]
-		cr.set_operator(cairo.OPERATOR_OVER)
+		cr.set_operator(cairo.OPERATOR_ATOP)
 		cr.set_source_rgba(*rgba_from_gdk(c, 0.7))
 
 		make_rounded_rect(cr, 0, 0, w, h, radius)


### PR DESCRIPTION
Rounded borders in the browser window are now always 1px wide (they used to look like they had a different width than the rect borders).
