### PR TITLE
a Custom Session Management plugin

### DIFF
--- a/help/C/plugin-calculator.page
+++ b/help/C/plugin-calculator.page
@@ -62,6 +62,10 @@
       </p>
      </item>
      </list>
+     <p>
+       The Calculator lets you also calculate expression without "=" on the 
+       beginning as long it have inside one of operators: +, -, *, /, ^, |, &, ~.
+     </p>
    </section>
   
 </page>

--- a/help/Makefile.am
+++ b/help/Makefile.am
@@ -33,7 +33,7 @@ DOC_PAGES = \
 	plugin-websearch.page
 
 
-DOC_LINGUAS = cs de es fr it pl sl
+DOC_LINGUAS = cs de es fr it pl ro sl
 
 
 # dist-hook: doc-dist-hook

--- a/help/ro/ro.po
+++ b/help/ro/ro.po
@@ -1,0 +1,1861 @@
+# Romanian translation for kupfer.
+# Copyright (C) 2011 kupfer's COPYRIGHT HOLDER
+# This file is distributed under the same license as the kupfer package.
+# Cătălin Bălan <laserbeam333@gmail.com>, 2011.
+msgid ""
+msgstr ""
+"Project-Id-Version: kupfer master\n"
+"POT-Creation-Date: 2011-06-23 10:09+0000\n"
+"PO-Revision-Date: 2011-01-06 14:51+0300\n"
+"Last-Translator: Cătălin Bălan <laserbeam333@gmail.com>\n"
+"Language-Team: Romanian Gnome Team <gnomero-list@lists.sourceforge.net\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ro\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2);;\n"
+"X-Generator: Virtaal 0.5.2\n"
+
+#: C/plugin-websearch.page:7(desc)
+msgid "Using the search the web plugin."
+msgstr ""
+
+#: C/plugin-websearch.page:10(app)
+#, fuzzy
+#| msgid "Search the Web Search Engines"
+msgid "Search the Web"
+msgstr "Motoare de căutare pentru Internet"
+
+#: C/plugin-websearch.page:13(title) C/plugin-triggers.page:23(title)
+#: C/plugin-notes.page:22(title) C/plugin-nautilusselection.page:13(title)
+#: C/plugin-gwibber.page:25(title) C/plugin-favorites.page:22(title)
+#: C/plugin-calculator.page:21(title) C/plugin-applications.page:19(title)
+#: C/generalusage.page:10(title)
+msgid "Basic Usage"
+msgstr "Folosire de bază"
+
+#: C/plugin-websearch.page:15(p)
+msgid "Activate Kupfer and make sure it is in free-text mode (press period)"
+msgstr ""
+
+#: C/plugin-websearch.page:17(p)
+msgid ""
+"Type in a search query and tap <key>Tab</key> to switch to the action pane."
+msgstr ""
+
+#: C/plugin-websearch.page:19(p)
+msgid ""
+"Type \"Search With\" to find Search the Web's action and tap <key>Tab</key> "
+"again to switch to the third pane (indirect object)."
+msgstr ""
+
+#: C/plugin-websearch.page:22(p)
+msgid ""
+"Select search engine with the arrow keys and type <key>Return</key> to open "
+"the search in a web browser."
+msgstr ""
+
+#: C/plugin-websearch.page:29(title)
+#, fuzzy
+#| msgid "Search the Web Search Engines"
+msgid "Search Engines"
+msgstr "Motoare de căutare pentru Internet"
+
+#: C/plugin-websearch.page:30(p)
+msgid ""
+"The Search the Web plugin uses <app>Firefox'</app> search engines, so you "
+"can add Search Engines directly in <app>Firefox</app> and <app>Kupfer</app> "
+"will find them later."
+msgstr ""
+"Modulul „Caută pe Internet” folosește motoarele de căutare din <app>Firefox</"
+"app>, așa că puteți adăuga motoare de căutare direct în <app>Firefox</app> "
+"și <app>Kupfer</app> le va găsi ulterior."
+
+#: C/plugin-websearch.page:35(p)
+msgid ""
+"You can also install custom search plugins directly, only for <app>Kupfer</"
+"app>, in the folder:"
+msgstr ""
+"De asemenea, puteți instala module de căutare direct, doar pentru "
+"<app>Kupfer</app>, în dosarul:"
+
+#: C/plugin-websearch.page:39(code)
+#, no-wrap
+msgid "~/.local/share/kupfer/searchplugins/"
+msgstr "~/.local/share/kupfer/searchplugins/"
+
+#: C/plugin-websearch.page:40(p)
+msgid "The search engine descriptions must written in OpenSearch format."
+msgstr ""
+
+#: C/plugin-triggers.page:7(desc)
+msgid "Using the triggers plugin."
+msgstr ""
+
+#: C/plugin-triggers.page:10(app) C/keyboard.page:213(title)
+msgid "Triggers"
+msgstr ""
+
+#: C/plugin-triggers.page:13(title)
+msgid "Triggers Plugin"
+msgstr ""
+
+#: C/plugin-triggers.page:14(p)
+msgid ""
+"With <app>Triggers</app> you can take a command you would normally perform "
+"in <app>Kupfer</app>, such as launching an application or opening a "
+"document, and bind a global key combination to run this command. As long as "
+"<app>Kupfer</app> is running, any application can have the current focus."
+msgstr ""
+
+#: C/plugin-triggers.page:25(title)
+msgid "Creating a new trigger"
+msgstr ""
+
+#: C/plugin-triggers.page:27(p)
+msgid "Set up a command in <app>Kupfer</app> that you want to run"
+msgstr ""
+
+#: C/plugin-triggers.page:32(p)
+msgid ""
+"Press <keyseq><key>Ctrl</key><key>Return</key></keyseq> to create a "
+"<em>composed command</em>."
+msgstr ""
+
+#: C/plugin-triggers.page:38(p)
+msgid ""
+"Type <key>Tab</key> and select the action <em>Add Trigger...</em> and press "
+"<key>Return</key>"
+msgstr ""
+
+#: C/plugin-triggers.page:44(p)
+msgid ""
+"Using the window that appears, press modifier keys and a letter or number "
+"key to set a global shortcut. An example is pressing and holding "
+"<keyseq><key>Ctrl</key><key>Alt</key></keyseq> and then pressing and "
+"releasing <key>R</key> to bind <keyseq><key>Ctrl</key><key>Alt</key><key>R</"
+"key></keyseq>."
+msgstr ""
+
+#: C/plugin-triggers.page:54(title)
+msgid "Removing a trigger"
+msgstr ""
+
+#: C/plugin-triggers.page:56(p)
+msgid ""
+"Find the source <em>Triggers</em> in <app>Kupfer</app> and press <key>→</"
+"key> to see its contents."
+msgstr ""
+
+#: C/plugin-triggers.page:62(p)
+msgid ""
+"Find the active trigger in the list and use the action <em>Remove Trigger</"
+"em>."
+msgstr ""
+
+#: C/plugin-triggers.page:68(p)
+msgid ""
+"Since trigger keyboard shortcuts are global, they can be used from any "
+"application. Select shortcuts with care so that they do not conflict with "
+"other functions."
+msgstr ""
+
+#: C/plugin-triggers.page:74(title) C/plugin-notes.page:60(title)
+#: C/plugin-gwibber.page:68(title) C/plugin-favorites.page:38(title)
+msgid "Power User Tips"
+msgstr ""
+
+#: C/plugin-triggers.page:75(p)
+msgid ""
+"<em>Proxy objects</em> such as <em>Selected Text</em>, <em>Selected File</"
+"em>, <em>Frontmost Window</em>, <em>Last Command</em> et cetera allow very "
+"powerful triggers."
+msgstr ""
+
+#: C/plugin-triggers.page:79(p)
+msgid ""
+"The application action <em>Launch</em> is special; if you bind a trigger "
+"using <em>Launch</em>, it will start the application if it is not running, "
+"but focus the application when it is already running. By contrast, <em>Start "
+"Again</em> will start the application if it is running or not."
+msgstr ""
+
+#: C/plugin-triggers.page:87(title)
+msgid "Example Triggers"
+msgstr ""
+
+#: C/plugin-triggers.page:90(em)
+msgid "Text Editor → Launch"
+msgstr ""
+
+#: C/plugin-triggers.page:91(p)
+msgid ""
+"Start <em>Text Editor</em> or focus its window if it is already running."
+msgstr ""
+
+#: C/plugin-triggers.page:97(em)
+msgid "Selected Text → Search With → Google"
+msgstr ""
+
+#: C/plugin-triggers.page:98(p)
+msgid "Search the web using the currently selected text."
+msgstr ""
+
+#: C/plugin-triggers.page:100(em)
+msgid "Selected File → Move To → (Downloads Folder)"
+msgstr ""
+
+#: C/plugin-triggers.page:101(p)
+msgid "Move the currently selected file to a specific folder"
+msgstr ""
+
+#: C/plugin-triggers.page:105(em)
+msgid "Songs → Search Contents"
+msgstr ""
+
+#: C/plugin-triggers.page:106(p)
+msgid ""
+"You may even add a trigger to open a specific subcatalog in Kupfer, for "
+"example Rhythmbox's songs."
+msgstr ""
+
+#: C/plugin-notes.page:7(desc)
+msgid "Using the notes plugin."
+msgstr ""
+
+#: C/plugin-notes.page:10(app) C/plugin-calculator.page:37(title)
+msgid "Notes"
+msgstr ""
+
+#: C/plugin-notes.page:13(title)
+#, fuzzy
+#| msgid "Plugins"
+msgid "Notes Plugin"
+msgstr "Module"
+
+#: C/plugin-notes.page:14(p)
+msgid ""
+"With <app>Notes</app> you can access or create new notes in either the "
+"program <app>Gnote</app> or <app>Tomboy</app>. <app>Notes</app> will work "
+"identically with either application—you can configure which one to use in "
+"the plugin's information pane in <app>Kupfer Preferences</app>."
+msgstr ""
+
+#: C/plugin-notes.page:24(title)
+msgid "Creating a new note"
+msgstr ""
+
+#: C/plugin-notes.page:26(p)
+msgid ""
+"Activate Kupfer and type <key>.</key> to enter text mode, then type in a "
+"note title"
+msgstr ""
+
+#: C/plugin-notes.page:32(p)
+msgid ""
+"Type <key>Tab</key> and select the action <em>Create Note</em> and press "
+"<key>Return</key>."
+msgstr ""
+
+#: C/plugin-notes.page:39(title)
+msgid "Finding a note by title"
+msgstr ""
+
+#: C/plugin-notes.page:41(p)
+msgid "Simply search for the note title in <app>Kupfer</app>"
+msgstr ""
+
+#: C/plugin-notes.page:45(title)
+#, fuzzy
+#| msgid "Descend into an object with content"
+msgid "Finding a note by content"
+msgstr "Coboară într-un obiect cu conținut"
+
+#: C/plugin-notes.page:47(p)
+msgid ""
+"Activate Kupfer and type <key>.</key> to enter text mode, then type in a "
+"search query"
+msgstr ""
+
+#: C/plugin-notes.page:53(p)
+msgid ""
+"Type <key>Tab</key> and select the action <em>Get Note Search Results...</"
+"em> and press <key>Return</key>."
+msgstr ""
+
+#: C/plugin-notes.page:63(p)
+msgid ""
+"You can use the <em>Selected Text</em> object and create a new note with the "
+"content of the selection."
+msgstr ""
+
+#: C/plugin-nautilusselection.page:7(desc)
+msgid "Using the selected file plugin."
+msgstr ""
+
+#: C/plugin-nautilusselection.page:10(app)
+msgid "Selected File"
+msgstr ""
+
+#: C/plugin-nautilusselection.page:14(p)
+msgid ""
+"Select a file in the file manager. Open <app>Kupfer</app> and search for the "
+"object <app>Selected File</app>, which represents the file or files that are "
+"selected."
+msgstr ""
+
+#: C/plugin-nautilusselection.page:19(p)
+msgid ""
+"Instead of searching, you can press <keyseq><key>Ctrl</key><key>G</key></"
+"keyseq> to directly focus the selected file. See <link xref=\"keyboard\"/> "
+"for more information."
+msgstr ""
+
+#: C/plugin-nautilusselection.page:26(title)
+msgid "<app>Selected File</app> requires <app>Nautilus</app>"
+msgstr ""
+
+#: C/plugin-nautilusselection.page:27(p)
+msgid ""
+"The selected file plugin works with the <app>Nautilus</app> file browser and "
+"requires that the extension <cmd>kupfer_provider.py</cmd> is installed (it "
+"is normally installed together with <app>Kupfer</app>). After installing it "
+"for the first time, <app>Nautilus</app> must start anew before it is active."
+msgstr ""
+
+#: C/plugin-gwibber.page:7(desc)
+msgid "Using the Gwibber plugin."
+msgstr ""
+
+#: C/plugin-gwibber.page:10(app)
+msgid "Gwibber"
+msgstr ""
+
+#: C/plugin-gwibber.page:13(title)
+msgid "Gwibber Plugin"
+msgstr ""
+
+#: C/plugin-gwibber.page:14(p)
+msgid ""
+"With the <app>Gwibber</app> plugin you can send messages to social networks "
+"such as Twitter or Identi.ca."
+msgstr ""
+
+#: C/plugin-gwibber.page:18(p)
+msgid ""
+"The plugin requires that the application <app>Gwibber</app> is installed and "
+"configured for your user. <app>Kupfer</app> will start and use Gwibber's "
+"service in the background."
+msgstr ""
+
+#: C/plugin-gwibber.page:27(title)
+msgid "Sending a message to all services"
+msgstr ""
+
+#: C/plugin-gwibber.page:29(p)
+msgid ""
+"Activate Kupfer and type <key>.</key> to enter text mode, then type in a "
+"message."
+msgstr ""
+
+#: C/plugin-gwibber.page:35(p)
+msgid ""
+"Type <key>Tab</key> and select the action <em>Send Message</em> and press "
+"<key>Return</key>."
+msgstr ""
+
+#: C/plugin-gwibber.page:42(title)
+msgid "Sending a message to a specific service"
+msgstr ""
+
+#: C/plugin-gwibber.page:44(p)
+msgid ""
+"Activate Kupfer and search for the service object, for example <em>Identi."
+"ca</em>"
+msgstr ""
+
+#: C/plugin-gwibber.page:50(p)
+msgid "Type <key>Tab</key> and select the action <em>Send Message</em>."
+msgstr ""
+
+#: C/plugin-gwibber.page:55(p)
+msgid ""
+"Type <key>Tab</key> to select the last pane, and type in a message. Press "
+"<key>Return</key> to send."
+msgstr ""
+
+#: C/plugin-gwibber.page:61(p)
+msgid ""
+"The plugin also provides a source for incoming messages, <em>Gwibber "
+"Messages</em> and more actions on messages such as <em>Reply</em>, <em>Send "
+"Private Message</em> etc."
+msgstr ""
+
+#: C/plugin-gwibber.page:71(p)
+msgid ""
+"You can use the <em>comma trick</em> if you want to send a message to more "
+"than one service, but not all, at the same time."
+msgstr ""
+
+#: C/plugin-favorites.page:7(desc)
+msgid "Using the favorites plugin."
+msgstr ""
+
+#: C/plugin-favorites.page:10(app)
+msgid "Favorites"
+msgstr ""
+
+#: C/plugin-favorites.page:13(title)
+#, fuzzy
+#| msgid "Calculator Plugin"
+msgid "Favorites Plugin"
+msgstr "Modulul calculator"
+
+#: C/plugin-favorites.page:14(p)
+msgid ""
+"With <app>Favorites</app> you mark objects, for example files, for quicker "
+"access. It is a sort of shelf on which you can store objects in Kupfer. "
+"Objects marked as favorites will also be ranked higher and are adorned with "
+"a star symbol."
+msgstr ""
+
+#: C/plugin-favorites.page:25(p)
+#, fuzzy
+#| msgid "Introduction to <app>Kupfer</app>."
+msgid "Find an object in <app>Kupfer</app>"
+msgstr "Introducere în <app>Kupfer</app>."
+
+#: C/plugin-favorites.page:30(p)
+msgid ""
+"Type <key>Tab</key> and select either the action <em>Add to Favorites</em> "
+"or <em>Remove from Favorites</em>."
+msgstr ""
+
+#: C/plugin-favorites.page:39(p)
+msgid ""
+"If you favorite an object, you can access it in more places. Not only in the "
+"\"Favorites\" subcatalog, but also as the indirect (secondary) object for "
+"some actions. For example:"
+msgstr ""
+
+#: C/plugin-favorites.page:45(p)
+msgid "Command-lines from favorites are quick to access."
+msgstr ""
+
+#: C/plugin-favorites.page:46(p)
+msgid ""
+"When scaling images with the <em>Scale...</em> action from the <app>Image "
+"Tools</app> plugin. This action needs a size description as the third "
+"object, like \"1024\" or \"1200x800\". If you often scale to the same size, "
+"say \"1200x800\", add this to favorites, and it will always appear as a "
+"suggestion for the action."
+msgstr ""
+
+#: C/plugin-favorites.page:54(p)
+msgid ""
+"Actions needing an email address as the indirect object will pick up email "
+"addresses from favorites as well as well."
+msgstr ""
+
+#: C/plugin-calculator.page:7(desc)
+#, fuzzy
+#| msgid "Calculator Plugin"
+msgid "Using the calculator plugin."
+msgstr "Modulul calculator"
+
+#: C/plugin-calculator.page:10(app)
+#, fuzzy
+#| msgid "Calculator Plugin"
+msgid "Calculator"
+msgstr "Modulul calculator"
+
+#: C/plugin-calculator.page:13(title)
+msgid "Calculator Plugin"
+msgstr "Modulul calculator"
+
+#: C/plugin-calculator.page:14(p)
+msgid ""
+"The calculator plugin lets you calculate expressions quickly. It can "
+"evaluate expressions entered as text starting with \"=\". Entering = from "
+"command mode will start text mode directly with = prefixed for quick access."
+msgstr ""
+"Modulul calculator vă permite să calculați expresii rapid. Acesta poate "
+"evalua expresii introduse ca text ce începe cu „=”. Introducerea = din modul "
+"de comandă va porni modul text direct cu = ca prefix pentru acces rapid."
+
+#: C/plugin-calculator.page:23(p)
+msgid "Activate Kupfer and type <key>=</key>"
+msgstr ""
+
+#: C/plugin-calculator.page:26(p)
+msgid ""
+"Type in a mathematical expression using <key>+</key>,<key>-</key>,<key>/</"
+"key>,<key>*</key> (and <key>**</key> for exponentiation)"
+msgstr ""
+
+#: C/plugin-calculator.page:30(p)
+msgid "Press <key>Return</key> to get the result."
+msgstr ""
+
+#: C/plugin-calculator.page:38(p)
+#, fuzzy
+#| msgid ""
+#| "The Calculator uses python's math and complex math modules, and parses "
+#| "expressions as Python expressions. You may use common mathematical "
+#| "functions, such as sqrt, sin, exp and log; the command <cmd>=help</cmd> "
+#| "will show a list of all defined functions and constants."
+msgid ""
+"The Calculator uses python's math and complex math modules, and parses "
+"expressions as Python expressions. You may use common mathematical "
+"functions, such as <cmd>sqrt</cmd>, <cmd>sin</cmd>, <cmd>exp</cmd> and "
+"<cmd>log</cmd>; the command <cmd>=help</cmd> will show a list of all defined "
+"functions and constants."
+msgstr ""
+"Calculatorul folosește modulele pentru matematică și matematică cu numere "
+"complexe din Python, și analizează textul ca o expresie Python. Puteți "
+"folosi funcții matematice comune, precum sqrt, sin, exp și log; comanda "
+"<cmd>=help</cmd> va afișa o listă cu toate funcțiile și constrângerile "
+"definite."
+
+#: C/plugin-calculator.page:47(p)
+#, fuzzy
+#| msgid ""
+#| "Notice that the power operator in Python is double stars, for example "
+#| "=3**3 will evaluate to 27."
+msgid ""
+"Notice that the power operator in Python is double stars, for example "
+"<code>=3**3</code> will evaluate to 27."
+msgstr ""
+"Amintiți-vă că operația pentru ridicare la putere în Python este „**”, de "
+"exemplu =3**3 va rezulta 27."
+
+#: C/plugin-calculator.page:53(p)
+msgid "To calculate trig functions for angles, convert to radians first:"
+msgstr ""
+"Pentru a calcula funcții trigonometrice pentru unghiuri, transformați măsura "
+"unghiurilor în radiani întâi:"
+
+#: C/plugin-calculator.page:56(code)
+#, no-wrap
+msgid "sin(radians(30)) -&gt; 0.5"
+msgstr "sin(radians(30)) -&gt; 0.5"
+
+#: C/plugin-calculator.page:59(p)
+msgid ""
+"The last result is stored as the name _ (an underscore, just like in the "
+"Python console)."
+msgstr ""
+"Ultimul rezultat este stocat sub numele de _ (un underscore, ca și în "
+"consola Python)."
+
+#: C/plugin-applications.page:7(desc)
+msgid "Using the applications plugin."
+msgstr ""
+
+#: C/plugin-applications.page:10(app)
+msgid "Applications"
+msgstr ""
+
+#: C/plugin-applications.page:13(title)
+#, fuzzy
+#| msgid "Calculator Plugin"
+msgid "Applications Plugin"
+msgstr "Modulul calculator"
+
+#: C/plugin-applications.page:14(p)
+msgid "<app>Applications</app> provides all installed programs."
+msgstr ""
+
+#: C/plugin-applications.page:21(title)
+msgid "Launching an application"
+msgstr ""
+
+#: C/plugin-applications.page:23(p)
+msgid "Activate Kupfer and type an abbreviation of the application name"
+msgstr ""
+
+#: C/plugin-applications.page:28(p)
+msgid "Press <key>Return</key> to launch the application."
+msgstr ""
+
+#: C/plugin-applications.page:34(title)
+msgid "Opening a file with a specific application"
+msgstr ""
+
+#: C/plugin-applications.page:36(p)
+#, fuzzy
+#| msgid "Introduction to <app>Kupfer</app>."
+msgid "Select a file in <app>Kupfer</app>"
+msgstr "Introducere în <app>Kupfer</app>."
+
+#: C/plugin-applications.page:41(p)
+msgid "Type <key>Tab</key> and select the action <em>Open With...</em>"
+msgstr ""
+
+#: C/plugin-applications.page:46(p)
+msgid ""
+"Type <key>Tab</key> to select the third (indirect object) pane and in it, "
+"select the application to open the file with."
+msgstr ""
+
+#: C/plugin-applications.page:53(p)
+msgid ""
+"The action <em>Open</em> opens files and folders with the registered default "
+"application for that specific file type. This can be configured using the "
+"action <em>Set Default Application...</em>."
+msgstr ""
+
+#: C/plugin-applications.page:58(p)
+msgid ""
+"The file type associations are provided by the desktop environment, and "
+"modifying them here will modify them on the desktop as well. This may not be "
+"true when not using GNOME or XFCE."
+msgstr ""
+
+#: C/plugin-applications.page:64(title)
+msgid "Selecting default application for a file type or folders"
+msgstr ""
+
+#: C/plugin-applications.page:66(p)
+#, fuzzy
+#| msgid "Introduction to <app>Kupfer</app>."
+msgid "Select a file or folder in <app>Kupfer</app>"
+msgstr "Introducere în <app>Kupfer</app>."
+
+#: C/plugin-applications.page:71(p)
+msgid ""
+"Type <key>Tab</key> and select the action <em>Set Default Application...</em>"
+msgstr ""
+
+#: C/plugin-applications.page:77(p)
+msgid ""
+"Type <key>Tab</key> to select the third (indirect object) pane and in it, "
+"select the application to always open the file type with."
+msgstr ""
+
+#: C/plugin-applications.page:85(title)
+#, fuzzy
+#| msgid "Configuration files and paths"
+msgid "Configuration"
+msgstr "Fișiere și căi de configurare"
+
+#: C/plugin-applications.page:86(p)
+msgid ""
+"The configuration option <em>Applications for Desktop Environment</em> in "
+"the plugin's information pane in <app>Kupfer Preferences</app> determines "
+"how <app>Kupfer</app> should act with regard to the desktop environment "
+"configuration—certain applications request not to be shown depending on "
+"which desktop environment is used. By default, it behaves like GNOME."
+msgstr ""
+
+#: C/moreusage.page:7(desc)
+msgid "More advanced usage information."
+msgstr ""
+
+#: C/moreusage.page:10(title)
+#, fuzzy
+#| msgid "Using <app>Kupfer</app> plugins."
+msgid "Using <app>Kupfer</app> in Depth"
+msgstr "Folosirea modulelor <app>Kupfer</app>"
+
+#: C/moreusage.page:13(title)
+#, fuzzy
+#| msgid "Adding your actions and scripts"
+msgid "Adding Applications and Scripts"
+msgstr "Adăugarea de acțiuni și scripturi personalizate"
+
+#: C/moreusage.page:14(p)
+msgid ""
+"<app>Kupfer</app> will show all applications that are configured visible in "
+"your menu editor."
+msgstr ""
+
+#: C/moreusage.page:18(p)
+#, fuzzy
+#| msgid ""
+#| "If you want to add a custom application, or an application called with "
+#| "special options, you can create a new launcher for it and place it in one "
+#| "of the standard places for applications, for example <file>~/.local/share/"
+#| "applications</file>, where <app>Kupfer</app> will find it."
+msgid ""
+"If you want to add an application manually, you can create a new <code>."
+"desktop</code> file and place it in one of the standard directories for "
+"applications, for example <file>~/.local/share/applications</file>, where "
+"<app>Kupfer</app> will find it."
+msgstr ""
+"Dacă doriți să adăugați o aplicație personalizată sau o aplicație apelată cu "
+"opțiuni speciale, puteți crea un lansator pentru ea și să-l plasați în unul "
+"dintre locurile standard pentru aplicații, de exemplu <file>~/.local/share/"
+"applications</file>, unde <app>Kupfer</app> îl va găsi."
+
+#: C/moreusage.page:24(p)
+msgid ""
+"If you have a collection of scripts that you want to call from <app>Kupfer</"
+"app>, you can add the scripts folder as a catalog directory to <app>Kupfer</"
+"app> in the preferences. Scripts that you add to <app>Kupfer</app>'s catalog "
+"this way can be run directly or in the terminal as long as they are "
+"executable."
+msgstr ""
+"Dacă aveți o colecție de scripturi ce care doriți să le apelați din "
+"<app>Kupfer</app>, puteți să le adăugați într-un dosar de scripturi ca și un "
+"dosar catalog în <app>Kupfer</app> la preferințe. Scripturile pe care le "
+"adăugați în catalogul <app>Kupfer</app> pot fi astfel rulate direct sau din "
+"terminal atât timp cât ele sunt executabile."
+
+#: C/moreusage.page:31(p)
+msgid ""
+"You can also save command-lines by using the action <em>Add to Favorites</"
+"em>."
+msgstr ""
+
+#: C/moreusage.page:38(title)
+msgid "Opening Files and Folders"
+msgstr ""
+
+#: C/moreusage.page:39(p)
+msgid ""
+"Using the action <em>Open</em>, files and folders are opened in their "
+"preferred application. The application associations can be changed, see "
+"<link xref=\"plugin-applications\"/>."
+msgstr ""
+
+#: C/moreusage.page:47(title)
+msgid "The <em>Comma Trick</em>"
+msgstr ""
+
+#: C/moreusage.page:48(p)
+msgid ""
+"The comma trick allows the user to use actions on many objects at the same "
+"time."
+msgstr ""
+
+#: C/moreusage.page:52(p)
+msgid ""
+"Simply press comma <key>,</key> when an object is selected. The object is "
+"put on a \"stack\", and you can find yet another file or object, press comma "
+"to put it on the stack. When you subsequently invoke an action, the action "
+"is carried out on all of the objects at the same time."
+msgstr ""
+
+#: C/moreusage.page:58(p)
+msgid ""
+"Some actions are only \"multiplied\" when used with many objects, other are "
+"smarter than that:"
+msgstr ""
+
+#: C/moreusage.page:61(p)
+msgid ""
+"Selecting many files and using the Create Archive action, all files will be "
+"packed into the same archive."
+msgstr ""
+
+#: C/moreusage.page:63(p)
+msgid ""
+"If you select multiple contacts and use a Send Email action, it creates one "
+"email directed at all the contacts."
+msgstr ""
+
+#: C/moreusage.page:65(p)
+msgid ""
+"If you select multiple subcatalogs (For example Firefox Bookmarks and "
+"Epiphany Bookmarks) and use Search Contents.., you get a subcatalog search "
+"restricted to the objects of those two catalogs! You can even bind a trigger "
+"to this command(!)"
+msgstr ""
+
+#: C/moreusage.page:71(p)
+msgid ""
+"The comma trick is <link href=\"http://www.43folders.com/2005/06/13/"
+"quicksilver-the-comma-trick\"> directly taken from Quicksilver</link> (the "
+"example given in the external article should work identically in Kupfer)."
+msgstr ""
+
+#: C/moreusage.page:80(title)
+#, fuzzy
+#| msgid "Grab current selection"
+msgid "Grab Current Selection"
+msgstr "Prinderea selecției curente"
+
+#: C/moreusage.page:81(p)
+msgid ""
+"To use the current selected text, from any application, with <app>Kupfer</"
+"app>, you can configure a global keyboard shortcut for the action <em>Show "
+"with Selection</em> in <app>Kupfer Preferences</app>."
+msgstr ""
+
+#: C/moreusage.page:85(p)
+msgid ""
+"If configured, pressing the global keyboard shortcut will summon "
+"<app>Kupfer</app> with the current selection as the focused object."
+msgstr ""
+
+#: C/moreusage.page:90(p)
+msgid "See <link xref=\"keyboard\"/>"
+msgstr ""
+
+#: C/moreusage.page:94(title)
+#, fuzzy
+#| msgid "Command line connection"
+msgid "Command-line Connection"
+msgstr "Conexiune cu linia de comandă"
+
+#: C/moreusage.page:95(p)
+msgid ""
+"The command <cmd>kupfer</cmd> on the command-line will focus <app>Kupfer</"
+"app> if it's already running, otherwise it will start it."
+msgstr ""
+
+#: C/moreusage.page:99(p)
+#, fuzzy
+#| msgid ""
+#| "For example, if you are using the shell in a directory where you have a "
+#| "file called \"report.pdf\", you can focus this file in <app>Kupfer</app> "
+#| "by running <cmd>kupfer report.pdf</cmd>."
+msgid ""
+"The command <cmd>kupfer</cmd> can be used to send files or text from the "
+"command-line to <app>Kupfer</app>. For example, if you are using the shell "
+"in a directory where you have a file called \"report.pdf\", you can focus "
+"this file in <app>Kupfer</app> by running <cmd>kupfer report.pdf</cmd>."
+msgstr ""
+"De exemplu, dacă folosiți shell-ul într-un dosar unde aveți un fișier numit "
+"„report.pdf”, puteți să focalizați acest fișier în <app>Kupfer</app> rulând "
+"<cmd>kupfer report.pdf</cmd>."
+
+#: C/moreusage.page:107(p)
+msgid ""
+"You can also send text if you pipe the output of a command into <cmd>kupfer</"
+"cmd>."
+msgstr ""
+
+#: C/moreusage.page:114(title)
+msgid "Managing Context and Current Selection"
+msgstr "Gestionarea contextului și a selecției curente"
+
+#: C/moreusage.page:115(p)
+msgid ""
+"If you find the object you want to use, then invoke an action, <app>Kupfer</"
+"app> goes away to perform the action (for example start a program or play a "
+"song). When you come back to <app>Kupfer</app>, it will still keep the same "
+"object and action selected. Some actions make sense to be repeated (like "
+"skipping to the next song) and it can be useful to perform different actions "
+"on the same object."
+msgstr ""
+"Dacă găsiți un obiect pe care doriți să-l folosiți, apoi să invocați o "
+"acțiune, <app>Kupfer</app> va pleca pentru a efectua acțiunea (de exemplu "
+"pentru a porni un program sau a reda o piesă). Când vă întoarceți la "
+"<app>Kupfer</app>, acesta va păstra același obiect sau acțiune selectată. "
+"Unele acțiuni au sens să fie repetate (de exemplu saltul la următoarea "
+"piesă). De asemenea, poate fi folosit pentru a efectua acțiuni diferite pe "
+"același obiect."
+
+#: C/moreusage.page:123(p)
+msgid ""
+"However, you always have the top level catalog reachable when you \"come back"
+"\" to <app>Kupfer</app> -- say you went into the subcatalog \"Albums\" to "
+"browse your albums only; you select an album to play, and play it. You come "
+"back with the album selected -- but your next search will still go over the "
+"top level catalog, not just albums."
+msgstr ""
+"Totuși, veți avea întotdeauna catalogul de cel mai înalt nivel accesibil "
+"când „vă întoarceți” la <app>Kupfer</app> -- De exemplu dacă ați coborât în "
+"subcatalogul „Albume” pentru a căuta doar albume; ați ales un album pentru a "
+"fi redat și ați executat acțiunea, la întoarcere veți găsi același album "
+"selectat, dar căutarea va continua de la catalogul de cel mai înalt nivel, "
+"nu doar la albume."
+
+#: C/moreusage.page:130(p)
+msgid ""
+"How to come back into the subcatalog you were in? You do that by simply "
+"browsing, not searching the first thing you do when you focus <app>Kupfer</"
+"app> again. A quick way is to press down-arrow or space to open the browse "
+"window; think of it as saying \"I want to stay in this subfolder\". With the "
+"browse window open, your next query will search the current subcatalog."
+msgstr ""
+"Cum să vă întoarceți la același subcatalog? Faceți asta prin simplu fapt că "
+"navigați întâi, nu căutați, când focalizați din nou pe <app>Kupfer</app>. Un "
+"mod rapid de a face asta e să apăsați săgeată-jos sau spațiu pentru a "
+"deschide fereastra de navigare. Puteți vedea această acțiune ca și „Vreau să "
+"stau în acest subdosar”. Cu fereastra de navigare deschisă, următoarea "
+"interogare va căuta în subcatalogul curent."
+
+#: C/moreusage.page:137(p)
+msgid ""
+"This way you can work both ways -- you can quickly drill down into folders "
+"to find a file, and when you come back for the next action with <app>Kupfer</"
+"app> you can either summon any normal toplevel object (just start typing), "
+"or stay around where you were, deep in that folder (press space, then type a "
+"query)."
+msgstr ""
+"În acest mod, puteți lucra în ambele moduri -- puteți ajunge repede în "
+"dosare pentru a găsi un fișier, și când vă întoarceți pentru următoarea "
+"acțiune, veți putea să chemați un obiect normal de la nivelul cel mai înalt "
+"(începeți pur și simplu să scrieți), sau reveniți unde erați, adânc în acel "
+"dosar (apăsați spațiu înainte de a scrie interogarea)."
+
+#: C/moreusage.page:146(title)
+msgid "Saving Commands as Files"
+msgstr ""
+
+#: C/moreusage.page:147(p)
+msgid ""
+"You can use keyboard shortcut for <em>Compose Command</em> (by default it is "
+"<keyseq><key>Ctrl</key><key>Return</key></keyseq>) to create a command "
+"object out of the currently focused command in Kupfer. This object can be "
+"saved as a runnable file if you use the <em>Save As...</em> action. The "
+"resulting file will can be executed when opened from the file manager (it "
+"requires that Kupfer is already running)."
+msgstr ""
+
+#: C/managing-plugins.page:7(desc)
+#, fuzzy
+#| msgid "Introduction to <app>Kupfer</app>."
+msgid "Using plugins with <app>Kupfer</app>."
+msgstr "Introducere în <app>Kupfer</app>."
+
+#: C/managing-plugins.page:10(title)
+msgid "How to Configure Plugins"
+msgstr ""
+
+#: C/managing-plugins.page:12(p)
+msgid ""
+"Functionality in Kupfer is organized by extentsion modules called \"plugins"
+"\". Each plugin provides additional functionality, for example integration "
+"with an external application."
+msgstr ""
+
+#: C/managing-plugins.page:19(title)
+msgid "Configuring Plugins"
+msgstr ""
+
+#: C/managing-plugins.page:21(title)
+#, fuzzy
+#| msgid "Using <app>Kupfer</app> plugins."
+msgid "Open <app>Kupfer Preferences</app> to the Plugins tab"
+msgstr "Folosirea modulelor <app>Kupfer</app>"
+
+#: C/managing-plugins.page:23(p)
+msgid "Use one of the following methods:"
+msgstr ""
+
+#: C/managing-plugins.page:25(p)
+msgid ""
+"Click the Kupfer icon in the notification area and select the item "
+"<em>Preferences</em>"
+msgstr ""
+
+#: C/managing-plugins.page:25(item)
+msgid "<placeholder-1/>."
+msgstr ""
+
+#: C/managing-plugins.page:29(p)
+msgid ""
+"Search for the object <app>Kupfer Preferences</app> in Kupfer itself. Press "
+"<key>Return</key> to open it."
+msgstr ""
+
+#: C/managing-plugins.page:33(p)
+#, fuzzy
+#| msgid "<key>↑</key> or <keyseq><key>Shift</key><key>Space</key></keyseq>"
+msgid "Use the keyboard shortcut <keyseq><key>Ctrl</key><key>;</key></keyseq>"
+msgstr "<key>↑</key> sau <keyseq><key>Shift</key><key>Spațiu</key></keyseq>"
+
+#: C/managing-plugins.page:39(p)
+msgid "Select the tab <em>Plugins</em>"
+msgstr ""
+
+#: C/managing-plugins.page:45(p)
+msgid ""
+"Select plugins in the list to read about them, and tick the box next to its "
+"name to activate the plugin, or untick to deactivate."
+msgstr ""
+
+#: C/managing-plugins.page:49(p)
+msgid ""
+"If the plugin has any configurable parameters, they will be visible below "
+"the plugin information."
+msgstr ""
+
+#: C/managing-plugins.page:53(p)
+msgid ""
+"The plugin <app>Kupfer Plugins</app> allows fast access to each plugin's "
+"information page as well as the action \"Show Source Code\" which reveals "
+"the implementation."
+msgstr ""
+
+#: C/managing-plugins.page:59(title)
+msgid "If a Plugin can not be Activated"
+msgstr ""
+
+#: C/managing-plugins.page:60(p)
+msgid ""
+"If a plugin fails to activate because it requires a software module that is "
+"not available, its plugin information will display a message like this:"
+msgstr ""
+
+#: C/managing-plugins.page:65(em)
+msgid "Plugin could not be read due to an error:"
+msgstr ""
+
+#: C/managing-plugins.page:66(em)
+msgid "Python module 'gdata' is needed"
+msgstr ""
+
+#: C/managing-plugins.page:67(p)
+msgid ""
+"This means that you need to install a needed python module from your "
+"distribution—and possibly the plugin documentation can tell you how."
+msgstr ""
+
+#: C/managing-plugins.page:72(p)
+msgid ""
+"The plugin may also unexpectedly fail to load, and display a different error "
+"message. It may then be a program error in either the plugin or <app>Kupfer</"
+"app>."
+msgstr ""
+
+#: C/managing-plugins.page:79(title)
+#, fuzzy
+#| msgid "Calculator Plugin"
+msgid "Installing more Plugins"
+msgstr "Modulul calculator"
+
+#: C/managing-plugins.page:80(p)
+msgid ""
+"You can install custom plugins into the folder <code>~/.local/share/kupfer/"
+"plugins</code>. Each plugin is either a single <code>.py</code> file or a "
+"python package (a folder directly containing a file called <code>__init__."
+"py</code>). Plugins in the package format can include icon files. Python "
+"packages can even be installed as <code>.zip</code> files."
+msgstr ""
+
+#: C/managing-plugins.page:88(p)
+msgid ""
+"<em>Caution:</em> Treat a plugin as a computer program. Do not install "
+"untrusted plugins."
+msgstr ""
+
+#: C/managing-plugins.page:95(title)
+#, fuzzy
+#| msgid "Plugins"
+msgid "Creating Plugins"
+msgstr "Module"
+
+#: C/managing-plugins.page:96(p)
+msgid ""
+"Documentation for plugin creators is available in the file "
+"<code>Documentation/Manual.rst</code> in the source distribution on the "
+"webpage at <link href=\"http://kaizer.se/wiki/kupfer/Manual/\">Kupfer "
+"Manual</link>. An easy way to start is to copy an existing plugin and "
+"experimenting with it."
+msgstr ""
+
+#: C/managing-plugins.page:107(title)
+msgid "The <em>Catalog</em> Tab in Preferences"
+msgstr ""
+
+#: C/managing-plugins.page:108(p)
+msgid ""
+"Each plugin can export a number of sources which contain objects. Normally, "
+"all these objects are directly accessible from a top-level search. Some "
+"plugins export so specialized or so many objects that their catalogs should "
+"better not have their objects exported to the top level. To reach those "
+"objects, you have to first find the catalog by name, then enter the catalog "
+"using the action <em>Search Contents</em>."
+msgstr ""
+
+#: C/managing-plugins.page:118(p)
+msgid ""
+"In the tab <em>Catalog</em> in <app>Kupfer Preferences</app>, a ticked box "
+"next to each source means that its objects are exported. An unticked box "
+"means that its contents are hidden from the top level."
+msgstr ""
+
+#: C/managing-plugins.page:123(p)
+msgid ""
+"<em>Note:</em> Kupfer may become slow if large enough subcatalogs are "
+"exported to the top level."
+msgstr ""
+
+#: C/license.page:7(desc)
+msgid "You can copy, modify and share Kupfer."
+msgstr ""
+
+#: C/license.page:10(title)
+msgid "License"
+msgstr "Licență"
+
+#: C/license.page:12(p)
+msgid ""
+"This program is free software: you can redistribute it and/or modify it "
+"under the terms of the <em>GNU General Public License</em> as published by "
+"the Free Software Foundation, either version 3 of the License, or (at your "
+"option) any later version."
+msgstr ""
+"Acest program este software liber: puteți să-l redistribuiți sau modificați "
+"luând în considerare termenii <em>GNU General Public License</em> publicată "
+"de Free Software Foundation, versiunea 3 a licenței, sau (la alegere) o altă "
+"versiune mai recentă."
+
+#: C/license.page:18(p)
+msgid ""
+"This program is distributed in the hope that it will be useful, but WITHOUT "
+"ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or "
+"FITNESS FOR A PARTICULAR PURPOSE. See the <em>GNU General Public License</"
+"em> for more details."
+msgstr ""
+"Acest program este distribuit în speranța că va fi folositor, dar FĂRĂ "
+"GARANȚIE; fără vreun fel de garanție pe VANDABILITATE sau POTRIVIRE PENTRU "
+"UN SCOP SPECIFIC. Citiți <em>GNU General Public License</em> pentru mai "
+"multe detalii."
+
+#: C/license.page:24(p)
+msgid ""
+"You should have received a copy of the GNU General Public License along with "
+"this program. If not, see <link href=\"http://www.gnu.org/licenses/\">gnu."
+"org/licenses</link>."
+msgstr ""
+"Ar fi trebui să primiți o copie a GNU General Public License împreună cu "
+"acest program. Dacă nu, vizitați <link href=\"http://www.gnu.org/licenses/"
+"\">gnu.org/licenses</link>."
+
+#: C/license.page:30(p)
+msgid ""
+"This documentation is licensed under a <link href=\"http://creativecommons."
+"org/licenses/by-sa/3.0/\">Creative Commons Attribution-Share Alike 3.0 "
+"Unported License</link>."
+msgstr ""
+"Această documentație este licențiată sub o licență neadaptată <link href="
+"\"http://creativecommons.org/licenses/by-sa/3.0/\">Creative Commons "
+"Atribuire-Distribuire în condiții identice 3.0</link>"
+
+#: C/license.page:36(p)
+msgid ""
+"As a special exception, the copyright holders give you permission to copy, "
+"modify, and distribute the example code contained in this document under the "
+"terms of your choosing, without restriction."
+msgstr ""
+"Ca și o excepție specială, deținătorii de drepturi de autor vă dau "
+"permisiunea să copiați, modificați și distribuiți exemple de cod conținute "
+"în acest document luând în considerare termeni aleși de dumneavoastră, fără "
+"restricție. "
+
+#: C/keyboard.page:7(desc)
+#, fuzzy
+#| msgid "Global Keyboard Shortcuts"
+msgid "Complete keyboard shortcuts reference."
+msgstr "Scurtături globale de tastatură"
+
+#: C/keyboard.page:10(title)
+msgid "Command Keys and Accelerator Keys"
+msgstr ""
+
+#: C/keyboard.page:13(title) C/generalusage.page:12(title)
+#, fuzzy
+msgid "Keyboard Interface"
+msgstr "Interfața de tastatură"
+
+#: C/keyboard.page:14(p)
+#, fuzzy
+#| msgid "In command mode, some keystrokes have special meanings:"
+msgid "In command mode, the following keystrokes have special meanings:"
+msgstr "În modul de comandă, câteva taste au înțelesuri speciale:"
+
+#: C/keyboard.page:19(p) C/generalusage.page:34(p)
+msgid "<key>↓</key> or <key>Space</key>"
+msgstr "<key>↓</key> sau <key>Spațiu</key>"
+
+#: C/keyboard.page:20(p) C/generalusage.page:35(p)
+msgid "Go to the next match"
+msgstr "Salt la rezultatul următor"
+
+#: C/keyboard.page:23(p) C/generalusage.page:38(p)
+msgid "<key>↑</key> or <keyseq><key>Shift</key><key>Space</key></keyseq>"
+msgstr "<key>↑</key> sau <keyseq><key>Shift</key><key>Spațiu</key></keyseq>"
+
+#: C/keyboard.page:26(p) C/generalusage.page:41(p)
+msgid "Go to the previous match"
+msgstr "Salt la rezultatul precedent"
+
+#: C/keyboard.page:29(p) C/generalusage.page:44(p)
+msgid "<key>→</key> or <key>/</key>"
+msgstr "<key>→</key> sau <key>/</key>"
+
+#: C/keyboard.page:30(p) C/generalusage.page:45(p)
+msgid "Descend into an object with content"
+msgstr "Coboară într-un obiect cu conținut"
+
+#: C/keyboard.page:33(key) C/generalusage.page:48(key)
+msgid "Backspace"
+msgstr "Backspace"
+
+#: C/keyboard.page:34(p) C/generalusage.page:49(p)
+msgid "Erase a character from the query. If the query is empty, go up a level"
+msgstr ""
+"Șterge un caracter din interogare. Dacă aceasta este goală, urcă un nivel"
+
+#: C/keyboard.page:39(key) C/keyboard.page:93(key) C/generalusage.page:54(key)
+msgid "."
+msgstr "."
+
+#: C/keyboard.page:40(p) C/generalusage.page:55(p)
+msgid "Activate free-text mode"
+msgstr "Activează modul text-liber"
+
+#: C/keyboard.page:43(key) C/keyboard.page:97(key) C/generalusage.page:58(key)
+msgid ","
+msgstr ","
+
+#: C/keyboard.page:44(p) C/generalusage.page:59(p)
+msgid "Put selected object on the stack (\"Comma Trick\")"
+msgstr "Pune obiectul selectat în stivă („Trucul virgulă”)"
+
+#: C/keyboard.page:47(p)
+msgid "Quick access keys:"
+msgstr ""
+
+#: C/keyboard.page:53(key)
+msgid "="
+msgstr ""
+
+#: C/keyboard.page:55(p)
+msgid ""
+"Activate free-text mode with = prefix (for <link xref=\"plugin-calculator\"/"
+">)"
+msgstr ""
+
+#: C/keyboard.page:61(key)
+msgid "/"
+msgstr ""
+
+#: C/keyboard.page:63(p)
+msgid ""
+"Activate free-text mode (when nothing is selected) with <code>/</code> "
+"prefix (to input a rooted path)"
+msgstr ""
+
+#: C/keyboard.page:68(p) C/generalusage.page:62(p)
+msgid "Additionally:"
+msgstr ""
+
+#: C/keyboard.page:72(p) C/generalusage.page:66(p)
+#, fuzzy
+#| msgid ""
+#| "Additionally, the key <key>Return</key> activates the current selection: "
+#| "the command is executed. <key>Escape</key> clears the current selection."
+msgid ""
+"<key>Return</key> activates the current selection: the command is executed."
+msgstr ""
+"Adițional, tasta <key>Enter</key> activează selecția curentă: această "
+"comandă este executată. <key>Escape</key> curăță selecția curentă."
+
+#: C/keyboard.page:74(p) C/generalusage.page:68(p)
+msgid "<key>Escape</key> clears the current selection."
+msgstr ""
+
+#: C/keyboard.page:75(p) C/generalusage.page:69(p)
+msgid "<key>Tab</key> switches between the object and the action pane."
+msgstr ""
+
+#: C/keyboard.page:77(p)
+msgid ""
+"The meaning of the keys <key>Space</key>, <key>.</key>, <key>,</key>, <key>/"
+"</key> and <key>=</key> can not be changed, but you can deactivate their "
+"special meaning with the checkbox <app>Use single keystroke commands</app> "
+"in <app>Kupfer Preferences</app>."
+msgstr ""
+
+#: C/keyboard.page:86(title)
+#, fuzzy
+#| msgid "Global Keyboard Shortcuts"
+msgid "Kupfer's Keyboard Shortcuts"
+msgstr "Scurtături globale de tastatură"
+
+#: C/keyboard.page:87(p)
+msgid ""
+"These keyboard shortcuts are used in <app>Kupfer</app>'s interface. They "
+"have the following meanings and default shortcuts:"
+msgstr ""
+
+#: C/keyboard.page:93(key) C/keyboard.page:97(key) C/keyboard.page:101(key)
+#: C/keyboard.page:105(key) C/keyboard.page:113(key) C/keyboard.page:117(key)
+#: C/keyboard.page:121(key) C/keyboard.page:125(key) C/keyboard.page:129(key)
+#: C/keyboard.page:174(key)
+msgid "Ctrl"
+msgstr ""
+
+#: C/keyboard.page:94(p)
+msgid "Toggle text mode"
+msgstr ""
+
+#: C/keyboard.page:98(p)
+msgid "The comma trick"
+msgstr ""
+
+#: C/keyboard.page:101(key)
+msgid ";"
+msgstr ""
+
+#: C/keyboard.page:102(p)
+msgid "Show preferences window"
+msgstr ""
+
+#: C/keyboard.page:105(key)
+msgid "R"
+msgstr ""
+
+#: C/keyboard.page:106(p)
+msgid "Reset all"
+msgstr ""
+
+#: C/keyboard.page:109(key)
+msgid "Alt"
+msgstr ""
+
+#: C/keyboard.page:109(key)
+msgid "A"
+msgstr ""
+
+#: C/keyboard.page:110(p)
+msgid "Alternate activate"
+msgstr ""
+
+#: C/keyboard.page:113(key)
+msgid "Return"
+msgstr ""
+
+#: C/keyboard.page:114(p)
+msgid "Compose command"
+msgstr ""
+
+#: C/keyboard.page:117(key)
+msgid "S"
+msgstr ""
+
+#: C/keyboard.page:118(p)
+msgid "Switch to first pane"
+msgstr ""
+
+#: C/keyboard.page:121(key)
+msgid "Q"
+msgstr ""
+
+#: C/keyboard.page:122(p)
+msgid "Select 'Quit'"
+msgstr ""
+
+#: C/keyboard.page:125(key)
+msgid "G"
+msgstr ""
+
+#: C/keyboard.page:126(p)
+msgid "Select 'Selected File'"
+msgstr ""
+
+#: C/keyboard.page:129(key)
+msgid "T"
+msgstr ""
+
+#: C/keyboard.page:130(p)
+msgid "Select 'Selected Text'"
+msgstr ""
+
+#: C/keyboard.page:133(key)
+msgid "F1"
+msgstr ""
+
+#: C/keyboard.page:134(p)
+msgid "Show Help"
+msgstr ""
+
+#: C/keyboard.page:139(title)
+#, fuzzy
+#| msgid "Additional Keyboard Shortcuts"
+msgid "How to configure a keyboard shortcut"
+msgstr "Scurtături adiționale de tastatură"
+
+#: C/keyboard.page:141(p) C/keyboard.page:185(p)
+msgid "Open <app>Kupfer Preferences</app> and go to the <em>Keyboard</em> tab."
+msgstr ""
+
+#: C/keyboard.page:147(p)
+msgid ""
+"Double-click the shorcut's row under <em>Browser Keyboard Shortcuts</em>."
+msgstr ""
+
+#: C/keyboard.page:153(p)
+msgid ""
+"Using the window that appears, press modifier keys and a letter or number "
+"key to set a shortcut. An example is pressing and holding <key>Ctrl</key> "
+"and then pressing and releasing <key>T</key> to bind <keyseq><key>Ctrl</"
+"key><key>T</key></keyseq>."
+msgstr ""
+
+#: C/keyboard.page:164(title)
+msgid "Global Keyboard Shortcuts"
+msgstr "Scurtături globale de tastatură"
+
+#: C/keyboard.page:165(p)
+msgid ""
+"<app>Kupfer</app> always listens to global shortcuts, even if it is not "
+"currently in the foreground."
+msgstr ""
+
+#: C/keyboard.page:169(p)
+msgid "They have the following meanings and default shortcuts:"
+msgstr ""
+
+#: C/keyboard.page:174(key)
+msgid "Space"
+msgstr ""
+
+#: C/keyboard.page:175(p)
+#, fuzzy
+#| msgid "Introduction to <app>Kupfer</app>."
+msgid "Show/hide <app>Kupfer</app>"
+msgstr "Introducere în <app>Kupfer</app>."
+
+#: C/keyboard.page:178(p)
+msgid "(not configured by default)"
+msgstr ""
+
+#: C/keyboard.page:179(p)
+msgid "Show <app>Kupfer</app> with 'Selection' object focused"
+msgstr ""
+
+#: C/keyboard.page:183(title)
+#, fuzzy
+#| msgid "Global Keyboard Shortcuts"
+msgid "How to configure a global keyboard shortcut"
+msgstr "Scurtături globale de tastatură"
+
+#: C/keyboard.page:191(p)
+msgid ""
+"Double-click the shorcut's row under <em>Global Keyboard Shortcuts</em>."
+msgstr ""
+
+#: C/keyboard.page:197(p)
+msgid ""
+"Using the window that appears, press modifier keys and a letter or number "
+"key to set a global shortcut. An example is pressing and holding <key>Super</"
+"key> and then pressing and releasing <key>Space</key> to bind "
+"<keyseq><key>Super</key><key>Space</key></keyseq>."
+msgstr ""
+
+#: C/keyboard.page:206(p)
+msgid ""
+"Since these keyboard shortcuts are global, they can be used from any "
+"application. Select shortcuts with care so that they do not conflict with "
+"other functions."
+msgstr ""
+
+#: C/keyboard.page:214(p)
+msgid ""
+"The plugin <em>Triggers</em> allows to activate actions with global keyboard "
+"shortcuts. Trigger shortcuts do not appear in <app>Kupfer Preferences</app>."
+msgstr ""
+
+#: C/keyboard.page:220(p)
+msgid "See <link xref=\"plugin-triggers\"/> for more information."
+msgstr ""
+
+#: C/introduction.page:7(desc)
+msgid "Introduction to <app>Kupfer</app>."
+msgstr "Introducere în <app>Kupfer</app>."
+
+#: C/introduction.page:10(title)
+msgid "Introduction"
+msgstr "Introducere"
+
+#: C/introduction.page:12(p)
+#, fuzzy
+#| msgid ""
+#| "<app>Kupfer</app> is to the largest part a keyboard-managed interface to "
+#| "applications and documents."
+msgid ""
+"<app>Kupfer</app> is an interface for quick and convenient access to "
+"applications and their documents."
+msgstr ""
+"<app>Kupfer</app> este în mare parte o interfață controlată prin tastatură "
+"către aplicații și documente."
+
+#: C/introduction.page:16(p)
+msgid ""
+"The most typical use is to find a specific application and launch it. We "
+"have tried to make <app>Kupfer</app> easy to extend with plugins so that "
+"this quick-access paradigm can be extended to many more objects than just "
+"applications."
+msgstr ""
+
+#: C/introduction.page:22(p)
+msgid ""
+"We hope that using <app>Kupfer</app> feels both <em>very fun</em> and "
+"<em>different</em>."
+msgstr ""
+
+#: C/introduction.page:26(p)
+#, fuzzy
+#| msgid ""
+#| "For more information about <app>Kupfer</app>, visit its <link href="
+#| "\"http://kaizer.se/wiki/kupfer/\">homepage</link>."
+msgid ""
+"For up-to-date information about <app>Kupfer</app>, visit its <link href="
+"\"http://kaizer.se/wiki/kupfer/\">homepage</link>."
+msgstr ""
+"Pentru mai multe informații despre <app>Kupfer</app>, vizitați <link href="
+"\"http://kaizer.se/wiki/kupfer/\">pagina web</link> al acestuia."
+
+#: C/index.page:9(name)
+msgid "Ulrik Sverdrup"
+msgstr "Ulrik Sverdrup"
+
+#: C/index.page:10(email)
+msgid "ulrik.sverdrup@gmail.com"
+msgstr "ulrik.sverdrup@gmail.com"
+
+#: C/index.page:13(year)
+msgid "2009"
+msgstr "2009"
+
+#: C/index.page:14(name)
+msgid "Kupfer Development Team"
+msgstr "Echipa de dezvoltare Kupfer"
+
+#: C/index.page:17(license)
+msgid "Creative Commons Share Alike 3.0"
+msgstr "Creative Commons Distribuire în condiții identice 3.0"
+
+#: C/index.page:21(title)
+#, fuzzy
+#| msgid "Kupfer manual"
+msgid "Kupfer Manual"
+msgstr "Manual Kupfer"
+
+#: C/index.page:24(title)
+msgid "Using Kupfer"
+msgstr "Folosirea Kupfer"
+
+#: C/index.page:27(title)
+msgid "About Specific Plugins"
+msgstr ""
+
+#: C/generalusage.page:7(desc)
+#, fuzzy
+#| msgid "Introduction to <app>Kupfer</app>."
+msgid "How to start using <app>Kupfer</app>."
+msgstr "Introducere în <app>Kupfer</app>."
+
+#: C/generalusage.page:14(p)
+msgid ""
+"<app>Kupfer</app> is to the largest part a keyboard-managed interface to "
+"applications and documents."
+msgstr ""
+"<app>Kupfer</app> este în mare parte o interfață controlată prin tastatură "
+"către aplicații și documente."
+
+#: C/generalusage.page:18(p)
+msgid ""
+"Kupfer's default mode is the command mode: If you type a query, kupfer will "
+"search for a match in its catalog."
+msgstr ""
+"Modul implicit în Kupfer este modul de comandă: Dacă tastați o interogare, "
+"kupfer va căuta o potrivire în catalog."
+
+#: C/generalusage.page:23(p)
+msgid ""
+"The arrow keys allow you to browse query matches quite naturally, going to "
+"the previous or next match, and going up and down in the subcatalogs."
+msgstr ""
+"Folosind tastele direcționale puteți naviga prin rezultatele interogării în "
+"mod natural, trecând la rezultatul anterior sau următor și urcând sau "
+"coborând în subcataloage."
+
+#: C/generalusage.page:29(p)
+msgid "In command mode, some keystrokes have special meanings:"
+msgstr "În modul de comandă, câteva taste au înțelesuri speciale:"
+
+#: C/generalusage.page:71(p)
+#, fuzzy
+#| msgid "<key>↑</key> or <keyseq><key>Shift</key><key>Space</key></keyseq>"
+msgid ""
+"By default you show <app>Kupfer</app> using the global keyboard shortcut "
+"<keyseq><key>Ctrl</key><key>Space</key></keyseq>."
+msgstr "<key>↑</key> sau <keyseq><key>Shift</key><key>Spațiu</key></keyseq>"
+
+#: C/generalusage.page:74(p)
+msgid "See <link xref=\"keyboard\"/> for more information."
+msgstr ""
+
+#: C/generalusage.page:78(title)
+msgid "Learning Habits"
+msgstr ""
+
+#: C/generalusage.page:79(p)
+msgid ""
+"<app>Kupfer</app> remembers which objects and actions are used the most. "
+"When beginning to use it, you have to use the arrow keys at times to make it "
+"precise which object you want to find. After a few uses of that object, "
+"Kupfer will rank it higher. Objects marked as <link xref=\"plugin-favorites"
+"\">favorites</link> are also ranked higher."
+msgstr ""
+
+#: C/generalusage.page:90(title)
+msgid "The Catalog"
+msgstr "Catalogul"
+
+#: C/generalusage.page:91(p)
+msgid ""
+"The Catalog is the collection of objects you can access in Kupfer, such as "
+"documents and programs."
+msgstr ""
+"Catalogul este colecția de obiecte pe care o puteți accesa în Kupfer, "
+"obiecte precum documente și programe."
+
+#: C/generalusage.page:96(p)
+#, fuzzy
+#| msgid ""
+#| "Objects in the catalog that have content, like folders, are marked with "
+#| "an arrow. Pressing <key>right-arrow</key> will enter these objects. Much "
+#| "of the catalog is composed of subcatalogs; plugin subcatalogs do in "
+#| "general list objects that are also available directly from the top level. "
+#| "Subcatalogs can be used for a narrower view or search scope, when using "
+#| "Kupfer."
+msgid ""
+"Objects in the catalog that have content, like folders, are marked with an "
+"arrow. Pressing <key>→</key> will enter these objects. Much of the catalog "
+"is composed of subcatalogs; plugin subcatalogs do in general list objects "
+"that are also available directly from the top level. Subcatalogs can be used "
+"for a narrower view or search scope, when using Kupfer."
+msgstr ""
+"Obiectele din catalog ce au conținut, precum dosarele, sunt marcate cu o "
+"săgeată. Tastarea <key>săgeată-dreapta</key> va intra în aceste obiecte. O "
+"parte mare din catalog este compus de subcataloage. Acestea în general "
+"conțin o listă restrânsă de obiecte ce sunt accesibile direct din nivelul "
+"cel mai înalt. Subcataloagele sunt folosite pentru a restrânge o căutare în "
+"Kupfer."
+
+#: C/generalusage.page:105(p)
+#, fuzzy
+#| msgid ""
+#| "Most subcatalogs update their content automatically. For example, the "
+#| "Desktop folder catalog is always uptodate."
+msgid ""
+"Most subcatalogs update their content automatically. For example, the "
+"Desktop folder source is always up-to-date."
+msgstr ""
+"Majoritatea subcataloagelor își actualizează conținutul automat. De exemplu, "
+"dosarul de Desktop este întotdeauna actualizat."
+
+#. Put one translator per line, in the form of NAME <EMAIL>, YEAR1, YEAR2
+#: C/index.page:0(None)
+msgid "translator-credits"
+msgstr "Cătălin Bălan <laserbeam333@gmail.com> 2011"
+
+#~ msgid "Using <app>Kupfer</app> more conveniently."
+#~ msgstr "Folosirea mai convenientă a <app>Kupfer</app>."
+
+#~ msgid ""
+#~ "Kupfer listens to global shortcuts, even if Kupfer is not currently in "
+#~ "the foreground. The most important global shortcut is the shortcut to "
+#~ "show and hide Kupfer's command window which by default is "
+#~ "<keyseq><key>Ctrl</key><key>Space</key></keyseq>."
+#~ msgstr ""
+#~ "Kupfer ascultă scurtăturile globale, chiar dacă acesta nu este în prim "
+#~ "plan. Cea mai importantă scurtătură globală este cea folosită pentru a "
+#~ "arăta și a ascunde fereastra de comandă Kupfer. Scurtătura implicită este "
+#~ "<keyseq><key>Ctrl</key><key>Spațiu</key></keyseq>."
+
+#~ msgid "Global Keyboard Shortcuts are configured in Kupfer's preferences."
+#~ msgstr ""
+#~ "Scurtăturile globale de tastatură sunt configurate în preferințele din "
+#~ "Kupfer."
+
+#~ msgid ""
+#~ "The Triggers plugin allows to configure actions to be activated by global "
+#~ "shortcuts, but triggers can only be configured in that plugin."
+#~ msgstr ""
+#~ "Modulul de declanșatoare permite configurarea acțiunilor ce sunt activate "
+#~ "prin scurtături globale, dar declanșatoarele pot fi configurate doar în "
+#~ "acest modul."
+
+#~ msgid ""
+#~ "Additional keyboard shortcuts that work with Kupfer when it is in the "
+#~ "foreground can be configured in Kupfer's preferences."
+#~ msgstr ""
+#~ "Scurtăturile adiționale de tastatură ce funcționează cu Kupfer când "
+#~ "acesta este în prim plan pot fi configurate din preferințele din Kupfer."
+
+#~ msgid ""
+#~ "Install custom plugins in the folder <file>~/.local/share/kupfer/plugins/"
+#~ "</file>"
+#~ msgstr ""
+#~ "Instalați module personalizate în dosarul <file>~/.local/share/kupfer/"
+#~ "plugins/</file>"
+
+#~ msgid ""
+#~ "Kupfer cache, config and data are located in the directories <file>~/."
+#~ "cache/kupfer</file>, <file>~/.config/kupfer</file> and <file>~/.local/"
+#~ "share/kupfer</file>."
+#~ msgstr ""
+#~ "Cacheul, fișierele de configurare și datele folosite de Kupfer se găsesc "
+#~ "în dosarele <file>~/.cache/kupfer</file>, <file>~/.config/kupfer</file> "
+#~ "și <file>~/.local/share/kupfer</file>."
+
+#, fuzzy
+#~ msgid ""
+#~ "You can install custom plugins into ~/.local/share/kupfer/plugins; adding "
+#~ "to <app>Kupfer</app>'s object knowledge can be surprisingly easy, just "
+#~ "look at the default plugins if you want to create new."
+#~ msgstr ""
+#~ "Puteți instala module personalizate în ~/.local/share/kupfer/plugins; "
+#~ "Adăugarea la obiectele cunoscute de <app>Kupfer</app> poate fi "
+#~ "surprinzător de ușoară, uitați-vă la modulele implicite dacă doriți să "
+#~ "creați altele noi."
+
+#~ msgid "Open Terminal Here"
+#~ msgstr "Deschide un terminal aici"
+
+#~ msgid ""
+#~ "Open terminal first calls <cmd>xdg-terminal</cmd>, then <cmd>gnome-"
+#~ "terminal</cmd>. xdg-terminal is a script to find the user's configured "
+#~ "terminal program for his/her Desktop Environment. Install <cmd>xdg-"
+#~ "terminal</cmd> if you need this (or install a symlink <em>called</em> xdg-"
+#~ "terminal)."
+#~ msgstr ""
+#~ "Deschide un terminal, apelează întâi <cmd>xdg-terminal</cmd>, apoi "
+#~ "<cmd>gnome-terminal</cmd>. xdg-terminal este un script folosit pentru a "
+#~ "găsi programul pentru terminal stabilit în preferințele de sistem ale "
+#~ "utilizatorului. Instalați <cmd>xdg-terminal</cmd> dacă doriți acest "
+#~ "comportament sau creați o legătură simbolică <em>numită</em> xdg-terminal."
+
+#~ msgid ""
+#~ "To use <app>Kupfer</app> like a pro, you can configure a \"Magic "
+#~ "Keybinding\" for <app>Kupfer</app>. GUI configuration is not yet "
+#~ "supported, but edit the configuration file <file>~/.config/kupfer/kupfer."
+#~ "cfg</file> to include the following:"
+#~ msgstr ""
+#~ "Pentru a folosi <app>Kupfer</app> ca un profesionist, puteți configura o "
+#~ "„Combinație de taste magică” pentru <app>Kupfer</app>. Configurarea "
+#~ "acesteia din interfața vizuală nu este încă posibilă, dar puteți modifica "
+#~ "fișierul de configurare <file>~/.config/kupfer/kupfer.cfg</file> pentru a "
+#~ "include următoarele:"
+
+#~ msgid ""
+#~ "\n"
+#~ "[Kupfer]\n"
+#~ "keybinding = &lt;Control&gt;space\n"
+#~ "magickeybinding = &lt;Ctrl&gt;&lt;Alt&gt;space\n"
+#~ "  "
+#~ msgstr ""
+#~ "\n"
+#~ "[Kupfer]\n"
+#~ "keybinding = &lt;Control&gt;space\n"
+#~ "magickeybinding = &lt;Ctrl&gt;&lt;Alt&gt;space\n"
+#~ "  "
+
+#~ msgid ""
+#~ "Now, pressing <keyseq><key>Ctrl</key><key>Alt</key><key>Space</key></"
+#~ "keyseq> will summon <app>Kupfer</app> with the current selection in "
+#~ "focus. Make sure you have installed <app>Kupfer</app>'s nautilus plugin, "
+#~ "then both the currently selected file in Nautilus, or the currently "
+#~ "selected text in the front application will be selected."
+#~ msgstr ""
+#~ "Acum, apăsarea secvenței <keyseq><key>Ctrl</key><key>Alt</"
+#~ "key><key>Spațiu</key></keyseq> va chema <app>Kupfer</app> cu selecția "
+#~ "curentă în prim plan. Asigurați-vă că aveți instalat modului nautilus în "
+#~ "<app>Kupfer</app>, apoi fișierul selectat în nautilus sau secvența de "
+#~ "text selectată în aplicația deschisă în prim plan vor fi selectate în "
+#~ "<app>Kupfer</app>."
+
+#~ msgid ""
+#~ "Now you can select a word in, say, a web browser, use <keyseq><key>Ctrl</"
+#~ "key><key>Alt</key><key>Space</key></keyseq>, and select action <gui>Look "
+#~ "Up</gui> to look up the selected word. Or select an image file, use "
+#~ "<keyseq><key>Ctrl</key><key>Alt</key><key>Space</key></keyseq>, select "
+#~ "action <gui>Scale</gui> with object <gui>1000</gui> to scale the image to "
+#~ "1000 pixels wide!"
+#~ msgstr ""
+#~ "Acum puteți selecta un cuvânt, de exemplu, într-un navigator de Internet, "
+#~ "folosiți secvența <keyseq><key>Ctrl</key><key>Alt</key><key>Spațiu</key></"
+#~ "keyseq>, și selectați acțiunea <gui>Caută în dicționar</gui> pentru a "
+#~ "căuta cuvântul selectat în dicționar. Sau selectați un fișier imagine, "
+#~ "folosiți secvența <keyseq><key>Ctrl</key><key>Alt</key><key>Spațiu</key></"
+#~ "keyseq>, apoi alegeți acțiunea <gui>Scalare</gui> cu <gui>1000</gui> ca "
+#~ "obiect pentru a redimensiona imaginea la 1000 pixeli lățime!"
+
+#~ msgid ""
+#~ "An example useful script is <link href=\"http://kaizer.se/wiki/code/"
+#~ "rhrating.py/\"> here</link> which changes the rating of <app>Rhythmbox</"
+#~ "app>'s currently playing song; I have added five scriptlets calling "
+#~ "<file>rhrating.py</file> with numbers from 0 to 5 to my catalog to "
+#~ "quickly rate tracks. (This is something that might be integrated into "
+#~ "<app>Kupfer</app> later)"
+#~ msgstr ""
+#~ "Un exemplu de script folositor poate fi găsit <link href=\"http://kaizer."
+#~ "se/wiki/code/rhrating.py/\">aici</link>. Acesta schimbă nota piesei "
+#~ "curente din <app>Rhythmbox</app>; Puteți, de exemplu, adăuga șase "
+#~ "scripturi ce apelează <file>rhrating.py</file> cu numerele de la 0 la 5 "
+#~ "în catalog pentru a da note rapid pieselor. (Este posibil ca această "
+#~ "funcție să fie implementată într-o versiune viitoare a <app>Kupfer</app>)"
+
+#~ msgid ""
+#~ "<app>Kupfer</app> is its own remote control. When <app>Kupfer</app> is "
+#~ "already running, <app>Kupfer</app> on the command-line will focus its "
+#~ "window, but there is more you can do: If you invoke <cmd><app>kupfer</"
+#~ "app><var>QUERY</var></cmd> where <var>QUERY</var> is a text string or a "
+#~ "filename, <app>Kupfer</app> will focus, and select this item. This way, "
+#~ "you can quickly invoke <app>Kupfer</app> actions even on objects from a "
+#~ "shell-based context."
+#~ msgstr ""
+#~ "<app>Kupfer</app> este propria sa telecomandă. Când <app>Kupfer</app> "
+#~ "este pornit, <app>Kupfer</app> în linia de comandă va aduce programul în "
+#~ "prim plan, dar poate face mai mult: Dacă invocați <cmd><app>kupfer</"
+#~ "app><var>INTEROGARE</var></cmd> unde <var>INTEROGARE</var> este un text "
+#~ "sau un fișier, <app>Kupfer</app> se va focaliza în prim plan și va alege "
+#~ "acel element. Astfel, puteți invoca acțiuni specifice lui <app>Kupfer</"
+#~ "app> pe obiecte dintr-un mediu bazat pe shell."
+
+#~ msgid ""
+#~ "You can also pipe the output of a command into <app>Kupfer</app> to send "
+#~ "text to the already running instance of <app>Kupfer</app>."
+#~ msgstr ""
+#~ "Puteți de asemenea să transmiteți datele de ieșire ale unei comenzi în "
+#~ "<app>Kupfer</app> pentru a trimite text unei instanțe <app>Kupfer</app> "
+#~ "ce rulează deja."
+
+#~ msgid "Legal Information."
+#~ msgstr "Informații legale."
+
+#~ msgid ""
+#~ "<app>Kupfer</app> is a program to change, speed up and make everything "
+#~ "about files and programs more fun on your computer. <app>Kupfer</app> is "
+#~ "a launcher; you typically use it to summon an application or a document "
+#~ "quickly by typing parts of its name. It can also do more than getting at "
+#~ "something quickly: there are different plugins for accessing more objects "
+#~ "and running custom commands."
+#~ msgstr ""
+#~ "<app>Kupfer</app> este un program folosit pentru a schimba, accelera și "
+#~ "transforma toate acțiunile legate de fișiere și programe în ceva "
+#~ "distractiv. <app>Kupfer</app> este un lansator; îl veți folosi în mod "
+#~ "normal pentru a chema o aplicație sau un document repede tastând părți "
+#~ "diferite din numele său. Poate de asemenea mult mai multe decât a găsi "
+#~ "ceva repede: există numeroase module concepute pentru accesarea mai "
+#~ "multor obiecte și rularea a unor comenzi personalizate."
+
+#~ msgid ""
+#~ "<app>Kupfer</app> is written using Python and has a flexible "
+#~ "architecture; the implementation is simple and makes the easy things work "
+#~ "first. One goal is that new plugins can be written quickly without too "
+#~ "much programming."
+#~ msgstr ""
+#~ "<app>Kupfer</app> este scris în Python și are o arhitectură flexibilă; "
+#~ "implementarea este simplă și face ca lucrurile ușoare să funcționeze "
+#~ "primele. Un scop al programului este ca noile module să fie scrie repede "
+#~ "și fără multă programare."
+
+#~ msgid ""
+#~ "The program is very inspired by <link href=\"http://www.blacktree.com/"
+#~ "\">Quicksilver</link>."
+#~ msgstr ""
+#~ "Programul este inspirat puternic de către <link href=\"http://www."
+#~ "blacktree.com/\">Quicksilver</link>."

--- a/kupfer/core/settings.py
+++ b/kupfer/core/settings.py
@@ -393,6 +393,8 @@ class SettingsController (gobject.GObject, pretty.OutputMixin):
 		"""
 		Get a list of (id_, name) tuples for the given @category_key
 		"""
+		if not category_key in self._alternative_validators:
+			return
 		validator = self._alternative_validators[category_key]
 		for (id_, alternative) in self._alternatives[category_key].iteritems():
 			name = alternative["name"]

--- a/kupfer/plugin/calculator.py
+++ b/kupfer/plugin/calculator.py
@@ -1,10 +1,17 @@
 from __future__ import division
 __kupfer_name__ = _("Calculator")
-__kupfer_actions__ = ("Calculate", )
+__kupfer_actions__ = ("Calculate", "CalculateOtherExpressions")
 __description__ = _("Calculate mathematical expressions")
-__version__ = "2012-06-09"
+__version__ = "2012-06-10"
 __author__ = "Ulrik Sverdrup <ulrik.sverdrup@gmail.com>"
 
+"""
+Changes:
+	2012-06-09:
+		+ calculate action for expression w/o =
+	2012-06-10:
+		+ separate Calculate action
+"""
 
 import cmath
 import math
@@ -67,7 +74,7 @@ class Help (object):
 				continue
 			wrapped_lines = textwrap.wrap(docsplit[1].strip(),
 					maxlen - left_margin)
-			wrapped = (u"\n" + u" "*left_margin).join(wrapped_lines)
+			wrapped = (u"\n" + u" " * left_margin).join(wrapped_lines)
 			formatted.append("%s\n    %s" % (docsplit[0], wrapped))
 		uiutils.show_text_result("\n\n".join(formatted), _("Calculator"))
 		raise IgnoreResultException
@@ -103,26 +110,29 @@ def format_result(res):
 class Calculate (Action):
 	# since it applies only to special queries, we can up the rank
 	rank_adjust = 10
+	# global last_result
+	last_result = {'last': None}
+
 	def __init__(self):
 		Action.__init__(self, _("Calculate"))
-		self.last_result = None
 
 	def has_result(self):
 		return True
+
 	def activate(self, leaf):
 		expr = leaf.object.lstrip("= ")
 
 		# try to add missing parantheses
 		brackets_missing = expr.count("(") - expr.count(")")
 		if brackets_missing > 0:
-			expr += ")"*brackets_missing
-		environment = make_environment(self.last_result)
+			expr += ")" * brackets_missing
+		environment = make_environment(self.last_result['last'])
 
 		pretty.print_debug(__name__, "Evaluating", repr(expr))
 		try:
 			result = eval(expr, environment)
 			resultstr = format_result(result)
-			self.last_result = result
+			self.last_result['last'] = result
 		except IgnoreResultException:
 			return
 		except Exception, exc:
@@ -132,9 +142,22 @@ class Calculate (Action):
 
 	def item_types(self):
 		yield TextLeaf
+
 	def valid_for_item(self, leaf):
 		text = leaf.object
-		return text and (text.startswith("=") or
+		return text and text.startswith("=")
+
+	def get_description(self):
+		return None
+
+
+class CalculateOtherExpressions(Calculate):
+	""" Calcualte expressions that not starts with "=" """
+	rank_adjust = 0
+
+	def valid_for_item(self, leaf):
+		text = leaf.object
+		return text and not text.startswith("=") and (
 				"+" in text or
 				"-" in text or
 				"*" in text or
@@ -143,6 +166,3 @@ class Calculate (Action):
 				"&" in text or
 				"|" in text or
 				"~" in text)
-
-	def get_description(self):
-		return None

--- a/kupfer/plugin/calculator.py
+++ b/kupfer/plugin/calculator.py
@@ -1,7 +1,8 @@
 from __future__ import division
 __kupfer_name__ = _("Calculator")
 __kupfer_actions__ = ("Calculate", )
-__description__ = _("Calculate expressions starting with '='")
+__description__ = _("Calculate expressions starting with '=', or " \
+"containing mathematical operators")
 __version__ = ""
 __author__ = "Ulrik Sverdrup <ulrik.sverdrup@gmail.com>"
 
@@ -128,7 +129,12 @@ class Calculate (Action):
 		yield TextLeaf
 	def valid_for_item(self, leaf):
 		text = leaf.object
-		return text and text.startswith("=")
+		return text and (text.startswith("=") or
+				"+" in text or
+				"-" in text or
+				"*" in text or
+				"/" in text or
+				"^" in text)
 
 	def get_description(self):
 		return None

--- a/kupfer/plugin/calculator.py
+++ b/kupfer/plugin/calculator.py
@@ -11,8 +11,10 @@ Changes:
 		+ calculate action for expression w/o =
 	2012-06-10:
 		+ separate Calculate action
+		+ change localized decimal point symbol to .
 """
 
+import locale
 import cmath
 import math
 
@@ -126,8 +128,9 @@ class Calculate (Action):
 		brackets_missing = expr.count("(") - expr.count(")")
 		if brackets_missing > 0:
 			expr += ")" * brackets_missing
+		# hack: change all decimal points (according to current locale) to '.'
+		expr = expr.replace(locale.localeconv()['decimal_point'], '.')
 		environment = make_environment(self.last_result['last'])
-
 		pretty.print_debug(__name__, "Evaluating", repr(expr))
 		try:
 			result = eval(expr, environment)

--- a/kupfer/plugin/calculator.py
+++ b/kupfer/plugin/calculator.py
@@ -1,9 +1,8 @@
 from __future__ import division
 __kupfer_name__ = _("Calculator")
 __kupfer_actions__ = ("Calculate", )
-__description__ = _("Calculate expressions starting with '=', or " \
-"containing mathematical operators")
-__version__ = ""
+__description__ = _("Calculate mathematical expressions")
+__version__ = "2012-06-09"
 __author__ = "Ulrik Sverdrup <ulrik.sverdrup@gmail.com>"
 
 
@@ -17,6 +16,7 @@ from kupfer import pretty
 class IgnoreResultException (Exception):
 	pass
 
+
 class KupferSurprise (float):
 	"""kupfer
 
@@ -27,9 +27,11 @@ class KupferSurprise (float):
 		utils.show_url(version.WEBSITE)
 		raise IgnoreResultException
 
+
 class DummyResult (object):
 	def __unicode__(self):
 		return u"<Result of last expression>"
+
 
 class Help (object):
 	"""help()
@@ -73,6 +75,7 @@ class Help (object):
 	def __complex__(self):
 		return self()
 
+
 def make_environment(last_result=None):
 	"Return a namespace for the calculator's expressions to be executed in."
 	environment = dict(vars(math))
@@ -86,6 +89,7 @@ def make_environment(last_result=None):
 	environment["__builtins__"] = {}
 	return environment
 
+
 def format_result(res):
 	cres = complex(res)
 	parts = []
@@ -94,6 +98,7 @@ def format_result(res):
 	if cres.imag:
 		parts.append(u"%s" % complex(0, cres.imag))
 	return u"+".join(parts) or u"%s" % res
+
 
 class Calculate (Action):
 	# since it applies only to special queries, we can up the rank
@@ -134,7 +139,10 @@ class Calculate (Action):
 				"-" in text or
 				"*" in text or
 				"/" in text or
-				"^" in text)
+				"^" in text or
+				"&" in text or
+				"|" in text or
+				"~" in text)
 
 	def get_description(self):
 		return None

--- a/kupfer/plugin/firefox_support.py
+++ b/kupfer/plugin/firefox_support.py
@@ -152,6 +152,8 @@ def get_bookmarks(bookmarks_file):
 	# construct and configure the parser
 	if not bookmarks_file:
 		return []
+	if not os.path.isfile(bookmarks_file):
+		return []
 	parser = BookmarksParser()
 
 	# initiate the parse; this will submit requests to delicious

--- a/kupfer/plugin/gtg.py
+++ b/kupfer/plugin/gtg.py
@@ -78,6 +78,8 @@ def _load_tasks(interface, apiver):
 		tasks = interface.get_tasks()
 	else:
 		tasks = interface.GetTasks()
+		if not tasks:
+			tasks = interface.GetTasksFiltered("")
 	for task in tasks:
 		title = task['title'].strip()
 		if not title:

--- a/kupfer/plugin/openoffice.py
+++ b/kupfer/plugin/openoffice.py
@@ -3,12 +3,14 @@
 __kupfer_name__ = _("OpenOffice / LibreOffice")
 __kupfer_sources__ = ("RecentsSource", )
 __description__ = _("Recently used documents in OpenOffice/LibreOffice")
-__version__ = "2011-04-07"
+__version__ = "2013-03-16"
 __author__ = "Karol Będkowski <karol.bedkowski@gmail.com>"
 
 '''
 Changes:
 	2011-04-02: Support new cofiguration file format in LibreOffice.
+	2013-03-16: Supoort all leaves like "libreoffice*", "openoffice.org*"
+				This provide support for leaves like libreoffice4.0-writer
 '''
 
 import os
@@ -59,26 +61,15 @@ class MultiAppContentMixin (object):
 
 	@classmethod
 	def decorate_item(cls, leaf):
-		if leaf.get_id() in cls.__get_appleaf_id_iter():
+		if any(leaf.get_id().startswith(content_id) for content_id
+				in cls.__get_appleaf_id_iter()):
 			return cls()
 
 
 class RecentsSource (MultiAppContentMixin, Source, FilesystemWatchMixin):
 	appleaf_content_id = [
-			"openoffice.org-writer",
-			"openoffice.org-base",
-			"openoffice.org-calc",
-			"openoffice.org-draw",
-			"openoffice.org-impress",
-			"openoffice.org-math",
-			"openoffice.org-startcenter",
-			"libreoffice-writer",
-			"libreoffice-base",
-			"libreoffice-calc",
-			"libreoffice-draw",
-			"libreoffice-impress",
-			"libreoffice-math",
-			"libreoffice-startcenter",
+			"libreoffice",
+			"openoffice.org",
 	]
 
 	def __init__(self, name=_("OpenOffice/LibreOffice Recent Items")):

--- a/kupfer/plugin/session_custom.py
+++ b/kupfer/plugin/session_custom.py
@@ -1,0 +1,60 @@
+__kupfer_name__ = _("Custom Session Management")
+__kupfer_sources__ = ("ItemSource",)
+__description__ = _("Run custom session management commands")
+__version__ = "2"
+__author__ = "Joseph Lansdowne <J49137@gmail.com>"
+
+import shlex
+
+from kupfer.plugin_support import PluginSettings
+from kupfer.plugin import session_support as support
+
+__kupfer_settings__ = PluginSettings(
+	{
+		"key": "logout",
+		"label": _("Log out"),
+		"type": str,
+		"value": ""
+	}, {
+		"key": "switchuser",
+		"label": _("Switch user"),
+		"type": str,
+		"value": ""
+	}, {
+		"key": "lockscreen",
+		"label": _("Lock screen"),
+		"type": str,
+		"value": ""
+	}, {
+		"key": "shutdown",
+		"label": _("Shut down"),
+		"type": str,
+		"value": ""
+	}, {
+		"key": "reboot",
+		"label": _("Restart"),
+		"type": str,
+		"value": ""
+	}, {
+		"key": "suspend",
+		"label": _("Suspend"),
+		"type": str,
+		"value": ""
+	}
+)
+
+
+class ItemSource (support.CommonSource):
+
+	def __init__(self):
+		support.CommonSource.__init__(self, _("Custom Session Management"))
+
+	def get_items(self):
+		for item in ("Logout", "SwitchUser", "LockScreen", "Shutdown",
+					 "Reboot", "Suspend"):
+			value = __kupfer_settings__[item.lower()].strip()
+			if value:
+				argv = shlex.split(value)
+				# session_support Leafs take list of argument lists as
+				# fallbacks
+				yield getattr(support, item)((argv,))

--- a/kupfer/plugin/session_gnome.py
+++ b/kupfer/plugin/session_gnome.py
@@ -1,17 +1,27 @@
+# -*- coding: UTF8 -*-
 __kupfer_name__ = _("GNOME Session Management")
 __kupfer_sources__ = ("GnomeItemsSource", )
 __description__ = _("Special items and actions for GNOME environment")
-__version__ = "2009-12-05"
+__version__ = "2012-10-16"
 __author__ = "Ulrik Sverdrup <ulrik.sverdrup@gmail.com>"
+
+"""
+Changes:
+	2012-10-16 Karol Będkowski:
+		+ support Gnome3; closes lp#788713;
+		  author: Joseph Lansdowne
+"""
 
 from kupfer.plugin import session_support as support
 
 
 # sequences of argument lists
 LOGOUT_CMD = (["gnome-panel-logout"],
-              ["gnome-session-save", "--kill"])
+              ["gnome-session-save", "--kill"],
+              ["gnome-session-quit", "--logout"])
 SHUTDOWN_CMD = (["gnome-panel-logout", "--shutdown"],
-                ["gnome-session-save", "--shutdown-dialog"])
+                ["gnome-session-save", "--shutdown-dialog"],
+                ["gnome-session-quit", "--power-off"])
 LOCKSCREEN_CMD = (["gnome-screensaver-command", "--lock"],
                   ["xdg-screensaver", "lock"])
 

--- a/kupfer/plugin/session_gnome.py
+++ b/kupfer/plugin/session_gnome.py
@@ -2,7 +2,7 @@
 __kupfer_name__ = _("GNOME Session Management")
 __kupfer_sources__ = ("GnomeItemsSource", )
 __description__ = _("Special items and actions for GNOME environment")
-__version__ = "2012-10-16"
+__version__ = "2013-4-25"
 __author__ = "Ulrik Sverdrup <ulrik.sverdrup@gmail.com>"
 
 """
@@ -30,8 +30,8 @@ class GnomeItemsSource (support.CommonSource):
 		support.CommonSource.__init__(self, _("GNOME Session Management"))
 	def get_items(self):
 		return (
-			support.Logout(LOGOUT_CMD),
+			support.LogoutBrowse(LOGOUT_CMD),
 			support.LockScreen(LOCKSCREEN_CMD),
-			support.Shutdown(SHUTDOWN_CMD),
+			support.ShutdownBrowse(SHUTDOWN_CMD),
 		)
 

--- a/kupfer/plugin/session_support.py
+++ b/kupfer/plugin/session_support.py
@@ -5,7 +5,7 @@ Common objects for session_* plugins.
 from kupfer.objects import Source, RunnableLeaf
 from kupfer import utils, pretty
 
-__version__ = "2009-12-05"
+__version__ = "2012-09-17"
 __author__ = "Ulrik Sverdrup <ulrik.sverdrup@gmail.com>"
 
 
@@ -20,22 +20,47 @@ def launch_argv_with_fallbacks(commands, print_error=True):
 	pretty.print_error(__name__, "Unable to run command(s)", commands)
 	return False
 
+
 class CommandLeaf (RunnableLeaf):
 	"""The represented object of the CommandLeaf is a list of commandlines"""
 	def run(self):
 		launch_argv_with_fallbacks(self.object)
 
-class Logout (CommandLeaf):
-	"""Log out from desktop"""
+
+class LogoutBrowse (CommandLeaf):
+	"""Log out or switch user"""
 	def __init__(self, commands, name=None):
 		if not name: name = _("Log Out...")
 		CommandLeaf.__init__(self, commands, name)
 	def get_description(self):
-		return _("Log out or change user")
+		return _("Log out or switch user")
 	def get_icon_name(self):
 		return "system-log-out"
 
-class Shutdown (CommandLeaf):
+
+class Logout (CommandLeaf):
+	"""Log out"""
+	def __init__(self, commands, name=None):
+		if not name: name = _("Log Out")
+		CommandLeaf.__init__(self, commands, name)
+	def get_description(self):
+		return _("Log out")
+	def get_icon_name(self):
+		return "system-log-out"
+
+
+class SwitchUser (CommandLeaf):
+	"""Switch user"""
+	def __init__(self, commands, name=None):
+		if not name: name = _("Change User")
+		CommandLeaf.__init__(self, commands, name)
+	def get_description(self):
+		return _("Switch to another user")
+	def get_icon_name(self):
+		return "system-switch-user"
+
+
+class ShutdownBrowse (CommandLeaf):
 	"""Shutdown computer or reboot"""
 	def __init__(self, commands, name=None):
 		if not name: name = _("Shut Down...")
@@ -44,6 +69,40 @@ class Shutdown (CommandLeaf):
 		return _("Shut down, restart or suspend computer")
 	def get_icon_name(self):
 		return "system-shutdown"
+
+
+class Shutdown (CommandLeaf):
+	"""Shutdown computer"""
+	def __init__(self, commands, name=None):
+		if not name: name = _("Shut Down")
+		CommandLeaf.__init__(self, commands, name)
+	def get_description(self):
+		return _("Shut down computer")
+	def get_icon_name(self):
+		return "system-shutdown"
+
+
+class Reboot (CommandLeaf):
+	"""Reboot computer"""
+	def __init__(self, commands, name=None):
+		if not name: name = _("Restart")
+		CommandLeaf.__init__(self, commands, name)
+	def get_description(self):
+		return _("Restart computer")
+	def get_icon_name(self):
+		return "system-reboot"
+
+
+class Suspend (CommandLeaf):
+	"""Suspend computer"""
+	def __init__(self, commands, name=None):
+		if not name: name = _("Suspend")
+		CommandLeaf.__init__(self, commands, name)
+	def get_description(self):
+		return _("Suspend computer")
+	def get_icon_name(self):
+		return "system-suspend"
+
 
 class LockScreen (CommandLeaf):
 	"""Lock screen"""
@@ -54,6 +113,7 @@ class LockScreen (CommandLeaf):
 		return _("Enable screensaver and lock")
 	def get_icon_name(self):
 		return "system-lock-screen"
+
 
 class CommonSource (Source):
 	def __init__(self, name):

--- a/kupfer/plugin/session_xfce.py
+++ b/kupfer/plugin/session_xfce.py
@@ -3,7 +3,7 @@
 __kupfer_name__ = _("XFCE Session Management")
 __kupfer_sources__ = ("XfceItemsSource", )
 __description__ = _("Special items and actions for XFCE environment")
-__version__ = "2009-12-05"
+__version__ = "2012-09-17"
 __author__ = "Karol Będkowski <karol.bedkowski@gmail.com>"
 
 from kupfer.plugin import session_support as support
@@ -20,7 +20,7 @@ class XfceItemsSource (support.CommonSource):
 		support.CommonSource.__init__(self, _("XFCE Session Management"))
 	def get_items(self):
 		return (
-			support.Logout(LOGOUT_CMD),
+			support.LogoutBrowse(LOGOUT_CMD),
 			support.LockScreen(LOCKSCREEN_CMD),
-			support.Shutdown(SHUTDOWN_CMD),
+			support.ShutdownBrowse(SHUTDOWN_CMD),
 		)

--- a/kupfer/plugin/top.py
+++ b/kupfer/plugin/top.py
@@ -126,7 +126,7 @@ class TaskSource(Source, PicklingHelperMixin):
 	def _async_top_start(self):
 		uid = os.getuid()
 		utils.AsyncCommand(["top", "-b", "-n", "1", "-u", "%d" % uid],
-		                   self._async_top_finished, 60)
+		                   self._async_top_finished, 60, env=["LC_NUMERIC=C"])
 
 	def get_items(self):
 		for task in self._cache:

--- a/kupfer/plugin/websearch.py
+++ b/kupfer/plugin/websearch.py
@@ -167,7 +167,7 @@ class OpenSearchSource (Source):
 
 		# firefox in home directory
 		ffx_home = firefox_support.get_firefox_home_file("searchplugins")
-		if ffx_home:
+		if ffx_home and os.path.isdir(ffx_home):
 			plugin_dirs.append(ffx_home)
 
 		plugin_dirs.extend(config.get_data_dirs("searchplugins",
@@ -185,6 +185,22 @@ class OpenSearchSource (Source):
 			if os.path.exists(addon_lang_dir):
 				plugin_dirs.append(addon_lang_dir)
 				break
+
+		# debian iceweasel
+		if os.path.isdir("/etc/iceweasel/searchplugins/common"):
+			plugin_dirs.append("/etc/iceweasel/searchplugins/common")
+		for suffix in suffixes:
+			addon_dir = os.path.join("/etc/iceweasel/searchplugins/locale",
+					suffix)
+			if os.path.isdir(addon_dir):
+				plugin_dirs.append(addon_dir)
+
+		# try to find all versions of firefox
+		for dirname in os.listdir("/usr/lib/"):
+			if dirname.startswith("firefox") or dirname.startswith("iceweasel"):
+				addon_dir = os.path.join("/usr/lib", dirname, "searchplugins")
+				if os.path.isdir(addon_dir):
+					plugin_dirs.append(addon_dir)
 
 		self.output_debug("Found following searchplugins directories",
 				sep="\n", *plugin_dirs)

--- a/kupfer/plugin_support.py
+++ b/kupfer/plugin_support.py
@@ -183,7 +183,7 @@ class UserNamePassword (settings.ExtendedSetting):
 	def save(self, plugin_id, key):
 		''' save @user_password - store password in keyring and return username
 		to save in standard configuration file '''
-		keyring.set_password(plugin_id, self.username, self.password)
+		keyring.set_password(plugin_id, str(self.username), self.password)
 		return self.username
 
 def check_keyring_support():

--- a/kupfer/ui/listen.py
+++ b/kupfer/ui/listen.py
@@ -11,6 +11,8 @@ try:
 	import dbus.service
 	from kupfer.dbuscompat import ExportedGObject
 
+	dbus.glib.threads_init()
+
 # if dbus unavailable print the exception here
 # but further actions (register) will fail without warning
 	session_bus = dbus.Bus()

--- a/kupfer/ui/preferences.py
+++ b/kupfer/ui/preferences.py
@@ -7,6 +7,7 @@ import gobject
 import pango
 from xdg import BaseDirectory as base
 from xdg import DesktopEntry as desktop
+from xdg import Exceptions as xdg_e
 
 
 from kupfer import config, pretty, utils, icons, version
@@ -270,7 +271,11 @@ class PreferencesWindowController (pretty.OutputMixin):
 		autostart_file = os.path.join(autostart_dir, KUPFER_DESKTOP)
 		if not os.path.exists(autostart_file):
 			return False
-		dfile = desktop.DesktopEntry(autostart_file)
+		try:
+			dfile = desktop.DesktopEntry(autostart_file)
+		except xdg_e.ParsingError, exception:
+			pretty.print_error(__name__, exception)
+			return False
 		return (dfile.hasKey(AUTOSTART_KEY) and
 				dfile.get(AUTOSTART_KEY, type="boolean"))
 

--- a/kupfer/ui/preferences.py
+++ b/kupfer/ui/preferences.py
@@ -292,14 +292,22 @@ class PreferencesWindowController (pretty.OutputMixin):
 				return
 			desktop_file_path = desktop_files[0]
 			# Read installed file and modify it
-			dfile = desktop.DesktopEntry(desktop_file_path)
+			try:
+				dfile = desktop.DesktopEntry(desktop_file_path)
+			except xdg_e.ParsingError, exception:
+				pretty.print_error(__name__, exception)
+				return
 			executable = dfile.getExec()
 			## append no-splash
 			if "--no-splash" not in executable:
 				executable += " --no-splash"
 			dfile.set("Exec", executable)
 		else:
-			dfile = desktop.DesktopEntry(autostart_file)
+			try:
+				dfile = desktop.DesktopEntry(autostart_file)
+			except xdg_e.ParsingError, exception:
+				pretty.print_error(__name__, exception)
+				return
 		activestr = str(bool(widget.get_active())).lower()
 		self.output_debug("Setting autostart to", activestr)
 		dfile.set(AUTOSTART_KEY, activestr)

--- a/kupfer/ui/preferences.py
+++ b/kupfer/ui/preferences.py
@@ -367,6 +367,7 @@ class PreferencesWindowController (pretty.OutputMixin):
 		self.store.set_value(it, checkcol, plugin_is_enabled)
 		setctl = settings.GetSettingsController()
 		setctl.set_plugin_enabled(plugin_id, plugin_is_enabled)
+		self.plugin_sidebar_update(plugin_id)
 
 	def _id_for_table_path(self, path):
 		it = self.store.get_iter(path)

--- a/kupfer/utils.py
+++ b/kupfer/utils.py
@@ -96,6 +96,8 @@ class AsyncCommand (object):
 
 	If stdin is a byte string, it is supplied on the command's stdin.
 
+	If env is None, command will inherit the parent's environment.
+
 	finish_callback -> (AsyncCommand, stdout_output, stderr_output)
 
 	Attributes:
@@ -106,7 +108,7 @@ class AsyncCommand (object):
 	# the maximum input (bytes) we'll read in one shot (one io_callback)
 	max_input_buf = 512 * 1024
 
-	def __init__(self, argv, finish_callback, timeout_s, stdin=None):
+	def __init__(self, argv, finish_callback, timeout_s, stdin=None, env=None):
 		self.stdout = []
 		self.stderr = []
 		self.stdin = []
@@ -121,7 +123,7 @@ class AsyncCommand (object):
 		flags = (glib.SPAWN_SEARCH_PATH | glib.SPAWN_DO_NOT_REAP_CHILD)
 		pid, stdin_fd, stdout_fd, stderr_fd = \
 		     glib.spawn_async(argv, standard_output=True, standard_input=True,
-		                      standard_error=True, flags=flags)
+		                      standard_error=True, flags=flags, envp=env)
 
 		if stdin:
 			self.stdin[:] = self._split_string(stdin, self.max_input_buf)

--- a/po/cs.po
+++ b/po/cs.po
@@ -10,14 +10,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kupfer master\n"
 "Report-Msgid-Bugs-To: http://bugs.launchpad.net/kupfer\n"
-"POT-Creation-Date: 2012-02-25 19:02+0000\n"
-"PO-Revision-Date: 2012-04-24 18:58+0200\n"
+"POT-Creation-Date: 2012-07-05 12:49+0000\n"
+"PO-Revision-Date: 2012-08-31 23:53+0200\n"
 "Last-Translator: Marek Černocký <marek@manet.cz>\n"
 "Language-Team: Czech <gnome-cs-list@gnome.org>\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cs\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #: ../auxdata/kupfer.desktop.in.h:1 ../kupfer/version.py:15
@@ -146,7 +146,7 @@ msgstr "Indexované složky"
 msgid "Folders whose files are always available in the catalog."
 msgstr "Složky, jejichž soubory jsou již dostupné v katalogu."
 
-#: ../data/preferences.ui.h:20 ../kupfer/obj/sources.py:156
+#: ../data/preferences.ui.h:20 ../kupfer/obj/sources.py:157
 msgid "Catalog"
 msgstr "Katalog"
 
@@ -519,7 +519,7 @@ msgid "Can not be used with multiple objects"
 msgstr "Nelze použít s více objekty naráz"
 
 #: ../kupfer/obj/fileactions.py:30 ../kupfer/plugin/notes.py:89
-#: ../kupfer/plugin/gnome_terminal.py:36 ../kupfer/plugin/gtg.py:108
+#: ../kupfer/plugin/gnome_terminal.py:36 ../kupfer/plugin/gtg.py:135
 #: ../kupfer/plugin/zim.py:176
 msgid "Open"
 msgstr "Otevřít"
@@ -616,21 +616,21 @@ msgid "Attempt to close all application windows"
 msgstr "Zkusit zavřít okna všech aplikací"
 
 #. TRANS: 'Run' as in Perform a (saved) command
-#: ../kupfer/obj/objects.py:396
+#: ../kupfer/obj/objects.py:398
 msgid "Run"
 msgstr "Spustit"
 
-#: ../kupfer/obj/objects.py:406
+#: ../kupfer/obj/objects.py:408
 msgid "Perform command"
 msgstr "Provést příkaz"
 
-#: ../kupfer/obj/objects.py:419
+#: ../kupfer/obj/objects.py:421
 msgid "(Empty Text)"
 msgstr "(Prázdný text)"
 
 #. TRANS: This is description for a TextLeaf, a free-text search
 #. TRANS: The plural parameter is the number of lines %(num)d
-#: ../kupfer/obj/objects.py:449
+#: ../kupfer/obj/objects.py:451
 #, python-format
 msgid "\"%(text)s\""
 msgid_plural "(%(num)d lines) \"%(text)s\""
@@ -654,19 +654,19 @@ msgstr "Rekurzivní zdroj ze složky %(dir)s, (%(levels)d úrovní)"
 msgid "Directory source %s"
 msgstr "Zdroj složka %s"
 
-#: ../kupfer/obj/sources.py:118
+#: ../kupfer/obj/sources.py:119
 msgid "Home Folder"
 msgstr "Domovská složka"
 
-#: ../kupfer/obj/sources.py:129
+#: ../kupfer/obj/sources.py:130
 msgid "Catalog Index"
 msgstr "Katalogový rejstřík"
 
-#: ../kupfer/obj/sources.py:144
+#: ../kupfer/obj/sources.py:145
 msgid "An index of all available sources"
 msgstr "Rejstřík ze všech dostupných zdrojů"
 
-#: ../kupfer/obj/sources.py:176
+#: ../kupfer/obj/sources.py:177
 msgid "Root catalog"
 msgstr "Kořenový katalog"
 
@@ -886,6 +886,10 @@ msgstr "Terminál X"
 msgid "Urxvt"
 msgstr "Urxvt"
 
+#: ../kupfer/plugin/core/alternatives.py:58
+msgid "Konsole"
+msgstr "Konsole"
+
 #: ../kupfer/plugin/core/commands.py:13 ../kupfer/plugin/core/commands.py:32
 msgid "Save As..."
 msgstr "Uložit jako…"
@@ -1073,11 +1077,11 @@ msgstr "Kopírovat do…"
 msgid "Copy file to a chosen location"
 msgstr "Kopírovat soubor na vybrané místo"
 
-#: ../kupfer/plugin/firefox.py:4 ../kupfer/plugin/firefox.py:36
+#: ../kupfer/plugin/firefox.py:4 ../kupfer/plugin/firefox.py:61
 msgid "Firefox Bookmarks"
 msgstr "Záložky ve Firefoxu"
 
-#: ../kupfer/plugin/firefox.py:6 ../kupfer/plugin/firefox.py:120
+#: ../kupfer/plugin/firefox.py:6 ../kupfer/plugin/firefox.py:147
 msgid "Index of Firefox bookmarks"
 msgstr "Seznam záložek v prohlížeči Firefox"
 
@@ -1085,32 +1089,16 @@ msgstr "Seznam záložek v prohlížeči Firefox"
 msgid "Include visited sites"
 msgstr "Zahrnout navštívené stránky"
 
+#: ../kupfer/plugin/firefox.py:44
+msgid "Firefox tag"
+msgstr "Štítky ve Firefoxu"
+
 #. TRANS: Multihead refers to support for multiple computer displays
 #. TRANS: In this case, it only concerns the special configuration
 #. TRANS: with multiple X "screens"
 #: ../kupfer/plugin/multihead.py:4
 msgid "Multihead Support"
 msgstr "Podpora více monitorů"
-
-#: ../kupfer/plugin/nautilusselection.py:1
-#: ../kupfer/plugin/nautilusselection.py:46
-msgid "Selected File"
-msgstr "Vybraný soubor"
-
-#: ../kupfer/plugin/nautilusselection.py:3
-msgid "Provides current nautilus selection, using Kupfer's Nautilus Extension"
-msgstr ""
-"Poskytuje současný výběr ze správce souborů Nautilus pomocí rozšíření "
-"Nautilus aplikace Kupfer"
-
-#: ../kupfer/plugin/nautilusselection.py:25
-#, python-format
-msgid "Selected File \"%s\""
-msgstr "Vybraný soubor „%s“"
-
-#: ../kupfer/plugin/nautilusselection.py:34
-msgid "Selected Files"
-msgstr "Vybrané soubory"
 
 #: ../kupfer/plugin/notes.py:6 ../kupfer/plugin/notes.py:178
 #: ../kupfer/plugin/notes.py:230
@@ -1738,7 +1726,7 @@ msgid "Claws Mail Contacts and Actions"
 msgstr "Kontakty a akce v Claws Mail"
 
 #: ../kupfer/plugin/clawsmail.py:26 ../kupfer/plugin/evolution.py:24
-#: ../kupfer/plugin/operamail.py:26 ../kupfer/plugin/thunderbird.py:25
+#: ../kupfer/plugin/operamail.py:26 ../kupfer/plugin/thunderbird.py:31
 msgid "Compose New Email"
 msgstr "Napsat nový e-mail"
 
@@ -1757,7 +1745,7 @@ msgstr ""
 
 #: ../kupfer/plugin/clawsmail.py:56 ../kupfer/plugin/defaultmail.py:18
 #: ../kupfer/plugin/evolution.py:40 ../kupfer/plugin/operamail.py:41
-#: ../kupfer/plugin/thunderbird.py:41
+#: ../kupfer/plugin/thunderbird.py:47
 msgid "Compose Email"
 msgstr "Napsat e-mail"
 
@@ -1837,55 +1825,55 @@ msgstr "Empathy"
 msgid "Access to Empathy Contacts"
 msgstr "Přístup ke kontaktům v komunikátoru Empathy"
 
-#: ../kupfer/plugin/empathy.py:25 ../kupfer/plugin/pidgin.py:29
+#: ../kupfer/plugin/empathy.py:26 ../kupfer/plugin/pidgin.py:29
 msgid "Show offline contacts"
 msgstr "Zobrazovat odpojené kontakty"
 
-#: ../kupfer/plugin/empathy.py:34 ../kupfer/plugin/gajim.py:26
+#: ../kupfer/plugin/empathy.py:35 ../kupfer/plugin/gajim.py:26
 #: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:30
 msgid "Available"
 msgstr "Dostupný"
 
-#: ../kupfer/plugin/empathy.py:35 ../kupfer/plugin/gajim.py:28
+#: ../kupfer/plugin/empathy.py:36 ../kupfer/plugin/gajim.py:28
 #: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:32
 msgid "Away"
 msgstr "Pryč"
 
-#: ../kupfer/plugin/empathy.py:36 ../kupfer/plugin/gajim.py:30
+#: ../kupfer/plugin/empathy.py:37 ../kupfer/plugin/gajim.py:30
 #: ../kupfer/plugin/skype.py:34
 msgid "Busy"
 msgstr "Nerušit"
 
-#: ../kupfer/plugin/empathy.py:37 ../kupfer/plugin/gajim.py:29
+#: ../kupfer/plugin/empathy.py:38 ../kupfer/plugin/gajim.py:29
 #: ../kupfer/plugin/skype.py:33
 msgid "Not Available"
 msgstr "Nedostupný"
 
-#: ../kupfer/plugin/empathy.py:38 ../kupfer/plugin/gajim.py:31
+#: ../kupfer/plugin/empathy.py:39 ../kupfer/plugin/gajim.py:31
 #: ../kupfer/plugin/skype.py:35
 msgid "Invisible"
 msgstr "Neviditelný"
 
-#: ../kupfer/plugin/empathy.py:39 ../kupfer/plugin/gajim.py:32
+#: ../kupfer/plugin/empathy.py:40 ../kupfer/plugin/gajim.py:32
 #: ../kupfer/plugin/skype.py:36
 msgid "Offline"
 msgstr "Odpojený"
 
-#: ../kupfer/plugin/empathy.py:96 ../kupfer/plugin/gajim.py:93
+#: ../kupfer/plugin/empathy.py:100 ../kupfer/plugin/gajim.py:93
 #: ../kupfer/plugin/pidgin.py:97 ../kupfer/plugin/skype.py:197
 msgid "Open Chat"
 msgstr "Otevřít diskuzi"
 
-#: ../kupfer/plugin/empathy.py:129 ../kupfer/plugin/gajim.py:121
+#: ../kupfer/plugin/empathy.py:133 ../kupfer/plugin/gajim.py:121
 #: ../kupfer/plugin/skype.py:243
 msgid "Change Global Status To..."
 msgstr "Změnit globální stav na…"
 
-#: ../kupfer/plugin/empathy.py:171
+#: ../kupfer/plugin/empathy.py:175
 msgid "Empathy Contacts"
 msgstr "Kontakty v komunikátoru Empathy"
 
-#: ../kupfer/plugin/empathy.py:237
+#: ../kupfer/plugin/empathy.py:249
 msgid "Empathy Account Status"
 msgstr "Stav účtu Empathy"
 
@@ -2153,7 +2141,6 @@ msgstr "Vyhledávání pomocí Google s přímým zobrazením výsledků"
 
 #: ../kupfer/plugin/google_search.py:58 ../kupfer/plugin/locate.py:46
 #: ../kupfer/plugin/tracker1.py:168 ../kupfer/plugin/tracker1.py:179
-#: ../kupfer/plugin/tracker.py:72 ../kupfer/plugin/tracker.py:113
 #, python-format
 msgid "Results for \"%s\""
 msgstr "Výsledky pro „%s“"
@@ -2177,54 +2164,54 @@ msgstr "Getting Things GNOME"
 msgid "Browse and create new tasks in GTG"
 msgstr "Procházení a vytváření nových úkolů v GTG"
 
-#: ../kupfer/plugin/gtg.py:87
+#: ../kupfer/plugin/gtg.py:114
 #, python-format
 msgid "due: %s"
 msgstr "termín: %s"
 
-#: ../kupfer/plugin/gtg.py:89
+#: ../kupfer/plugin/gtg.py:116
 #, python-format
 msgid "start: %s"
 msgstr "začít: %s"
 
-#: ../kupfer/plugin/gtg.py:91
+#: ../kupfer/plugin/gtg.py:118
 #, python-format
 msgid "tags: %s"
 msgstr "značky: %s"
 
-#: ../kupfer/plugin/gtg.py:118
+#: ../kupfer/plugin/gtg.py:148
 msgid "Open task in Getting Things GNOME!"
 msgstr "Otevřít úkol v Getting Things GNOME!"
 
-#: ../kupfer/plugin/gtg.py:125
+#: ../kupfer/plugin/gtg.py:155
 msgid "Delete"
 msgstr "Smazat"
 
-#: ../kupfer/plugin/gtg.py:135
+#: ../kupfer/plugin/gtg.py:168
 msgid "Permanently remove this task"
 msgstr "Trvale odstranit tento úkol"
 
-#: ../kupfer/plugin/gtg.py:140
+#: ../kupfer/plugin/gtg.py:173
 msgid "Mark Done"
 msgstr "Označit „Dokončeno“"
 
-#: ../kupfer/plugin/gtg.py:149
+#: ../kupfer/plugin/gtg.py:182
 msgid "Mark this task as done"
 msgstr "Označit tento úkol jako dokončený"
 
-#: ../kupfer/plugin/gtg.py:154
+#: ../kupfer/plugin/gtg.py:187
 msgid "Dismiss"
 msgstr "Zahodit"
 
-#: ../kupfer/plugin/gtg.py:163
+#: ../kupfer/plugin/gtg.py:196
 msgid "Mark this task as not to be done anymore"
 msgstr "Označit úkol, že již nebude dokončen"
 
-#: ../kupfer/plugin/gtg.py:168
+#: ../kupfer/plugin/gtg.py:201
 msgid "Create Task"
 msgstr "Vytvořit úkol"
 
-#: ../kupfer/plugin/gtg.py:182
+#: ../kupfer/plugin/gtg.py:218
 msgid "Create new task in Getting Things GNOME"
 msgstr "Vytvořit nový úkol v aplikaci Getting Things GNOME"
 
@@ -2475,11 +2462,11 @@ msgstr "Při vyhledávání souborů nebrat ohled na velikost písmen"
 msgid "OpenOffice / LibreOffice"
 msgstr "OpenOffice / LibreOffice"
 
-#: ../kupfer/plugin/openoffice.py:5 ../kupfer/plugin/openoffice.py:135
+#: ../kupfer/plugin/openoffice.py:5 ../kupfer/plugin/openoffice.py:136
 msgid "Recently used documents in OpenOffice/LibreOffice"
 msgstr "Dokumenty nedávno použité v OpenOffice/LibreOffice"
 
-#: ../kupfer/plugin/openoffice.py:83
+#: ../kupfer/plugin/openoffice.py:84
 msgid "OpenOffice/LibreOffice Recent Items"
 msgstr "Nedávné položky OpenOffice/LibreOffice"
 
@@ -2864,15 +2851,15 @@ msgstr "Thunderbird"
 msgid "Thunderbird/Icedove Contacts and Actions"
 msgstr "Kontakty a akce v Thunderbird/Icedove"
 
-#: ../kupfer/plugin/thunderbird.py:32
+#: ../kupfer/plugin/thunderbird.py:38
 msgid "Compose a new message in Thunderbird"
 msgstr "Napsat novou zprávu v aplikaci Thunderbird"
 
-#: ../kupfer/plugin/thunderbird.py:66
+#: ../kupfer/plugin/thunderbird.py:74
 msgid "Thunderbird Address Book"
 msgstr "Adresář aplikace Thunderbird"
 
-#: ../kupfer/plugin/thunderbird.py:91
+#: ../kupfer/plugin/thunderbird.py:99
 msgid "Contacts from Thunderbird Address Book"
 msgstr "Kontakty z adresáře poštovního klienta Thunderbird"
 
@@ -2928,68 +2915,29 @@ msgstr "Úlohy běžící pro současného uživatele"
 msgid "Tracker"
 msgstr "Tracker"
 
-#: ../kupfer/plugin/tracker1.py:18 ../kupfer/plugin/tracker.py:15
+#: ../kupfer/plugin/tracker1.py:18
 msgid "Tracker desktop search integration"
 msgstr "Vyhledávač Tracker integrovaný v pracovním prostředí"
 
-#: ../kupfer/plugin/tracker1.py:49 ../kupfer/plugin/tracker.py:41
+#: ../kupfer/plugin/tracker1.py:49
 msgid "Search in Tracker"
 msgstr "Vyhledat prohledávačem Tracker"
 
-#: ../kupfer/plugin/tracker1.py:54 ../kupfer/plugin/tracker.py:46
+#: ../kupfer/plugin/tracker1.py:54
 msgid "Open Tracker Search Tool and search for this term"
 msgstr "Otevřít vyhledávací nástroj Tracker a vyhledat tento výraz"
 
-#: ../kupfer/plugin/tracker1.py:62 ../kupfer/plugin/tracker.py:55
+#: ../kupfer/plugin/tracker1.py:62
 msgid "Get Tracker Results..."
 msgstr "Získat výsledky prohledávače Tracker…"
 
-#: ../kupfer/plugin/tracker1.py:71 ../kupfer/plugin/tracker.py:64
+#: ../kupfer/plugin/tracker1.py:71
 msgid "Show Tracker results for query"
 msgstr "Zobrazit výsledky dotazu z prohledávače Tracker"
 
-#: ../kupfer/plugin/tracker.py:5
-msgid "Tracker 0.6"
-msgstr "Tracker 0.6"
-
-#: ../kupfer/plugin/tracker.py:165 ../kupfer/plugin/tracker.py:171
-msgid "Tracker tags"
-msgstr "Značky prohledávače Tracker"
-
-#: ../kupfer/plugin/tracker.py:180
-msgid "Tracker Tags"
-msgstr "Značky prohledávače Tracker"
-
-#: ../kupfer/plugin/tracker.py:186
-msgid "Browse Tracker's tags"
-msgstr "Procházet značky prohledávače Tracker"
-
-#: ../kupfer/plugin/tracker.py:197 ../kupfer/plugin/tracker.py:204
-#, python-format
-msgid "Tag %s"
-msgstr "Značka %s"
-
-#: ../kupfer/plugin/tracker.py:211
-#, python-format
-msgid "Objects tagged %s with Tracker"
-msgstr "Objekt má značku %s od prohledávače Tracker"
-
-#: ../kupfer/plugin/tracker.py:223
-msgid "Add Tag..."
-msgstr "Přidat značku…"
-
-#: ../kupfer/plugin/tracker.py:249
-msgid "Add tracker tag to file"
-msgstr "Přidat souboru značku prohledávače Tracker"
-
-#: ../kupfer/plugin/tracker.py:255
-msgid "Remove Tag..."
-msgstr "Odstranit značku…"
-
-#: ../kupfer/plugin/tracker.py:274
-msgid "Remove tracker tag from file"
-msgstr "Odstranit souboru značku prohledávače Tracker"
-
+#. FIXME: Port tracker tag sources and actions
+#. to the new, much more powerful sparql + dbus API
+#. (using tracker-tag as in 0.6 is a plain hack and a dead end)
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/truecrypt.py:3
 msgid "TrueCrypt"

--- a/po/gl.po
+++ b/po/gl.po
@@ -3,34 +3,36 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # Fran Diéguez <frandieguez@ubuntu.com>, 2010.
+# Oscar Blanco <dev.4m1g0@gmail.com>, 2012.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: kupfer\n"
 "Report-Msgid-Bugs-To: http://bugs.launchpad.net/kupfer\n"
-"POT-Creation-Date: 2011-04-14 21:40+0200\n"
-"PO-Revision-Date: 2010-12-11 00:24+0100\n"
-"Last-Translator: Fran Diéguez <frandieguez@ubuntu.com>\n"
+"POT-Creation-Date: 2012-08-05 21:10+0000\n"
+"PO-Revision-Date: 2012-08-10 17:37+0200\n"
+"Last-Translator: Oscar Blanco <dev.4m1g0@gmail.com>\n"
 "Language-Team: Galician <gnome-gl-list@gnome.org>\n"
 "Language: gl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-Language: Galician\n"
+"X-Generator: Gtranslator 2.91.5\n"
 
-#: ../auxdata/kupfer.desktop.in.h:1
-msgid "Application Launcher"
-msgstr "Iniciador de aplicativos"
-
-#: ../auxdata/kupfer.desktop.in.h:2
-msgid "Convenient command and access tool for applications and documents"
-msgstr "Ferramenta cómoda para controlar e acceder a aplicativos e documentos"
-
-#: ../auxdata/kupfer.desktop.in.h:3 ../kupfer/version.py:15
+#: ../auxdata/kupfer.desktop.in.h:1 ../kupfer/version.py:15
 #: ../kupfer/plugin/core/contents.py:91
 msgid "Kupfer"
 msgstr "Kupfer"
+
+#: ../auxdata/kupfer.desktop.in.h:2
+msgid "Application Launcher"
+msgstr "Iniciador de aplicativos"
+
+#: ../auxdata/kupfer.desktop.in.h:3
+msgid "Convenient command and access tool for applications and documents"
+msgstr "Ferramenta cómoda para controlar e acceder a aplicativos e documentos"
 
 #: ../auxdata/kupfer-exec.desktop.in.h:1
 msgid "Execute in Kupfer"
@@ -40,115 +42,140 @@ msgstr "Executar en Kupfer"
 msgid "Saved Kupfer Command"
 msgstr "Gardouse a orde de Kupfer"
 
-#: ../data/preferences.ui.h:1
-msgid "<b>Browser Keyboard Shortcuts</b>"
-msgstr "<b>Atallos de teclado do explorador</b>"
-
-#: ../data/preferences.ui.h:2
-msgid "<b>Global Keyboard Shortcuts</b>"
-msgstr "<b>Atallos de teclado globais</b>"
-
-#: ../data/preferences.ui.h:3
-msgid "<b>Start</b>"
-msgstr "<b>Iniciar</b>"
-
-#: ../data/preferences.ui.h:4 ../kupfer/obj/sources.py:150
-msgid "Catalog"
-msgstr "Catálogo"
-
-#: ../data/preferences.ui.h:5
-#, fuzzy
-msgid "Desktop Environment"
-msgstr "Aplicativos para o contorno do escritorio"
-
-#: ../data/preferences.ui.h:6
-msgid "Folders whose files are always available in the catalog."
-msgstr ""
-
-#: ../data/preferences.ui.h:7
-msgid "General"
-msgstr "Xeral"
-
-#: ../data/preferences.ui.h:8
-msgid "Icon set:"
-msgstr ""
-
-#: ../data/preferences.ui.h:9
-#, fuzzy
-msgid "Inclusion in Top Level Searches"
-msgstr "Incluír as cancións no nivel superior"
-
-#: ../data/preferences.ui.h:10
-#, fuzzy
-msgid "Indexed Folders"
-msgstr "Novo cartafol"
-
-#: ../data/preferences.ui.h:11
-msgid "Keyboard"
-msgstr "Teclado"
-
-#: ../data/preferences.ui.h:12 ../kupfer/plugin/core/contents.py:78
-msgid "Kupfer Preferences"
-msgstr "Preferencias de Kupfer"
-
-#: ../data/preferences.ui.h:13
-msgid ""
-"Marked sources have their objects included in top level searches.\n"
-"An unmarked source's contents are only available by locating its subcatalog."
-msgstr ""
-
-#: ../data/preferences.ui.h:15
-msgid "Plugins"
-msgstr "Engadidos"
-
-#: ../data/preferences.ui.h:16 ../kupfer/ui/preferences.py:844
-msgid "Reset"
-msgstr "Restabelecer"
-
-#: ../data/preferences.ui.h:17
-msgid "Show icon in notification area"
-msgstr "Mostrar a icona na área de notificacións"
-
-#: ../data/preferences.ui.h:18
-msgid "Start automatically on login"
-msgstr "Abrir automaticamente ao iniciar a sesión "
-
-#: ../data/preferences.ui.h:19
-#, fuzzy
-msgid "Terminal emulator:"
-msgstr "Abrir o terminal aquí"
-
-#: ../data/preferences.ui.h:20
-msgid "Use single keystroke commands (Space, /, period, comma etc.)"
-msgstr "Usar ordes dunha soa tecla (espazo, /, punto, coma, etc.)"
-
 #: ../data/credentials_dialog.ui.h:1
 msgid "User credentials"
 msgstr "Credenciais do usuario"
 
 #: ../data/credentials_dialog.ui.h:2
-msgid "_Change"
-msgstr "_Cambiar"
+msgid "_User:"
+msgstr "_Usuario:"
 
 #: ../data/credentials_dialog.ui.h:3
 msgid "_Password:"
 msgstr "C_ontrasinal:"
 
 #: ../data/credentials_dialog.ui.h:4
-msgid "_User:"
-msgstr "_Usuario:"
+msgid "_Change"
+msgstr "_Cambiar"
 
 #: ../data/getkey_dialog.ui.h:1
-msgid "Keybinding could not be bound"
-msgstr "Non foi posíbel ligar a combinación de teclas"
+msgid "Set Keyboard Shortcut"
+msgstr "Estabelecer o atallo do teclado"
 
 #: ../data/getkey_dialog.ui.h:2
 msgid "Please press desired key combination"
 msgstr "Prema a combinación de teclas desexada"
 
 #: ../data/getkey_dialog.ui.h:3
-msgid "Set Keyboard Shortcut"
-msgstr "Estabelecer o atallo do teclado"
+msgid "Keybinding could not be bound"
+msgstr "Non foi posíbel ligar a combinación de teclas"
+
+#: ../data/preferences.ui.h:1 ../kupfer/plugin/core/contents.py:78
+msgid "Kupfer Preferences"
+msgstr "Preferencias de Kupfer"
+
+#: ../data/preferences.ui.h:2
+msgid "Start automatically on login"
+msgstr "Abrir automaticamente ao iniciar a sesión "
+
+#: ../data/preferences.ui.h:3
+msgid "<b>Start</b>"
+msgstr "<b>Iniciar</b>"
+
+#: ../data/preferences.ui.h:4
+msgid "Show icon in notification area"
+msgstr "Mostrar a icona na área de notificacións"
+
+#: ../data/preferences.ui.h:5
+msgid "Icon set:"
+msgstr "Conxunto de iconas:"
+
+#: ../data/preferences.ui.h:6
+msgid "Terminal emulator:"
+msgstr "Emulador da terminal:"
+
+#: ../data/preferences.ui.h:7
+msgid "Desktop Environment"
+msgstr "Contorno do escritorio"
+
+#: ../data/preferences.ui.h:8 ../kupfer/plugin/gmail/__init__.py:60
+msgid "General"
+msgstr "Xeral"
+
+#: ../data/preferences.ui.h:9
+msgid "<b>Global Keyboard Shortcuts</b>"
+msgstr "<b>Atallos de teclado globais</b>"
+
+#: ../data/preferences.ui.h:10 ../kupfer/ui/preferences.py:849
+msgid "Reset"
+msgstr "Restabelecer"
+
+#: ../data/preferences.ui.h:11
+msgid "<b>Browser Keyboard Shortcuts</b>"
+msgstr "<b>Atallos de teclado do explorador</b>"
+
+#: ../data/preferences.ui.h:12
+msgid "Use single keystroke commands (Space, /, period, comma etc.)"
+msgstr "Usar ordes dunha soa tecla (espazo, /, punto, coma, etc.)"
+
+#: ../data/preferences.ui.h:13
+msgid "Keyboard"
+msgstr "Teclado"
+
+#: ../data/preferences.ui.h:14
+msgid "Plugins"
+msgstr "Engadidos"
+
+#: ../data/preferences.ui.h:15
+msgid "Inclusion in Top Level Searches"
+msgstr "Incluír nas búsquedas de nivel superior"
+
+#: ../data/preferences.ui.h:16
+msgid ""
+"Marked sources have their objects included in top level searches.\n"
+"An unmarked source's contents are only available by locating its subcatalog."
+msgstr ""
+"As fontes sinaladas teñen os seus obxetos incluidos nas búsquedas de nivel "
+"superior.\n"
+"Os contidos dunha fonte desmarcada só están dispoñibeis atopando o seu "
+"subcatálogo."
+
+#: ../data/preferences.ui.h:18
+msgid "Indexed Folders"
+msgstr "Cartafois indexados"
+
+#: ../data/preferences.ui.h:19
+msgid "Folders whose files are always available in the catalog."
+msgstr "Cartafois cuxos ficheiros están sempre dipoñibeis no catálogo."
+
+#: ../data/preferences.ui.h:20 ../kupfer/obj/sources.py:157
+msgid "Catalog"
+msgstr "Catálogo"
+
+#: ../kupfer/core/commandexec.py:239
+#, python-format
+msgid "Could not to carry out '%s'"
+msgstr "Non foi posíbel executar «%s»"
+
+#: ../kupfer/core/commandexec.py:268
+#, python-format
+msgid "\"%s\" produced a result"
+msgstr "«%s» xerou un resultado"
+
+#: ../kupfer/core/execfile.py:30
+#, python-format
+msgid "No permission to run \"%s\" (not executable)"
+msgstr "Non ten permisos para executar «%s» (non é executábel)"
+
+#: ../kupfer/core/execfile.py:47
+#, python-format
+msgid "Command in \"%s\" is not available"
+msgstr "A orde en «%s» non está dispoñíbel"
+
+#: ../kupfer/keyrelay.py:62
+#, python-format
+msgid "Keyboard relay is active for display %s"
+msgstr "A transmisión do teclado está activa para a pantalla %s"
 
 #: ../kupfer/main.py:43
 msgid "do not present main interface on launch"
@@ -162,27 +189,29 @@ msgstr "lista de engadidos dispoñíbeis"
 msgid "enable debug info"
 msgstr "activar a información de depuración"
 
-#: ../kupfer/main.py:46
-msgid "run keyboard shortcut relay service on this display"
-msgstr ""
-
+#. TRANS: --exec-helper=HELPER is an internal command
+#. TRANS: that executes a helper program that is part of kupfer
 #: ../kupfer/main.py:49
+msgid "run plugin helper"
+msgstr "executar plugin-helper"
+
+#: ../kupfer/main.py:52
 msgid "show usage help"
 msgstr "mostrar a axuda"
 
-#: ../kupfer/main.py:50
+#: ../kupfer/main.py:53
 msgid "show version information"
 msgstr "mostrar a información da versión"
 
-#: ../kupfer/main.py:56
+#: ../kupfer/main.py:59
 msgid "Usage: kupfer [ OPTIONS | FILE ... ]"
 msgstr "Uso: kupfer [OPCIÓNS | FICHEIRO ...]"
 
-#: ../kupfer/main.py:67
+#: ../kupfer/main.py:70
 msgid "Available plugins:"
 msgstr "Engadidos dispoñíbeis:"
 
-#: ../kupfer/main.py:114
+#: ../kupfer/main.py:121
 #, python-format
 msgid ""
 "%(PROGRAM_NAME)s: %(SHORT_DESCRIPTION)s\n"
@@ -211,13 +240,12 @@ msgid "Compose Command"
 msgstr "Escribir unha orde"
 
 #: ../kupfer/ui/accelerators.py:11
-#, fuzzy
 msgid "Mark Default Action"
-msgstr "Estabelecer o aplicativo predefinido..."
+msgstr "Marcar a acción predefinida"
 
 #: ../kupfer/ui/accelerators.py:12
 msgid "Forget Object"
-msgstr ""
+msgstr "Esquecer obxeto"
 
 #: ../kupfer/ui/accelerators.py:13
 msgid "Reset All"
@@ -278,19 +306,19 @@ msgstr "Teclear para buscar %s"
 msgid "No action"
 msgstr "Sen acción"
 
-#: ../kupfer/ui/browser.py:1461
+#: ../kupfer/ui/browser.py:1513
 #, python-format
 msgid "Make \"%(action)s\" Default for \"%(object)s\""
-msgstr ""
+msgstr "Facer «%(action)s» predefinida para «%(object)s»"
 
 #. TRANS: Removing learned and/or configured bonus search score
-#: ../kupfer/ui/browser.py:1471
+#: ../kupfer/ui/browser.py:1523
 #, python-format
 msgid "Forget About \"%s\""
-msgstr ""
+msgstr "Esquecerse de «%s»"
 
 #. TRANS: Names of global keyboard shortcuts
-#: ../kupfer/ui/browser.py:1903 ../kupfer/ui/preferences.py:58
+#: ../kupfer/ui/browser.py:1960 ../kupfer/ui/preferences.py:58
 msgid "Show Main Interface"
 msgstr "Mostrar a interface principal"
 
@@ -339,30 +367,40 @@ msgstr "Fontes"
 msgid "Actions"
 msgstr "Accións"
 
+#: ../kupfer/ui/preferences.py:575
+#, python-format
+msgid "Using encrypted password storage: %s"
+msgstr "Usándose almacenamento de contrasinais cifrado: %s"
+
+#: ../kupfer/ui/preferences.py:577
+#, python-format
+msgid "Using password storage: %s"
+msgstr "Usándose almacenamento de contrasinais: %s"
+
 #. TRANS: Plugin-specific configuration (header)
-#: ../kupfer/ui/preferences.py:589
+#: ../kupfer/ui/preferences.py:594
 msgid "Configuration"
 msgstr "Configuración"
 
-#: ../kupfer/ui/preferences.py:609
+#: ../kupfer/ui/preferences.py:614
 msgid "Set username and password"
 msgstr "Estabelecer o nome do usuario e o contrasinal"
 
 #. TRANS: File Chooser Title
-#: ../kupfer/ui/preferences.py:663
+#: ../kupfer/ui/preferences.py:668
 msgid "Choose a Directory"
 msgstr "Escoller un directorio"
 
-#: ../kupfer/ui/preferences.py:842
+#: ../kupfer/ui/preferences.py:847
 msgid "Reset all shortcuts to default values?"
 msgstr ""
 "Desexa restabelecer os valores predefinidos de todos os atallos do teclado?"
 
-#: ../kupfer/ui/preferences.py:850 ../kupfer/plugin/custom_terminal.py:12
+#: ../kupfer/ui/preferences.py:855 ../kupfer/plugin/custom_terminal.py:12
 msgid "Command"
 msgstr "Orde"
 
-#: ../kupfer/ui/preferences.py:851
+#: ../kupfer/ui/preferences.py:856
 msgid "Shortcut"
 msgstr "Atallo"
 
@@ -407,35 +445,9 @@ msgstr ""
 msgid "Could not find running Kupfer"
 msgstr "Non foi posíbel encontrar un Kupfer en execución"
 
-#: ../kupfer/keyrelay.py:62
-#, python-format
-msgid "Keyboard relay is active for display %s"
-msgstr ""
-
-#: ../kupfer/core/commandexec.py:239
-#, python-format
-msgid "Could not to carry out '%s'"
-msgstr "Non foi posíbel executar «%s»"
-
-#: ../kupfer/core/commandexec.py:268
-#, python-format
-msgid "\"%s\" produced a result"
-msgstr "«%s» xerou un resultado"
-
-#: ../kupfer/core/execfile.py:30
-#, python-format
-msgid "No permission to run \"%s\" (not executable)"
-msgstr "Non ten permisos para executar «%s» (non é executábel)"
-
-#: ../kupfer/core/execfile.py:47
-#, python-format
-msgid "Command in \"%s\" is not available"
-msgstr "A orde en «%s» non está dispoñíbel"
-
 #: ../kupfer/obj/base.py:457 ../kupfer/plugin/core/text.py:22
-#, fuzzy
 msgid "Text"
-msgstr "Mostrar o texto"
+msgstr "Texto"
 
 #: ../kupfer/obj/compose.py:15
 msgid "Run after Delay..."
@@ -456,23 +468,56 @@ msgid_plural "%s objects"
 msgstr[0] "%s obxecto"
 msgstr[1] "%s obxectos"
 
-#: ../kupfer/obj/contacts.py:87 ../kupfer/plugin/pidgin.py:156
+#: ../kupfer/obj/contacts.py:129 ../kupfer/plugin/pidgin.py:156
 #, python-format
 msgid "[%(status)s] %(userid)s/%(service)s"
 msgstr "[%(status)s] %(userid)s/%(service)s"
 
+#: ../kupfer/obj/contacts.py:131
+msgid "unknown"
+msgstr "descoñecido"
+
+#: ../kupfer/obj/contacts.py:144
+msgid "Aim"
+msgstr "Aim"
+
+#: ../kupfer/obj/contacts.py:151
+msgid "Google Talk"
+msgstr "Google Talk"
+
+#: ../kupfer/obj/contacts.py:159
+msgid "ICQ"
+msgstr "ICQ"
+
+#: ../kupfer/obj/contacts.py:166
+msgid "MSN"
+msgstr "MSN"
+
+#: ../kupfer/obj/contacts.py:173
+msgid "QQ"
+msgstr "QQ"
+
+#: ../kupfer/obj/contacts.py:180
+msgid "Yahoo"
+msgstr "Yahoo"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/obj/contacts.py:187 ../kupfer/plugin/skype.py:2
+msgid "Skype"
+msgstr "Skype"
+
 #: ../kupfer/obj/exceptions.py:19
 #, python-format
 msgid "%s does not support this operation"
-msgstr ""
+msgstr "%s non soporta esta operación"
 
 #: ../kupfer/obj/exceptions.py:24
 msgid "Can not be used with multiple objects"
-msgstr ""
+msgstr "Non se pode usar con múltiples obxetos"
 
 #: ../kupfer/obj/fileactions.py:30 ../kupfer/plugin/notes.py:89
-#: ../kupfer/plugin/gnome_terminal.py:36 ../kupfer/plugin/gtg.py:108
-#: ../kupfer/plugin/zim.py:107
+#: ../kupfer/plugin/gnome_terminal.py:36 ../kupfer/plugin/gtg.py:135
+#: ../kupfer/plugin/zim.py:176
 msgid "Open"
 msgstr "Abrir"
 
@@ -482,9 +527,9 @@ msgid "No default application for %(file)s (%(type)s)"
 msgstr "Non existe un aplicativo predefinido para %(file)s (%(type)s)"
 
 #: ../kupfer/obj/fileactions.py:45
-#, fuzzy, python-format
+#, python-format
 msgid "Please use \"%s\""
-msgstr "Ficheiro seleccionado «%s»"
+msgstr "Use «%s»"
 
 #: ../kupfer/obj/fileactions.py:45 ../kupfer/plugin/applications.py:109
 msgid "Set Default Application..."
@@ -494,96 +539,95 @@ msgstr "Estabelecer o aplicativo predefinido..."
 msgid "Open with default application"
 msgstr "Abrir co aplicativo predefinido"
 
-#: ../kupfer/obj/fileactions.py:77
+#: ../kupfer/obj/fileactions.py:74
 msgid "Reveal"
 msgstr "Mostrar"
 
-#: ../kupfer/obj/fileactions.py:86
+#: ../kupfer/obj/fileactions.py:83
 msgid "Open parent folder"
 msgstr "Abrir o cartafol pai"
 
-#: ../kupfer/obj/fileactions.py:92
+#: ../kupfer/obj/fileactions.py:89
 msgid "Open Terminal Here"
 msgstr "Abrir o terminal aquí"
 
-#: ../kupfer/obj/fileactions.py:105
+#: ../kupfer/obj/fileactions.py:102
 msgid "Open this location in a terminal"
 msgstr "Abrir esta localización no terminal"
 
-#: ../kupfer/obj/fileactions.py:113
+#: ../kupfer/obj/fileactions.py:110
 msgid "Run in Terminal"
 msgstr "Executar no terminal"
 
-#: ../kupfer/obj/fileactions.py:113
+#: ../kupfer/obj/fileactions.py:110
 msgid "Run (Execute)"
 msgstr "Executar"
 
-#: ../kupfer/obj/fileactions.py:133
+#: ../kupfer/obj/fileactions.py:130
 msgid "Run this program in a Terminal"
 msgstr "Executar este programa no terminal"
 
-#: ../kupfer/obj/fileactions.py:135
+#: ../kupfer/obj/fileactions.py:132
 msgid "Run this program"
 msgstr "Executar este programa"
 
-#: ../kupfer/obj/objects.py:248 ../kupfer/plugin/windows.py:105
-#: ../kupfer/plugin/windows.py:264
+#: ../kupfer/obj/objects.py:252 ../kupfer/plugin/windows.py:105
+#: ../kupfer/plugin/windows.py:264 ../kupfer/plugin/vim/plugin.py:172
 msgid "Go To"
 msgstr "Ir a"
 
-#: ../kupfer/obj/objects.py:274
+#: ../kupfer/obj/objects.py:278
 msgid "Open URL"
 msgstr "Abrir o URL"
 
-#: ../kupfer/obj/objects.py:285
+#: ../kupfer/obj/objects.py:289
 msgid "Open URL with default viewer"
 msgstr "Abrir o URL co visualizador predefinido"
 
-#: ../kupfer/obj/objects.py:299
+#: ../kupfer/obj/objects.py:303
 msgid "Launch"
 msgstr "Iniciar"
 
-#: ../kupfer/obj/objects.py:312
+#: ../kupfer/obj/objects.py:316
 msgid "Show application window"
 msgstr "Mostrar a xanela do aplicativo"
 
-#: ../kupfer/obj/objects.py:313
+#: ../kupfer/obj/objects.py:317
 msgid "Launch application"
 msgstr "Iniciar o aplicativo"
 
-#: ../kupfer/obj/objects.py:324
+#: ../kupfer/obj/objects.py:328
 msgid "Launch Again"
 msgstr "Iniciar outra vez"
 
-#: ../kupfer/obj/objects.py:331
+#: ../kupfer/obj/objects.py:335
 msgid "Launch another instance of this application"
 msgstr "Iniciar outra instancia deste aplicativo"
 
-#: ../kupfer/obj/objects.py:337 ../kupfer/plugin/windows.py:37
+#: ../kupfer/obj/objects.py:341 ../kupfer/plugin/windows.py:37
 msgid "Close"
 msgstr "Pechar"
 
-#: ../kupfer/obj/objects.py:345
+#: ../kupfer/obj/objects.py:349
 msgid "Attempt to close all application windows"
 msgstr "Tentar pechar todas as xanelas do aplicativo"
 
 #. TRANS: 'Run' as in Perform a (saved) command
-#: ../kupfer/obj/objects.py:392
+#: ../kupfer/obj/objects.py:398
 msgid "Run"
 msgstr "Executar"
 
-#: ../kupfer/obj/objects.py:402
+#: ../kupfer/obj/objects.py:408
 msgid "Perform command"
 msgstr "Executar a orde"
 
-#: ../kupfer/obj/objects.py:416
-#, fuzzy
+#: ../kupfer/obj/objects.py:421
 msgid "(Empty Text)"
-msgstr "Ficheiro baleiro"
+msgstr "(Texto baleiro)"
 
 #. TRANS: This is description for a TextLeaf, a free-text search
 #. TRANS: The plural parameter is the number of lines %(num)d
-#: ../kupfer/obj/objects.py:432
+#: ../kupfer/obj/objects.py:451
 #, python-format
 msgid "\"%(text)s\""
 msgid_plural "(%(num)d lines) \"%(text)s\""
@@ -601,24 +645,24 @@ msgstr "%s e outros."
 msgid "Recursive source of %(dir)s, (%(levels)d levels)"
 msgstr "Fonte recursiva de %(dir)s, (%(levels)d niveis)"
 
-#: ../kupfer/obj/sources.py:103
+#: ../kupfer/obj/sources.py:108
 #, python-format
 msgid "Directory source %s"
 msgstr "Directorio fonte %s"
 
-#: ../kupfer/obj/sources.py:113
+#: ../kupfer/obj/sources.py:119
 msgid "Home Folder"
 msgstr "Cartafol persoal"
 
-#: ../kupfer/obj/sources.py:124
+#: ../kupfer/obj/sources.py:130
 msgid "Catalog Index"
 msgstr "Índice do catálogo"
 
-#: ../kupfer/obj/sources.py:139
+#: ../kupfer/obj/sources.py:145
 msgid "An index of all available sources"
 msgstr "Un índice de todas as fontes dispoñíbeis"
 
-#: ../kupfer/obj/sources.py:170
+#: ../kupfer/obj/sources.py:177
 msgid "Root catalog"
 msgstr "Catálogo raíz"
 
@@ -636,33 +680,210 @@ msgstr "O engadido %s non está configurado"
 msgid "Invalid user credentials for %s"
 msgstr "As credenciais de usuario son incorrectas para %s"
 
+#: ../kupfer/plugin/applications.py:2 ../kupfer/plugin/applications.py:38
+msgid "Applications"
+msgstr "Aplicativos"
+
+#: ../kupfer/plugin/applications.py:8 ../kupfer/plugin/applications.py:74
+msgid "All applications and preferences"
+msgstr "Todos os aplicativos e preferencias"
+
+#: ../kupfer/plugin/applications.py:23
+msgid "Applications for Desktop Environment"
+msgstr "Aplicativos para o contorno do escritorio"
+
+#: ../kupfer/plugin/applications.py:83
+msgid "Open With..."
+msgstr "Abrir con…"
+
+#: ../kupfer/plugin/applications.py:105
+msgid "Open with any application"
+msgstr "Abrir con calquera aplicativo"
+
+#: ../kupfer/plugin/applications.py:124
+msgid "Set default application to open this file type"
+msgstr "Estabelecer o aplicativo predefinido para abrir este tipo de ficheiro"
+
+#: ../kupfer/plugin/archivemanager.py:1
+msgid "Archive Manager"
+msgstr "Xestor de arquivadores"
+
+#: ../kupfer/plugin/archivemanager.py:9
+msgid "Use Archive Manager actions"
+msgstr "Usar as accións do Xestor de arquivadores"
+
+#: ../kupfer/plugin/archivemanager.py:27
+msgid "Compressed archive type for 'Create Archive In'"
+msgstr "Tipo de arquivo comprimido para «Crear un arquivo en»"
+
+#: ../kupfer/plugin/archivemanager.py:44
+msgid "Extract Here"
+msgstr "Extraer aquí"
+
+#: ../kupfer/plugin/archivemanager.py:64
+msgid "Extract compressed archive"
+msgstr "Extraer o arquivo comprimido"
+
+#: ../kupfer/plugin/archivemanager.py:70
+msgid "Create Archive"
+msgstr "Crear un arquivo"
+
+#: ../kupfer/plugin/archivemanager.py:86
+#: ../kupfer/plugin/archivemanager.py:129
+msgid "Create a compressed archive from folder"
+msgstr "Crear o arquivo comprimido dun cartafol"
+
+#: ../kupfer/plugin/archivemanager.py:92
+msgid "Create Archive In..."
+msgstr "Crear un arquivo en..."
+
+#. TRANS: Default filename (no extension) for 'Create Archive In...'
+#: ../kupfer/plugin/archivemanager.py:115
+msgid "Archive"
+msgstr "Arquivo"
+
+#: ../kupfer/plugin/calculator.py:2 ../kupfer/plugin/calculator.py:69
+msgid "Calculator"
+msgstr "Calculadora"
+
+#: ../kupfer/plugin/calculator.py:4
+msgid "Calculate expressions starting with '='"
+msgstr "Calcular as expresións que comezan con «=»"
+
+#: ../kupfer/plugin/calculator.py:101
+msgid "Calculate"
+msgstr "Calcular"
+
+#: ../kupfer/plugin/clipboard.py:1 ../kupfer/plugin/clipboard.py:112
+msgid "Clipboards"
+msgstr "Portapapeis"
+
+#: ../kupfer/plugin/clipboard.py:4
+msgid "Recent clipboards and clipboard proxy objects"
+msgstr "Portapapeis recentes e obxetos proxy do portapapeis"
+
+#: ../kupfer/plugin/clipboard.py:24
+msgid "Number of recent clipboards to remember"
+msgstr "Número de portapapeis recentes que lembrar"
+
+#: ../kupfer/plugin/clipboard.py:30
+msgid "Include selected text in clipboard history"
+msgstr "Incluir o texto seleccionado no historial do portapapeis"
+
+#: ../kupfer/plugin/clipboard.py:36
+msgid "Copy selected text to primary clipboard"
+msgstr "Copiar o texto seleccionado ao portapapeis primario"
+
+#: ../kupfer/plugin/clipboard.py:47
+msgid "Selected Text"
+msgstr "Texto seleccionado"
+
+#: ../kupfer/plugin/clipboard.py:57
+#, python-format
+msgid "Clipboard \"%(desc)s\""
+msgid_plural "Clipboard with %(num)d lines \"%(desc)s\""
+msgstr[0] "Portapapeis «%(desc)s»"
+msgstr[1] "Portapapeis con %(num)d liñas «%(desc)s»"
+
+#: ../kupfer/plugin/clipboard.py:64
+msgid "Clipboard Text"
+msgstr "Texto do portapapeis"
+
+#: ../kupfer/plugin/clipboard.py:74
+msgid "Clipboard File"
+msgstr "Ficheiro do portapapeis"
+
+#: ../kupfer/plugin/clipboard.py:84
+msgid "Clipboard Files"
+msgstr "Ficheiros do portapapeis"
+
+#: ../kupfer/plugin/clipboard.py:92
+msgid "Clear"
+msgstr "Limpar"
+
+#: ../kupfer/plugin/clipboard.py:104
+msgid "Remove all recent clipboards"
+msgstr "Eliminar os elementos recentes do portapeis"
+
+#: ../kupfer/plugin/commands.py:1 ../kupfer/plugin/commands.py:187
+msgid "Shell Commands"
+msgstr "Ordes da Shell"
+
+#: ../kupfer/plugin/commands.py:9
+#, python-format
+msgid ""
+"Run command-line programs. Actions marked with the symbol %s run in a "
+"subshell."
+msgstr ""
+"Executar programas de liña de comandos. As accións marcadas co símbolo «%s» "
+"executaranse nunha subshell."
+
+#: ../kupfer/plugin/commands.py:41
+msgid "Run (Get Output)"
+msgstr "Executar (obter a información de saída)"
+
+#: ../kupfer/plugin/commands.py:59
+msgid "Run program and return its output"
+msgstr "Executar o programa e mostrar a información de saída"
+
+#. TRANS: The user starts a program (command) and the text
+#. TRANS: is an argument to the command
+#: ../kupfer/plugin/commands.py:65
+msgid "Pass to Command..."
+msgstr "Enviar a un comando…"
+
+#: ../kupfer/plugin/commands.py:107
+msgid "Run program with object as an additional parameter"
+msgstr "Executar programa cun obxeto como parámetro adicional"
+
+#. TRANS: The user starts a program (command) and
+#. TRANS: the text is written on stdin
+#: ../kupfer/plugin/commands.py:115
+msgid "Write to Command..."
+msgstr "Redirixir a un comando…"
+
+#: ../kupfer/plugin/commands.py:149 ../kupfer/plugin/commands.py:161
+msgid "Run program and supply text on the standard input"
+msgstr "Executar o programa e proporcionar texto na saída estándar"
+
+#. TRANS: The user starts a program (command) and
+#. TRANS: the text is written on stdin, and we
+#. TRANS: present the output (stdout) to the user.
+#: ../kupfer/plugin/commands.py:157
+msgid "Filter through Command..."
+msgstr "Filtrar a través dun comando…"
+
+#: ../kupfer/plugin/commands.py:215
+msgid "Run command-line programs"
+msgstr "Executar programas de liña de comandos"
+
 #: ../kupfer/plugin/core/alternatives.py:7
 msgid "GTK+"
-msgstr ""
+msgstr "GTK+"
 
 #: ../kupfer/plugin/core/alternatives.py:13
-#, fuzzy
 msgid "GNOME Terminal"
-msgstr "Perfís do terminal de GNOME"
+msgstr "Terminal de GNOME"
 
 #: ../kupfer/plugin/core/alternatives.py:22
-#, fuzzy
 msgid "XFCE Terminal"
-msgstr "Executar no terminal"
+msgstr "Terminal de XFCE"
 
 #: ../kupfer/plugin/core/alternatives.py:31
-#, fuzzy
 msgid "LXTerminal"
-msgstr "Executar no terminal"
+msgstr "LXTerminal"
 
 #: ../kupfer/plugin/core/alternatives.py:40
-#, fuzzy
 msgid "X Terminal"
-msgstr "Executar no terminal"
+msgstr "Terminal X"
 
 #: ../kupfer/plugin/core/alternatives.py:49
 msgid "Urxvt"
-msgstr ""
+msgstr "Urxvt"
+
+#: ../kupfer/plugin/core/alternatives.py:58
+msgid "Konsole"
+msgstr "Konsole"
 
 #: ../kupfer/plugin/core/commands.py:13 ../kupfer/plugin/core/commands.py:32
 msgid "Save As..."
@@ -696,38 +917,29 @@ msgstr "Obter axuda con Kupfer"
 msgid "Show preferences window for Kupfer"
 msgstr "Mostrar a xanela de preferencias de Kupfer"
 
-#: ../kupfer/plugin/core/__init__.py:65
+#: ../kupfer/plugin/core/__init__.py:64
 msgid "Search Contents"
 msgstr "Contidos da busca"
 
-#: ../kupfer/plugin/core/__init__.py:83
+#: ../kupfer/plugin/core/__init__.py:82
 msgid "Search inside this catalog"
 msgstr "Buscar neste catálogo"
 
-#: ../kupfer/plugin/core/__init__.py:91
+#: ../kupfer/plugin/core/__init__.py:90
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../kupfer/plugin/core/__init__.py:106
+#: ../kupfer/plugin/core/__init__.py:105
 msgid "Copy to clipboard"
 msgstr "Copiar ao portapapeis"
 
-#: ../kupfer/plugin/core/__init__.py:128
+#: ../kupfer/plugin/core/__init__.py:127
 msgid "Rescan"
 msgstr "Escanear outra vez"
 
-#: ../kupfer/plugin/core/__init__.py:143
+#: ../kupfer/plugin/core/__init__.py:142
 msgid "Force reindex of this source"
 msgstr "Forzar a reindexación desta fonte"
-
-#: ../kupfer/plugin/core/selection.py:8 ../kupfer/plugin/core/selection.py:36
-msgid "Selected Text"
-msgstr "Texto seleccionado"
-
-#: ../kupfer/plugin/core/selection.py:23
-#, python-format
-msgid "Selected Text \"%s\""
-msgstr "Texto seleccionado «%s»"
 
 #: ../kupfer/plugin/core/internal.py:13
 msgid "Last Command"
@@ -744,171 +956,6 @@ msgstr "Último resultado"
 #: ../kupfer/plugin/core/internal.py:66
 msgid "Command Results"
 msgstr "Resultados da orde"
-
-#: ../kupfer/plugin/archivemanager.py:1
-#, fuzzy
-msgid "Archive Manager"
-msgstr "Arquivo"
-
-#: ../kupfer/plugin/archivemanager.py:9
-#, fuzzy
-msgid "Use Archive Manager actions"
-msgstr "Accións do xestor de ficheiros Thunar"
-
-#: ../kupfer/plugin/archivemanager.py:27
-msgid "Compressed archive type for 'Create Archive In'"
-msgstr "Tipo de arquivo comprimido para «Crear un arquivo en»"
-
-#: ../kupfer/plugin/archivemanager.py:44
-msgid "Extract Here"
-msgstr "Extraer aquí"
-
-#: ../kupfer/plugin/archivemanager.py:64
-msgid "Extract compressed archive"
-msgstr "Extraer o arquivo comprimido"
-
-#: ../kupfer/plugin/archivemanager.py:70
-msgid "Create Archive"
-msgstr "Crear un arquivo"
-
-#: ../kupfer/plugin/archivemanager.py:86
-#: ../kupfer/plugin/archivemanager.py:129
-msgid "Create a compressed archive from folder"
-msgstr "Crear o arquivo comprimido dun cartafol"
-
-#: ../kupfer/plugin/archivemanager.py:92
-msgid "Create Archive In..."
-msgstr "Crear un arquivo en..."
-
-#. TRANS: Default filename (no extension) for 'Create Archive In...'
-#: ../kupfer/plugin/archivemanager.py:115
-msgid "Archive"
-msgstr "Arquivo"
-
-#: ../kupfer/plugin/applications.py:2 ../kupfer/plugin/applications.py:38
-msgid "Applications"
-msgstr "Aplicativos"
-
-#: ../kupfer/plugin/applications.py:8 ../kupfer/plugin/applications.py:74
-msgid "All applications and preferences"
-msgstr "Todos os aplicativos e preferencias"
-
-#: ../kupfer/plugin/applications.py:23
-msgid "Applications for Desktop Environment"
-msgstr "Aplicativos para o contorno do escritorio"
-
-#: ../kupfer/plugin/applications.py:83
-msgid "Open With..."
-msgstr "Abrir con…"
-
-#: ../kupfer/plugin/applications.py:105
-msgid "Open with any application"
-msgstr "Abrir con calquera aplicativo"
-
-#: ../kupfer/plugin/applications.py:124
-msgid "Set default application to open this file type"
-msgstr "Estabelecer o aplicativo predefinido para abrir este tipo de ficheiro"
-
-#: ../kupfer/plugin/calculator.py:2 ../kupfer/plugin/calculator.py:69
-msgid "Calculator"
-msgstr "Calculadora"
-
-#: ../kupfer/plugin/calculator.py:4
-msgid "Calculate expressions starting with '='"
-msgstr "Calcular as expresións que comezan con «=»"
-
-#: ../kupfer/plugin/calculator.py:101
-msgid "Calculate"
-msgstr "Calcular"
-
-#: ../kupfer/plugin/clipboard.py:1 ../kupfer/plugin/clipboard.py:71
-msgid "Clipboards"
-msgstr "Portapapeis"
-
-#: ../kupfer/plugin/clipboard.py:4 ../kupfer/plugin/clipboard.py:111
-msgid "Recent clipboards"
-msgstr "Portapapeis recentes"
-
-#: ../kupfer/plugin/clipboard.py:20
-msgid "Number of recent clipboards"
-msgstr "Número de portapapeis recentes"
-
-#: ../kupfer/plugin/clipboard.py:26
-msgid "Include recent selections"
-msgstr "Incluír as seleccións recentes"
-
-#: ../kupfer/plugin/clipboard.py:32
-msgid "Copy selection to primary clipboard"
-msgstr "Copiar as seleccións ao portapapeis primario"
-
-#: ../kupfer/plugin/clipboard.py:44
-#, python-format
-msgid "Clipboard \"%(desc)s\""
-msgid_plural "Clipboard with %(num)d lines \"%(desc)s\""
-msgstr[0] "Portapapeis «%(desc)s»"
-msgstr[1] "Portapapeis con %(num)d liñas «%(desc)s»"
-
-#: ../kupfer/plugin/clipboard.py:51
-msgid "Clear"
-msgstr "Limpar"
-
-#: ../kupfer/plugin/clipboard.py:63
-msgid "Remove all recent clipboards"
-msgstr "Eliminar os elementos recentes do portapeis"
-
-#: ../kupfer/plugin/commands.py:1 ../kupfer/plugin/commands.py:187
-msgid "Shell Commands"
-msgstr "Ordes da Shell"
-
-#: ../kupfer/plugin/commands.py:9
-#, python-format
-msgid ""
-"Run command-line programs. Actions marked with the symbol %s run in a "
-"subshell."
-msgstr ""
-
-#: ../kupfer/plugin/commands.py:41
-msgid "Run (Get Output)"
-msgstr "Executar (obter a información de saída)"
-
-#: ../kupfer/plugin/commands.py:59
-msgid "Run program and return its output"
-msgstr "Executar o programa e mostrar a información de saída"
-
-#. TRANS: The user starts a program (command) and the text
-#. TRANS: is an argument to the command
-#: ../kupfer/plugin/commands.py:65
-#, fuzzy
-msgid "Pass to Command..."
-msgstr "Última orde"
-
-#: ../kupfer/plugin/commands.py:107
-msgid "Run program with object as an additional parameter"
-msgstr ""
-
-#. TRANS: The user starts a program (command) and
-#. TRANS: the text is written on stdin
-#: ../kupfer/plugin/commands.py:115
-#, fuzzy
-msgid "Write to Command..."
-msgstr "Escribir en…"
-
-#: ../kupfer/plugin/commands.py:149 ../kupfer/plugin/commands.py:161
-#, fuzzy
-msgid "Run program and supply text on the standard input"
-msgstr "Executar o programa e mostrar a información de saída"
-
-#. TRANS: The user starts a program (command) and
-#. TRANS: the text is written on stdin, and we
-#. TRANS: present the output (stdout) to the user.
-#: ../kupfer/plugin/commands.py:157
-msgid "Filter through Command..."
-msgstr ""
-
-#: ../kupfer/plugin/commands.py:215
-#, fuzzy
-msgid "Run command-line programs"
-msgstr "Executar programas por liña de ordes"
 
 #: ../kupfer/plugin/dictionary.py:1 ../kupfer/plugin/dictionary.py:21
 msgid "Dictionary"
@@ -1007,11 +1054,11 @@ msgid "More file actions"
 msgstr "Máis accións sobre os ficheiros"
 
 #: ../kupfer/plugin/fileactions.py:40 ../kupfer/plugin/windows.py:122
-#: ../kupfer/plugin/thunar.py:210
+#: ../kupfer/plugin/thunar.py:211
 msgid "Move To..."
 msgstr "Mover a..."
 
-#: ../kupfer/plugin/fileactions.py:67 ../kupfer/plugin/thunar.py:252
+#: ../kupfer/plugin/fileactions.py:67 ../kupfer/plugin/thunar.py:253
 msgid "Move file to new location"
 msgstr "Mover o ficheiro a unha nova localización"
 
@@ -1019,19 +1066,19 @@ msgstr "Mover o ficheiro a unha nova localización"
 msgid "Rename To..."
 msgstr "Renomear como..."
 
-#: ../kupfer/plugin/fileactions.py:145 ../kupfer/plugin/thunar.py:165
+#: ../kupfer/plugin/fileactions.py:145 ../kupfer/plugin/thunar.py:166
 msgid "Copy To..."
 msgstr "Copiar a…"
 
-#: ../kupfer/plugin/fileactions.py:186 ../kupfer/plugin/thunar.py:206
+#: ../kupfer/plugin/fileactions.py:186 ../kupfer/plugin/thunar.py:207
 msgid "Copy file to a chosen location"
 msgstr "Copiar o ficheiro á localización escollida"
 
-#: ../kupfer/plugin/firefox.py:4 ../kupfer/plugin/firefox.py:36
+#: ../kupfer/plugin/firefox.py:4 ../kupfer/plugin/firefox.py:61
 msgid "Firefox Bookmarks"
 msgstr "Marcadores de Firefox"
 
-#: ../kupfer/plugin/firefox.py:6 ../kupfer/plugin/firefox.py:120
+#: ../kupfer/plugin/firefox.py:6 ../kupfer/plugin/firefox.py:147
 msgid "Index of Firefox bookmarks"
 msgstr "Índice dos marcadores de Firefox"
 
@@ -1039,25 +1086,16 @@ msgstr "Índice dos marcadores de Firefox"
 msgid "Include visited sites"
 msgstr "Incluír os sitios visitados"
 
-#: ../kupfer/plugin/nautilusselection.py:1
-#: ../kupfer/plugin/nautilusselection.py:46
-msgid "Selected File"
-msgstr "Ficheiro seleccionado"
+#: ../kupfer/plugin/firefox.py:44
+msgid "Firefox tag"
+msgstr "Etiqueta de Firefox"
 
-#: ../kupfer/plugin/nautilusselection.py:3
-msgid "Provides current nautilus selection, using Kupfer's Nautilus Extension"
-msgstr ""
-"Proporciona a selección actual do nautilus usando a extensión para nautilus "
-"de Kupfer"
-
-#: ../kupfer/plugin/nautilusselection.py:25
-#, python-format
-msgid "Selected File \"%s\""
-msgstr "Ficheiro seleccionado «%s»"
-
-#: ../kupfer/plugin/nautilusselection.py:34
-msgid "Selected Files"
-msgstr "Ficheiros seleccionados"
+#. TRANS: Multihead refers to support for multiple computer displays
+#. TRANS: In this case, it only concerns the special configuration
+#. TRANS: with multiple X "screens"
+#: ../kupfer/plugin/multihead.py:4
+msgid "Multihead Support"
+msgstr "Soporte de múltiples monitores"
 
 #: ../kupfer/plugin/notes.py:6 ../kupfer/plugin/notes.py:178
 #: ../kupfer/plugin/notes.py:230
@@ -1284,7 +1322,7 @@ msgid "Show Text"
 msgstr "Mostrar o texto"
 
 #: ../kupfer/plugin/show_text.py:7 ../kupfer/plugin/show_text.py:31
-#: ../kupfer/plugin/show_text.py:52
+#: ../kupfer/plugin/show_text.py:58
 msgid "Display text in a window"
 msgstr "Mostrar o texto nunha xanela"
 
@@ -1292,7 +1330,7 @@ msgstr "Mostrar o texto nunha xanela"
 msgid "Large Type"
 msgstr "Tipo grande"
 
-#: ../kupfer/plugin/show_text.py:60
+#: ../kupfer/plugin/show_text.py:66
 msgid "Show Notification"
 msgstr "Mostrar a notificación"
 
@@ -1337,13 +1375,12 @@ msgid "Triggers"
 msgstr "Disparadores"
 
 #: ../kupfer/plugin/triggers.py:6
-#, fuzzy
 msgid ""
 "Assign global keybindings (triggers) to objects created with 'Compose "
 "Command'."
 msgstr ""
 "Asignar combinacións globais de teclas (disparadores) aos obxectos creados "
-"con «Escribir unha orde»  (Ctrl+Retorno)."
+"con «Escribir unha orde»."
 
 #: ../kupfer/plugin/triggers.py:161
 msgid "Add Trigger..."
@@ -1504,16 +1541,15 @@ msgid "Jump to this window's workspace and focus"
 msgstr "Saltar ao espazo de traballo desta xanela e focalizar"
 
 #: ../kupfer/plugin/windows.py:252
-#, fuzzy, python-format
+#, python-format
 msgid "%d window"
 msgid_plural "%d windows"
-msgstr[0] "Seguinte xanela"
-msgstr[1] "Seguinte xanela"
+msgstr[0] "%d xanela"
+msgstr[1] "%d xanelas"
 
 #: ../kupfer/plugin/windows.py:256
-#, fuzzy
 msgid "Active workspace"
-msgstr "Saltar a este espazo de traballo"
+msgstr "Espazo de traballo activo"
 
 #: ../kupfer/plugin/windows.py:274
 msgid "Jump to this workspace"
@@ -1585,21 +1621,23 @@ msgstr "Contido de %s"
 #. don't panic! This is just because it's crazy and fun! ツ
 #: ../kupfer/plugin/asciiunicodeiconset.py:3
 msgid "Ascii & Unicode Icon Set"
-msgstr ""
+msgstr "Conxunto de iconas ASCII e Unicode"
 
 #: ../kupfer/plugin/asciiunicodeiconset.py:5
 msgid ""
 "Provides the Ascii and Unicode icon sets that use letters and symbols to "
 "produce icons for the objects found in Kupfer."
 msgstr ""
+"Forneza o conxunto de iconas ASCII e Unicode que usan letras e simbolos para "
+"producir iconas para os obxetos atopados en Kupfer."
 
 #: ../kupfer/plugin/asciiunicodeiconset.py:21
 msgid "Ascii"
-msgstr ""
+msgstr "ASCII"
 
 #: ../kupfer/plugin/asciiunicodeiconset.py:23
 msgid "Unicode"
-msgstr ""
+msgstr "Unicode"
 
 #: ../kupfer/plugin/audacious.py:1 ../kupfer/plugin/audacious.py:187
 msgid "Audacious"
@@ -1683,7 +1721,7 @@ msgid "Claws Mail Contacts and Actions"
 msgstr "Contactos e accións de Claws Mail"
 
 #: ../kupfer/plugin/clawsmail.py:26 ../kupfer/plugin/evolution.py:24
-#: ../kupfer/plugin/operamail.py:26 ../kupfer/plugin/thunderbird.py:25
+#: ../kupfer/plugin/operamail.py:26 ../kupfer/plugin/thunderbird.py:31
 msgid "Compose New Email"
 msgstr "Escribir un novo correo-e"
 
@@ -1701,7 +1739,7 @@ msgstr "Recibir as novas mensaxes de todas as contas de ClawsMail"
 
 #: ../kupfer/plugin/clawsmail.py:56 ../kupfer/plugin/defaultmail.py:18
 #: ../kupfer/plugin/evolution.py:40 ../kupfer/plugin/operamail.py:41
-#: ../kupfer/plugin/thunderbird.py:41
+#: ../kupfer/plugin/thunderbird.py:47
 msgid "Compose Email"
 msgstr "Escribir un correo-e"
 
@@ -1724,13 +1762,12 @@ msgstr "Contactos da axenda de enderezos de Claws Mail"
 
 #: ../kupfer/plugin/custom_terminal.py:1
 #: ../kupfer/plugin/custom_terminal.py:39
-#, fuzzy
 msgid "Custom Terminal"
-msgstr "Executar no terminal"
+msgstr "Terminal personalizada"
 
 #: ../kupfer/plugin/custom_terminal.py:2
 msgid "Configure a custom terminal emulator"
-msgstr ""
+msgstr "Configurar un emulador de terminal personalizada"
 
 #: ../kupfer/plugin/custom_terminal.py:18
 msgid "Execute flag"
@@ -1738,15 +1775,15 @@ msgstr "Executar opción"
 
 #: ../kupfer/plugin/customtheme.py:1
 msgid "Custom Theme"
-msgstr ""
+msgstr "Tema personalizado"
 
 #: ../kupfer/plugin/customtheme.py:3
 msgid "Use a custom color theme"
-msgstr ""
+msgstr "Usar un tema de cor personalizado"
 
 #: ../kupfer/plugin/customtheme.py:110
 msgid "Theme:"
-msgstr ""
+msgstr "Tema:"
 
 #: ../kupfer/plugin/defaultmail.py:1
 msgid "Default Email Client"
@@ -1766,70 +1803,75 @@ msgstr "Devhelp"
 msgid "Search in Devhelp"
 msgstr "Buscar en Devhelp"
 
+#: ../kupfer/plugin/duckduckgo.py:5 ../kupfer/plugin/duckduckgo.py:19
+msgid "DuckDuckGo Search"
+msgstr "Búsqueda DuckDuckGo"
+
+#: ../kupfer/plugin/duckduckgo.py:8 ../kupfer/plugin/duckduckgo.py:30
+msgid "Search the web securely with DuckDuckGo"
+msgstr "Buscar con seguridade na web con DuckDuckGo"
+
 #. -*- coding: UTF-8 -*-
 #. vim: set noexpandtab ts=8 sw=8:
 #: ../kupfer/plugin/empathy.py:3
 msgid "Empathy"
-msgstr ""
+msgstr "Empathy"
 
 #: ../kupfer/plugin/empathy.py:6
-#, fuzzy
 msgid "Access to Empathy Contacts"
-msgstr "Acceder aos contactos de Gajim"
+msgstr "Acceder aos contactos de Empathy"
 
-#: ../kupfer/plugin/empathy.py:25 ../kupfer/plugin/pidgin.py:29
+#: ../kupfer/plugin/empathy.py:26 ../kupfer/plugin/pidgin.py:29
 msgid "Show offline contacts"
 msgstr "Mostrar os contactos desconectados"
 
-#: ../kupfer/plugin/empathy.py:34 ../kupfer/plugin/gajim.py:26
+#: ../kupfer/plugin/empathy.py:35 ../kupfer/plugin/gajim.py:26
 #: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:30
 msgid "Available"
 msgstr "Dispoñíbel"
 
-#: ../kupfer/plugin/empathy.py:35 ../kupfer/plugin/gajim.py:28
+#: ../kupfer/plugin/empathy.py:36 ../kupfer/plugin/gajim.py:28
 #: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:32
 msgid "Away"
 msgstr "Ausente"
 
-#: ../kupfer/plugin/empathy.py:36 ../kupfer/plugin/gajim.py:30
+#: ../kupfer/plugin/empathy.py:37 ../kupfer/plugin/gajim.py:30
 #: ../kupfer/plugin/skype.py:34
 msgid "Busy"
 msgstr "Ocupado"
 
-#: ../kupfer/plugin/empathy.py:37 ../kupfer/plugin/gajim.py:29
+#: ../kupfer/plugin/empathy.py:38 ../kupfer/plugin/gajim.py:29
 #: ../kupfer/plugin/skype.py:33
 msgid "Not Available"
 msgstr "Non dispoñíbel"
 
-#: ../kupfer/plugin/empathy.py:38 ../kupfer/plugin/gajim.py:31
+#: ../kupfer/plugin/empathy.py:39 ../kupfer/plugin/gajim.py:31
 #: ../kupfer/plugin/skype.py:35
 msgid "Invisible"
 msgstr "Invisíbel"
 
-#: ../kupfer/plugin/empathy.py:39 ../kupfer/plugin/gajim.py:32
+#: ../kupfer/plugin/empathy.py:40 ../kupfer/plugin/gajim.py:32
 #: ../kupfer/plugin/skype.py:36
 msgid "Offline"
 msgstr "Desconectado"
 
-#: ../kupfer/plugin/empathy.py:96 ../kupfer/plugin/gajim.py:90
-#: ../kupfer/plugin/pidgin.py:97 ../kupfer/plugin/skype.py:204
+#: ../kupfer/plugin/empathy.py:100 ../kupfer/plugin/gajim.py:93
+#: ../kupfer/plugin/pidgin.py:97 ../kupfer/plugin/skype.py:197
 msgid "Open Chat"
 msgstr "Abrir unha conversa"
 
-#: ../kupfer/plugin/empathy.py:129 ../kupfer/plugin/gajim.py:118
-#: ../kupfer/plugin/skype.py:250
+#: ../kupfer/plugin/empathy.py:133 ../kupfer/plugin/gajim.py:121
+#: ../kupfer/plugin/skype.py:243
 msgid "Change Global Status To..."
 msgstr "Cambiar o estado global a..."
 
-#: ../kupfer/plugin/empathy.py:171
-#, fuzzy
+#: ../kupfer/plugin/empathy.py:175
 msgid "Empathy Contacts"
-msgstr "Contactos de Gajim"
+msgstr "Contactos de Empathy"
 
-#: ../kupfer/plugin/empathy.py:237
-#, fuzzy
+#: ../kupfer/plugin/empathy.py:249
 msgid "Empathy Account Status"
-msgstr "Estado da conta de Gajim"
+msgstr "Estado da conta de Empathy"
 
 #: ../kupfer/plugin/evolution.py:4
 msgid "Evolution"
@@ -1885,18 +1927,119 @@ msgstr "Acceder aos contactos de Gajim"
 msgid "Free for Chat"
 msgstr "Dispoñíbel para conversar"
 
-#: ../kupfer/plugin/gajim.py:146
+#: ../kupfer/plugin/gajim.py:149
 msgid "Gajim Contacts"
 msgstr "Contactos de Gajim"
 
-#: ../kupfer/plugin/gajim.py:210
+#: ../kupfer/plugin/gajim.py:213
 msgid "Gajim Account Status"
 msgstr "Estado da conta de Gajim"
 
 #. TRANS: "Glob" is the matching files like a shell with "*.py" etc.
 #: ../kupfer/plugin/glob.py:3 ../kupfer/plugin/glob.py:17
 msgid "Glob"
-msgstr ""
+msgstr "Glob"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/gmail/__init__.py:2 ../kupfer/plugin/gmail/__init__.py:234
+msgid "Gmail"
+msgstr "Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:5
+msgid "Load contacts and compose new email in Gmail"
+msgstr "Cargar os contactos e escribir un novo correo-e en Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:33
+msgid "Load contacts' pictures"
+msgstr "Cargar as imaxes dos contactos"
+
+#: ../kupfer/plugin/gmail/__init__.py:39
+msgid "Load additional information"
+msgstr "Cargar información adicional"
+
+#: ../kupfer/plugin/gmail/__init__.py:50
+msgid "Work email"
+msgstr "Correo-e do traballo"
+
+#: ../kupfer/plugin/gmail/__init__.py:51
+msgid "Home email"
+msgstr "Correo-e persoal"
+
+#: ../kupfer/plugin/gmail/__init__.py:52
+msgid "Other email"
+msgstr "Outro correo-e"
+
+#: ../kupfer/plugin/gmail/__init__.py:54
+msgid "Work address"
+msgstr "Enderezo do traballo"
+
+#: ../kupfer/plugin/gmail/__init__.py:55
+msgid "Home address"
+msgstr "Enderezo persoal"
+
+#: ../kupfer/plugin/gmail/__init__.py:56
+msgid "Other address"
+msgstr "Outro enderezo"
+
+#: ../kupfer/plugin/gmail/__init__.py:58
+msgid "Car phone"
+msgstr "Teléfono do coche"
+
+#: ../kupfer/plugin/gmail/__init__.py:59
+msgid "Fax"
+msgstr "Fax"
+
+#: ../kupfer/plugin/gmail/__init__.py:61
+msgid "Home phone"
+msgstr "Teléfono persoal"
+
+#: ../kupfer/plugin/gmail/__init__.py:62
+msgid "Home fax"
+msgstr "Fax persoal"
+
+#: ../kupfer/plugin/gmail/__init__.py:63
+msgid "Internal phone"
+msgstr "Teléfono interno"
+
+#: ../kupfer/plugin/gmail/__init__.py:64
+msgid "Mobile"
+msgstr "Móbil"
+
+#: ../kupfer/plugin/gmail/__init__.py:65
+msgid "Other"
+msgstr "Outro"
+
+#: ../kupfer/plugin/gmail/__init__.py:66
+msgid "VOIP"
+msgstr "VOIP"
+
+#: ../kupfer/plugin/gmail/__init__.py:67
+msgid "Work phone"
+msgstr "Teléfono do traballo"
+
+#: ../kupfer/plugin/gmail/__init__.py:68
+msgid "Work fax"
+msgstr "Fax do traballo"
+
+#: ../kupfer/plugin/gmail/__init__.py:93
+msgid "Compose Email in Gmail"
+msgstr "Redactar un correo-e en Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:117
+msgid "Open web browser and compose new email in Gmail"
+msgstr "Abrir o navegador web e redactar un novo correo-e en Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:123
+msgid "Edit Contact in Gmail"
+msgstr "Editar contacto en Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:133
+msgid "Open web browser and edit contact in Gmail"
+msgstr "Abrir o navegador web e editar contacto en Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:263
+msgid "Contacts from Google services (Gmail)"
+msgstr "Contactos dos servizos de Google (Gmail)"
 
 #: ../kupfer/plugin/gnome_terminal.py:1 ../kupfer/plugin/gnome_terminal.py:56
 msgid "GNOME Terminal Profiles"
@@ -1905,31 +2048,6 @@ msgstr "Perfís do terminal de GNOME"
 #: ../kupfer/plugin/gnome_terminal.py:3
 msgid "Launch GNOME Terminal profiles"
 msgstr "Iniciar os perfís do terminal de GNOME"
-
-#. -*- coding: UTF-8 -*-
-#: ../kupfer/plugin/gmail/__init__.py:2 ../kupfer/plugin/gmail/__init__.py:144
-msgid "Gmail"
-msgstr "Gmail"
-
-#: ../kupfer/plugin/gmail/__init__.py:5
-msgid "Load contacts and compose new email in Gmail"
-msgstr "Cargar os contactos e escribir un novo correo-e en Gmail"
-
-#: ../kupfer/plugin/gmail/__init__.py:32
-msgid "Load contacts' pictures"
-msgstr "Cargar as imaxes dos contactos"
-
-#: ../kupfer/plugin/gmail/__init__.py:51
-msgid "Compose Email in GMail"
-msgstr "Escribir un correo-e en Gmail"
-
-#: ../kupfer/plugin/gmail/__init__.py:74
-msgid "Open web browser and compose new email in GMail"
-msgstr "Abrir o navegador web e escribir un novo correo-e en Gmail"
-
-#: ../kupfer/plugin/gmail/__init__.py:177
-msgid "Contacts from Google services (Gmail)"
-msgstr "Contactos dos servizos de Google (Gmail)"
 
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/google_picasa/__init__.py:2
@@ -2016,7 +2134,6 @@ msgid "Search Google with results shown directly"
 msgstr "Buscar en Google mostrando os resultados directamente"
 
 #: ../kupfer/plugin/google_search.py:58 ../kupfer/plugin/locate.py:46
-#: ../kupfer/plugin/tracker.py:72 ../kupfer/plugin/tracker.py:113
 #: ../kupfer/plugin/tracker1.py:168 ../kupfer/plugin/tracker1.py:179
 #, python-format
 msgid "Results for \"%s\""
@@ -2032,49 +2149,6 @@ msgstr "Mostrar máis resultados para «%s»"
 msgid "%s total found"
 msgstr "%s encontrados en total"
 
-#: ../kupfer/plugin/google_translate.py:6
-msgid "Google Translate"
-msgstr "Google Translate"
-
-#: ../kupfer/plugin/google_translate.py:8
-#: ../kupfer/plugin/google_translate.py:153
-msgid "Translate text with Google Translate"
-msgstr "Traducir un texto con Google Translate"
-
-#: ../kupfer/plugin/google_translate.py:83
-msgid "Google Translate connection timed out"
-msgstr "A conexión con Google Translate expirou"
-
-#: ../kupfer/plugin/google_translate.py:86
-msgid "Error connecting to Google Translate"
-msgstr "Produciuse un erro na conexión con Google Translate"
-
-#: ../kupfer/plugin/google_translate.py:136
-#: ../kupfer/plugin/google_translate.py:223
-msgid "Translate To..."
-msgstr "Traducir a…"
-
-#: ../kupfer/plugin/google_translate.py:179
-#, python-format
-msgid "Translate into %s"
-msgstr "Traducir a %s"
-
-#: ../kupfer/plugin/google_translate.py:203
-msgid "Languages"
-msgstr "Idiomas"
-
-#: ../kupfer/plugin/google_translate.py:238
-msgid "Show translated page in browser"
-msgstr "Mostrar no navegador a páxina traducida"
-
-#: ../kupfer/plugin/google_translate.py:255
-msgid "Show Translation To..."
-msgstr "Mostrar a tradución en..."
-
-#: ../kupfer/plugin/google_translate.py:271
-msgid "Show translation in browser"
-msgstr "Mostrar a tradución no navegador"
-
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/gtg.py:2
 msgid "Getting Things GNOME"
@@ -2084,60 +2158,60 @@ msgstr "Getting Things GNOME"
 msgid "Browse and create new tasks in GTG"
 msgstr "Explorar e crear novas tarefas en GTG"
 
-#: ../kupfer/plugin/gtg.py:87
+#: ../kupfer/plugin/gtg.py:114
 #, python-format
 msgid "due: %s"
 msgstr "límite: %s"
 
-#: ../kupfer/plugin/gtg.py:89
+#: ../kupfer/plugin/gtg.py:116
 #, python-format
 msgid "start: %s"
 msgstr "iniciar: %s"
 
-#: ../kupfer/plugin/gtg.py:91
+#: ../kupfer/plugin/gtg.py:118
 #, python-format
 msgid "tags: %s"
 msgstr "etiquetas: %s"
 
-#: ../kupfer/plugin/gtg.py:118
+#: ../kupfer/plugin/gtg.py:148
 msgid "Open task in Getting Things GNOME!"
 msgstr "Abrir a tarefa en Getting Things GNOME"
 
-#: ../kupfer/plugin/gtg.py:125
+#: ../kupfer/plugin/gtg.py:155
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../kupfer/plugin/gtg.py:135
+#: ../kupfer/plugin/gtg.py:168
 msgid "Permanently remove this task"
 msgstr "Eliminar esta tarefa permanentemente"
 
-#: ../kupfer/plugin/gtg.py:140
+#: ../kupfer/plugin/gtg.py:173
 msgid "Mark Done"
 msgstr "Marcar como feita"
 
-#: ../kupfer/plugin/gtg.py:149
+#: ../kupfer/plugin/gtg.py:182
 msgid "Mark this task as done"
 msgstr "Marcar esta tarefa como feita"
 
-#: ../kupfer/plugin/gtg.py:154
+#: ../kupfer/plugin/gtg.py:187
 msgid "Dismiss"
 msgstr "Ignorar"
 
-#: ../kupfer/plugin/gtg.py:163
+#: ../kupfer/plugin/gtg.py:196
 msgid "Mark this task as not to be done anymore"
 msgstr "Marcar esta tarefa para non ser feita máis"
 
-#: ../kupfer/plugin/gtg.py:168
+#: ../kupfer/plugin/gtg.py:201
 msgid "Create Task"
 msgstr "Crear unha tarefa"
 
-#: ../kupfer/plugin/gtg.py:182
+#: ../kupfer/plugin/gtg.py:218
 msgid "Create new task in Getting Things GNOME"
 msgstr "Crear unha tarefa nova en Getting Things GNOME"
 
 #: ../kupfer/plugin/gwibber.py:3
 msgid "Gwibber"
-msgstr ""
+msgstr "Gwibber"
 
 #: ../kupfer/plugin/gwibber.py:6
 msgid ""
@@ -2145,42 +2219,42 @@ msgid ""
 "social networks like Twitter, Identi.ca etc. Requires the package 'gwibber-"
 "service'."
 msgstr ""
+"Microblogging con Gwibber. Permite enviar e recibir mensaxes de redes "
+"sociais como Twitter, Identi.ca etc. Require o paquete «gwibber-service»."
 
 #: ../kupfer/plugin/gwibber.py:45
 msgid "Maximum number of messages to show"
-msgstr ""
+msgstr "Número máximo de mensaxes a mostrar"
 
 #. TRANS: Account description, similar to "John on Identi.ca"
 #: ../kupfer/plugin/gwibber.py:98
-#, fuzzy, python-format
+#, python-format
 msgid "%(user)s on %(service)s"
-msgstr "%(user)s %(when)s"
+msgstr "%(user)s en %(service)s"
 
 #. TRANS: Gwibber Message description
 #. TRANS: Similar to "John  May 5 2011 11:40 on Identi.ca"
 #. TRANS: the %(user)s and similar tokens must be unchanged
 #: ../kupfer/plugin/gwibber.py:153
-#, fuzzy, python-format
+#, python-format
 msgid "%(user)s %(when)s on %(where)s"
-msgstr "%(user)s %(when)s"
+msgstr "%(user)s %(when)s en %(where)s"
 
 #: ../kupfer/plugin/gwibber.py:187
-#, fuzzy
 msgid "Send Message"
-msgstr "Enviar unha mensaxe..."
+msgstr "Enviar unha mensaxe"
 
 #: ../kupfer/plugin/gwibber.py:205
 msgid "Send message to all Gwibber accounts"
-msgstr ""
+msgstr "Enviar a mensaxe a todas as contas de Gwibber"
 
 #: ../kupfer/plugin/gwibber.py:210
-#, fuzzy
 msgid "Send Message To..."
-msgstr "Enviar unha mensaxe..."
+msgstr "Enviar unha mensaxe a…"
 
 #: ../kupfer/plugin/gwibber.py:238
 msgid "Send message to a Gwibber account"
-msgstr ""
+msgstr "Enviar a mensaxe a unha conta de Gwibber"
 
 #: ../kupfer/plugin/gwibber.py:243 ../kupfer/plugin/pidgin.py:120
 msgid "Send Message..."
@@ -2188,107 +2262,99 @@ msgstr "Enviar unha mensaxe..."
 
 #: ../kupfer/plugin/gwibber.py:273
 msgid "Send message to selected Gwibber account"
-msgstr ""
+msgstr "Enviar a mensaxe a conta de Gwibber seleccionada"
 
 #: ../kupfer/plugin/gwibber.py:278
 msgid "Reply..."
 msgstr "Responder…"
 
 #: ../kupfer/plugin/gwibber.py:314
-#, fuzzy
 msgid "Delete Message"
-msgstr "Enviar unha mensaxe..."
+msgstr "Eliminar a mensaxe"
 
 #: ../kupfer/plugin/gwibber.py:337
-#, fuzzy
 msgid "Send Private Message..."
-msgstr "Enviar unha mensaxe directa..."
+msgstr "Enviar unha mensaxe privada..."
 
 #: ../kupfer/plugin/gwibber.py:370
-#, fuzzy
 msgid "Send direct message to user"
-msgstr "Enviar unha mensaxe directa a..."
+msgstr "Enviar unha mensaxe directa o usuario"
 
 #: ../kupfer/plugin/gwibber.py:376
 msgid "Retweet"
-msgstr ""
+msgstr "Retwitear"
 
 #: ../kupfer/plugin/gwibber.py:376
-#, fuzzy
 msgid "Retweet To..."
-msgstr "Renomear como..."
+msgstr "Retwitear a…"
 
 #: ../kupfer/plugin/gwibber.py:407
-#, fuzzy
 msgid "Retweet message to all Gwibber accounts"
-msgstr "Recibir as novas mensaxes de todas as contas de ClawsMail"
+msgstr "Retwitear a mensaxe a todas as contas de Gwibber"
 
 #: ../kupfer/plugin/gwibber.py:408
 msgid "Retweet message to a Gwibber account"
-msgstr ""
+msgstr "Retwitear a mensaxe a unha conta de Gwibber"
 
 #: ../kupfer/plugin/gwibber.py:413
-#, fuzzy
 msgid "Open in Browser"
-msgstr "Abrir o cartafol pai"
+msgstr "Abrir no navegador"
 
 #: ../kupfer/plugin/gwibber.py:419
-#, fuzzy
 msgid "Open message in default web browser"
-msgstr "Abrir o URL co visualizador predefinido"
+msgstr "Abrir a mensaxe co navegador web predefinido"
 
 #: ../kupfer/plugin/gwibber.py:425 ../kupfer/plugin/gwibber.py:463
-#, fuzzy
 msgid "Gwibber Accounts"
-msgstr "Estado da conta de Gajim"
+msgstr "Contas de Gwibber"
 
 #: ../kupfer/plugin/gwibber.py:456
 msgid "Accounts configured in Gwibber"
-msgstr ""
+msgstr "Contas configuradas en Gwibber"
 
 #: ../kupfer/plugin/gwibber.py:495
 msgid "Gwibber Messages"
-msgstr ""
+msgstr "Mensaxes de Gwibber"
 
 #: ../kupfer/plugin/gwibber.py:518
 msgid "Recent messages received by Gwibber"
-msgstr ""
+msgstr "Mensaxes recentes recibidas por Gwibber"
 
 #. TRANS:  %s is a service name
 #: ../kupfer/plugin/gwibber.py:527
 #, python-format
 msgid "Gwibber Messages for %s"
-msgstr ""
+msgstr "Mensaxes de Gwibber para %s"
 
 #: ../kupfer/plugin/gwibber.py:543
 msgid "Gwibber Streams"
-msgstr ""
+msgstr "Canles de Gwibber"
 
 #: ../kupfer/plugin/gwibber.py:566
 msgid "Streams configured in Gwibber"
-msgstr ""
+msgstr "Canles configuradas en Gwibber"
 
 #. TRANS: Gwibber messages in %s :: %s is a Stream name
 #: ../kupfer/plugin/gwibber.py:574
 #, python-format
 msgid "Gwibber Messages in %s"
-msgstr ""
+msgstr "Mensaxes de Gwibber en %s"
 
 #: ../kupfer/plugin/gwibber_simple.py:3
 msgid "Gwibber (Simple)"
-msgstr ""
+msgstr "Gwibber (Simple)"
 
 #: ../kupfer/plugin/gwibber_simple.py:7
 msgid "Send updates via the microblogging client Gwibber"
-msgstr ""
+msgstr "Enviar actualizacións a través do cliente de microblogging Gwibber"
 
 #: ../kupfer/plugin/gwibber_simple.py:45
 msgid "Send Update"
-msgstr ""
+msgstr "Enviar actualización"
 
 #: ../kupfer/plugin/gwibber_simple.py:65
 msgid "Unable to activate Gwibber service"
-msgstr ""
+msgstr "Non foi posíbel activar o servizo de Gwibber"
 
 #: ../kupfer/plugin/higherorder.py:1
 msgid "Higher-order Actions"
@@ -2387,25 +2453,15 @@ msgstr ""
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/openoffice.py:3
 msgid "OpenOffice / LibreOffice"
-msgstr ""
+msgstr "OpenOffice / LibreOffice"
 
-#: ../kupfer/plugin/openoffice.py:5 ../kupfer/plugin/openoffice.py:135
-#, fuzzy
+#: ../kupfer/plugin/openoffice.py:5 ../kupfer/plugin/openoffice.py:136
 msgid "Recently used documents in OpenOffice/LibreOffice"
-msgstr "Documentos usados recentemente en OpenOffice"
+msgstr "Documentos usados recentemente en OpenOffice/LibreOffice"
 
-#: ../kupfer/plugin/openoffice.py:83
-#, fuzzy
+#: ../kupfer/plugin/openoffice.py:84
 msgid "OpenOffice/LibreOffice Recent Items"
-msgstr "Elementos recentes de OpenOffice"
-
-#: ../kupfer/plugin/opera.py:4 ../kupfer/plugin/opera.py:22
-msgid "Opera Bookmarks"
-msgstr "Marcadores de Opera"
-
-#: ../kupfer/plugin/opera.py:6 ../kupfer/plugin/opera.py:54
-msgid "Index of Opera bookmarks"
-msgstr "Índice dos marcadores de Opera"
+msgstr "Elementos recentes de OpenOffice/LibreOffice"
 
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/operamail.py:2
@@ -2427,6 +2483,14 @@ msgstr "Contactos de Opera Mail"
 #: ../kupfer/plugin/operamail.py:120
 msgid "Contacts from Opera Mail"
 msgstr "Contactos de Opera Mail"
+
+#: ../kupfer/plugin/opera.py:4 ../kupfer/plugin/opera.py:22
+msgid "Opera Bookmarks"
+msgstr "Marcadores de Opera"
+
+#: ../kupfer/plugin/opera.py:6 ../kupfer/plugin/opera.py:54
+msgid "Index of Opera bookmarks"
+msgstr "Índice dos marcadores de Opera"
 
 #: ../kupfer/plugin/pidgin.py:3
 msgid "Pidgin"
@@ -2459,13 +2523,17 @@ msgstr "Acceso rápido ás sesións de PuTTY"
 msgid "Start Session"
 msgstr "Iniciar unha sesión"
 
+#: ../kupfer/plugin/qsicons/__init__.py:24
+msgid "Quicksilver Icons"
+msgstr "Iconas Quicksilver"
+
 #: ../kupfer/plugin/quickview.py:1
 msgid "Quick Image Viewer"
-msgstr ""
+msgstr "Visor rápido de imaxes"
 
 #: ../kupfer/plugin/quickview.py:53
 msgid "View Image"
-msgstr ""
+msgstr "Ver imaxe"
 
 #: ../kupfer/plugin/rst.py:1
 msgid "reStructuredText"
@@ -2508,33 +2576,33 @@ msgstr "Sesións de Screen"
 msgid "Attach"
 msgstr "Anexar"
 
-#: ../kupfer/plugin/sendkeys.py:2 ../kupfer/plugin/sendkeys.py:49
+#: ../kupfer/plugin/sendkeys.py:2 ../kupfer/plugin/sendkeys.py:52
 msgid "Send Keys"
-msgstr ""
+msgstr "Enviar teclas"
 
 #: ../kupfer/plugin/sendkeys.py:8
 msgid "Send synthetic keyboard events using xautomation"
-msgstr ""
+msgstr "Enviar eventos sintéticos de teclado usando xautomation"
 
-#: ../kupfer/plugin/sendkeys.py:25
+#: ../kupfer/plugin/sendkeys.py:28
 msgid "Paste to Foreground Window"
-msgstr ""
+msgstr "Pegar na xanela en primeiro plano"
 
-#: ../kupfer/plugin/sendkeys.py:43
+#: ../kupfer/plugin/sendkeys.py:46
 msgid "Copy to clipboard and send Ctrl+V to foreground window"
-msgstr ""
+msgstr "Copiar ao portapapeis e enviar Ctrl+V a xanela en primeiro plano"
 
-#: ../kupfer/plugin/sendkeys.py:85
+#: ../kupfer/plugin/sendkeys.py:101
 msgid "Send keys to foreground window"
-msgstr ""
+msgstr "Enviar teclas a xanela en primeiro plano"
 
-#: ../kupfer/plugin/sendkeys.py:90
+#: ../kupfer/plugin/sendkeys.py:106
 msgid "Type Text"
-msgstr ""
+msgstr "Escribir texto"
 
-#: ../kupfer/plugin/sendkeys.py:111
+#: ../kupfer/plugin/sendkeys.py:127
 msgid "Type the text to foreground window"
-msgstr ""
+msgstr "Escribir o texto na xanela en primeiro plano"
 
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/services.py:2 ../kupfer/plugin/services.py:96
@@ -2590,19 +2658,12 @@ msgid "Services"
 msgstr "Servizos"
 
 #: ../kupfer/plugin/show_qrcode.py:5 ../kupfer/plugin/show_qrcode.py:25
-#, fuzzy
 msgid "Show QRCode"
-msgstr "Mostrar o código fonte"
+msgstr "Mostrar o código QR"
 
 #: ../kupfer/plugin/show_qrcode.py:9 ../kupfer/plugin/show_qrcode.py:60
-#, fuzzy
 msgid "Display text as QRCode in a window"
-msgstr "Mostrar o texto nunha xanela"
-
-#. -*- coding: UTF-8 -*-
-#: ../kupfer/plugin/skype.py:2
-msgid "Skype"
-msgstr "Skype"
+msgstr "Mostrar o texto como código QR nunha xanela"
 
 #: ../kupfer/plugin/skype.py:5
 msgid "Access to Skype contacts"
@@ -2616,24 +2677,24 @@ msgstr "Skypéame"
 msgid "Logged Out"
 msgstr "Sesión finalizada"
 
-#: ../kupfer/plugin/skype.py:183
+#: ../kupfer/plugin/skype.py:179
 #, python-format
 msgid "[%(status)s] %(userid)s"
 msgstr "[%(status)s] %(userid)s"
 
-#: ../kupfer/plugin/skype.py:225
+#: ../kupfer/plugin/skype.py:218
 msgid "Call"
 msgstr "Chamar"
 
-#: ../kupfer/plugin/skype.py:239
+#: ../kupfer/plugin/skype.py:232
 msgid "Place a call to contact"
 msgstr "Chamar ao contacto"
 
-#: ../kupfer/plugin/skype.py:274
+#: ../kupfer/plugin/skype.py:267
 msgid "Skype Contacts"
 msgstr "Contactos de Skype"
 
-#: ../kupfer/plugin/skype.py:294
+#: ../kupfer/plugin/skype.py:287
 msgid "Skype Statuses"
 msgstr "Estados de Skype"
 
@@ -2665,6 +2726,18 @@ msgstr "Servidores SSH como os especificados en ~/.ssh/config"
 #: ../kupfer/plugin_support.py:144
 msgid "No D-Bus connection to desktop session"
 msgstr "Non hai conexión D-Bus coa sesión do escritorio"
+
+#: ../kupfer/plugin_support.py:171
+msgid "GNOME Keyring"
+msgstr "Depósito de claves de GNOME"
+
+#: ../kupfer/plugin_support.py:172
+msgid "KWallet"
+msgstr "KWallet"
+
+#: ../kupfer/plugin_support.py:173
+msgid "Unencrypted File"
+msgstr "Ficheiro non cifrado"
 
 #: ../kupfer/plugin/templates.py:1 ../kupfer/plugin/templates.py:107
 msgid "Document Templates"
@@ -2719,36 +2792,45 @@ msgstr "Escribir en…"
 msgid "Get Text Contents"
 msgstr "Obter os contidos de texto"
 
-#: ../kupfer/plugin/thunar.py:1 ../kupfer/plugin/thunar.py:184
-#: ../kupfer/plugin/thunar.py:224 ../kupfer/plugin/thunar.py:283
+#: ../kupfer/plugin/thunar.py:1 ../kupfer/plugin/thunar.py:185
+#: ../kupfer/plugin/thunar.py:225 ../kupfer/plugin/thunar.py:278
+#: ../kupfer/plugin/thunar.py:329
 msgid "Thunar"
 msgstr "Thunar"
 
-#: ../kupfer/plugin/thunar.py:10
+#: ../kupfer/plugin/thunar.py:11
 msgid "File manager Thunar actions"
 msgstr "Accións do xestor de ficheiros Thunar"
 
-#: ../kupfer/plugin/thunar.py:66
+#: ../kupfer/plugin/thunar.py:67
 msgid "Select in File Manager"
 msgstr "Seleccionar un xestor de ficheiros"
 
-#: ../kupfer/plugin/thunar.py:94
+#: ../kupfer/plugin/thunar.py:95
 msgid "Show Properties"
 msgstr "Mostrar as propiedades"
 
-#: ../kupfer/plugin/thunar.py:117
+#: ../kupfer/plugin/thunar.py:118
 msgid "Show information about file in file manager"
 msgstr "Mostrar a información do ficheiro no xestor de ficheiros"
 
-#: ../kupfer/plugin/thunar.py:126
+#: ../kupfer/plugin/thunar.py:127
 msgid "Send To..."
 msgstr "Enviar a..."
 
-#: ../kupfer/plugin/thunar.py:258
+#: ../kupfer/plugin/thunar.py:259
+msgid "Symlink In..."
+msgstr "Crear unha ligazón simbólica en…"
+
+#: ../kupfer/plugin/thunar.py:300
+msgid "Create a symlink to file in a chosen location"
+msgstr "Crear unha ligazón simbólica a un ficheiro na ubicación elixida"
+
+#: ../kupfer/plugin/thunar.py:304
 msgid "Empty Trash"
 msgstr "Baleirar o lixo"
 
-#: ../kupfer/plugin/thunar.py:298
+#: ../kupfer/plugin/thunar.py:344
 msgid "Thunar Send To Objects"
 msgstr "Enviar a Obxectos Thunar"
 
@@ -2760,15 +2842,15 @@ msgstr "Thunderbird"
 msgid "Thunderbird/Icedove Contacts and Actions"
 msgstr "Contactos e accións de Thunderbird/Icedove"
 
-#: ../kupfer/plugin/thunderbird.py:32
+#: ../kupfer/plugin/thunderbird.py:38
 msgid "Compose a new message in Thunderbird"
 msgstr "Escribir unha nova mensaxe en Thunderbird"
 
-#: ../kupfer/plugin/thunderbird.py:66
+#: ../kupfer/plugin/thunderbird.py:74
 msgid "Thunderbird Address Book"
 msgstr "Axenda de Thunderbird"
 
-#: ../kupfer/plugin/thunderbird.py:91
+#: ../kupfer/plugin/thunderbird.py:99
 msgid "Contacts from Thunderbird Address Book"
 msgstr "Contactos da axenda de Thunderbird"
 
@@ -2820,72 +2902,29 @@ msgstr "pid: %(pid)s  cpu: %(cpu)g%%  mem: %(mem)g%%  tempo: %(time)s"
 msgid "Running tasks for current user"
 msgstr "Tarefas en execución do usuario actual"
 
-#: ../kupfer/plugin/tracker.py:5
-msgid "Tracker 0.6"
-msgstr "Tracker 0.6"
+#: ../kupfer/plugin/tracker1.py:10
+msgid "Tracker"
+msgstr "Tracker"
 
-#: ../kupfer/plugin/tracker.py:15 ../kupfer/plugin/tracker1.py:18
+#: ../kupfer/plugin/tracker1.py:18
 msgid "Tracker desktop search integration"
 msgstr "Integración co aplicativo de buscas de escritorio Tracker"
 
-#: ../kupfer/plugin/tracker.py:41 ../kupfer/plugin/tracker1.py:49
+#: ../kupfer/plugin/tracker1.py:49
 msgid "Search in Tracker"
 msgstr "Buscar en Tracker"
 
-#: ../kupfer/plugin/tracker.py:46 ../kupfer/plugin/tracker1.py:54
+#: ../kupfer/plugin/tracker1.py:54
 msgid "Open Tracker Search Tool and search for this term"
 msgstr "Abrir Tracker e buscar este termo"
 
-#: ../kupfer/plugin/tracker.py:55 ../kupfer/plugin/tracker1.py:62
+#: ../kupfer/plugin/tracker1.py:62
 msgid "Get Tracker Results..."
 msgstr "Obter os resultados de Tracker…"
 
-#: ../kupfer/plugin/tracker.py:64 ../kupfer/plugin/tracker1.py:71
+#: ../kupfer/plugin/tracker1.py:71
 msgid "Show Tracker results for query"
 msgstr "Mostrar os resultados da consulta en Tracker"
-
-#: ../kupfer/plugin/tracker.py:165 ../kupfer/plugin/tracker.py:171
-msgid "Tracker tags"
-msgstr "Etiquetas de Tracker"
-
-#: ../kupfer/plugin/tracker.py:180
-msgid "Tracker Tags"
-msgstr "Etiquetas de Tracker"
-
-#: ../kupfer/plugin/tracker.py:186
-msgid "Browse Tracker's tags"
-msgstr "Examinar as etiquetas de Tracker"
-
-#: ../kupfer/plugin/tracker.py:197 ../kupfer/plugin/tracker.py:204
-#, python-format
-msgid "Tag %s"
-msgstr "Etiqueta %s"
-
-#: ../kupfer/plugin/tracker.py:211
-#, python-format
-msgid "Objects tagged %s with Tracker"
-msgstr "Obxectos etiquetados %s con Tracker"
-
-#: ../kupfer/plugin/tracker.py:223
-msgid "Add Tag..."
-msgstr "Engadir unha etiqueta..."
-
-#: ../kupfer/plugin/tracker.py:249
-msgid "Add tracker tag to file"
-msgstr "Engadir unha etiqueta de tracker ao ficheiro"
-
-#: ../kupfer/plugin/tracker.py:255
-msgid "Remove Tag..."
-msgstr "Eliminar a etiqueta..."
-
-#: ../kupfer/plugin/tracker.py:274
-msgid "Remove tracker tag from file"
-msgstr "Eliminar a etiqueta de tracker do ficheiro"
-
-#: ../kupfer/plugin/tracker1.py:10
-#, fuzzy
-msgid "Tracker"
-msgstr "Tracker 0.6"
 
 #. FIXME: Port tracker tag sources and actions
 #. to the new, much more powerful sparql + dbus API
@@ -2940,6 +2979,43 @@ msgstr "Sesións de TSClient"
 msgid "Saved sessions in Terminal Server Client"
 msgstr "Sesións gardadas en Terminal Server Client"
 
+#: ../kupfer/plugin/vim/__init__.py:1
+msgid "Vim"
+msgstr "Vim"
+
+#: ../kupfer/plugin/vim/__init__.py:4
+msgid "Recently used documents in Vim"
+msgstr "Documentos usados recentemente en Vim"
+
+#: ../kupfer/plugin/vim/plugin.py:56
+msgid "Vim Recent Documents"
+msgstr "Documentos recentes de Vim"
+
+#: ../kupfer/plugin/vim/plugin.py:219
+msgid "Close (Save All)"
+msgstr "Pechar (gardar todo)"
+
+#: ../kupfer/plugin/vim/plugin.py:237
+msgid "Send..."
+msgstr "Enviar…"
+
+#: ../kupfer/plugin/vim/plugin.py:264
+msgid "Send ex command"
+msgstr "Enviar comando «ex»"
+
+#: ../kupfer/plugin/vim/plugin.py:272
+msgid "Insert in Vim..."
+msgstr "Inserir en Vim…"
+
+#: ../kupfer/plugin/vim/plugin.py:309
+msgid "Active Vim Sessions"
+msgstr "Sesións activas de Vim"
+
+#: ../kupfer/plugin/vim/plugin.py:338
+#, python-format
+msgid "Vim Session %s"
+msgstr "Sesión %s de Vim"
+
 #: ../kupfer/plugin/vinagre.py:4
 msgid "Vinagre"
 msgstr "Vinagre"
@@ -2956,18 +3032,6 @@ msgstr "Iniciar unha sesión de Vinagre"
 msgid "Vinagre Bookmarks"
 msgstr "Marcadores de Vinagre"
 
-#: ../kupfer/plugin/vim.py:1
-msgid "Vim"
-msgstr "Vim"
-
-#: ../kupfer/plugin/vim.py:3
-msgid "Recently used documents in Vim"
-msgstr "Documentos usados recentemente en Vim"
-
-#: ../kupfer/plugin/vim.py:46
-msgid "Vim Recent Documents"
-msgstr "Documentos recentes de Vim"
-
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/virtualbox/__init__.py:3
 msgid "VirtualBox"
@@ -2983,7 +3047,7 @@ msgstr ""
 
 #: ../kupfer/plugin/virtualbox/__init__.py:22
 msgid "Force use CLI interface"
-msgstr ""
+msgstr "Forzar o uso da interface CLI"
 
 #: ../kupfer/plugin/virtualbox/__init__.py:86
 #: ../kupfer/plugin/virtualbox/__init__.py:97
@@ -3024,48 +3088,157 @@ msgstr "Máquinas de VirtualBox"
 msgid "Zim"
 msgstr "Zim"
 
-#: ../kupfer/plugin/zim.py:10
+#: ../kupfer/plugin/zim.py:11
 msgid "Access to Pages stored in Zim - A Desktop Wiki and Outliner"
 msgstr ""
 "Acceder ás páxinas gardadas en Zim - Unha wiki de escritorio e un "
 "esquematizador"
 
-#: ../kupfer/plugin/zim.py:28
+#: ../kupfer/plugin/zim.py:30
 msgid "Page names start with :colon"
 msgstr "Os nomes de páxinas comezan con :(dous puntos)"
 
-#: ../kupfer/plugin/zim.py:58
+#: ../kupfer/plugin/zim.py:36
+msgid "Default page name for quick notes"
+msgstr "Nome de páxina predefinido para as notas rápidas"
+
+#: ../kupfer/plugin/zim.py:38
+#, python-format
+msgid "Note %x %X"
+msgstr "Nota %x %X"
+
+#: ../kupfer/plugin/zim.py:39
+msgid ""
+"Strftime tags can be used: %H - hour, %M - minutes, etc\n"
+"Please check python documentation for details.\n"
+"NOTE: comma will be replaced by _"
+msgstr ""
+"Pódense usar etiquetas «strftime»: %H - hora, %M - minutos, etc\n"
+"Consulte a documentación de Python para obter máis detalles.\n"
+"Nota: as comas reemplazaranse por «_»"
+
+#: ../kupfer/plugin/zim.py:45
+msgid "Default namespace for quick notes"
+msgstr "Espazo de nomes predefinido para as notas rápidas"
+
+#: ../kupfer/plugin/zim.py:80
 #, python-format
 msgid "Zim Page from Notebook \"%s\""
 msgstr "Páxina Zim do caderno de notas «%s»"
 
-#: ../kupfer/plugin/zim.py:67
+#: ../kupfer/plugin/zim.py:89
 msgid "Create Zim Page"
 msgstr "Crear unha páxina Zim"
 
-#: ../kupfer/plugin/zim.py:74
+#: ../kupfer/plugin/zim.py:96
 msgid "Create page in default notebook"
 msgstr "Crear unha páxina no caderno de notas predefinido"
 
-#: ../kupfer/plugin/zim.py:84
+#: ../kupfer/plugin/zim.py:108
 msgid "Create Zim Page In..."
 msgstr "Crear unha páxina Zim en..."
 
-#: ../kupfer/plugin/zim.py:122
+#: ../kupfer/plugin/zim.py:132
+msgid "Insert QuickNote into Zim"
+msgstr "Inserir nota rápida en Zim"
+
+#: ../kupfer/plugin/zim.py:142
+msgid "Quick note selected text into Zim notebook"
+msgstr "Nota rápida seleccionada no caderno de notas Zim"
+
+#: ../kupfer/plugin/zim.py:191
 msgid "Create Subpage..."
 msgstr "Crear unha subpáxina..."
 
-#: ../kupfer/plugin/zim.py:243
+#: ../kupfer/plugin/zim.py:370
 msgid "Zim Notebooks"
 msgstr "Caderno de notas de Zim"
 
-#: ../kupfer/plugin/zim.py:259
+#: ../kupfer/plugin/zim.py:387
 msgid "Zim Pages"
 msgstr "Páxinas Zim"
 
-#: ../kupfer/plugin/zim.py:287
+#: ../kupfer/plugin/zim.py:415
 msgid "Pages stored in Zim Notebooks"
 msgstr "Páxinas gardadas no caderno de notas de Zim"
+
+#~ msgid "Selected Text \"%s\""
+#~ msgstr "Texto seleccionado «%s»"
+
+#~ msgid "Recent clipboards"
+#~ msgstr "Portapapeis recentes"
+
+#~ msgid "Include recent selections"
+#~ msgstr "Incluír as seleccións recentes"
+
+#~ msgid ""
+#~ "Provides current nautilus selection, using Kupfer's Nautilus Extension"
+#~ msgstr ""
+#~ "Proporciona a selección actual do nautilus usando a extensión para "
+#~ "nautilus de Kupfer"
+
+#~ msgid "Selected File \"%s\""
+#~ msgstr "Ficheiro seleccionado «%s»"
+
+#~ msgid "Selected Files"
+#~ msgstr "Ficheiros seleccionados"
+
+#~ msgid "Translate text with Google Translate"
+#~ msgstr "Traducir un texto con Google Translate"
+
+#~ msgid "Google Translate connection timed out"
+#~ msgstr "A conexión con Google Translate expirou"
+
+#~ msgid "Error connecting to Google Translate"
+#~ msgstr "Produciuse un erro na conexión con Google Translate"
+
+#~ msgid "Translate To..."
+#~ msgstr "Traducir a…"
+
+#~ msgid "Translate into %s"
+#~ msgstr "Traducir a %s"
+
+#~ msgid "Languages"
+#~ msgstr "Idiomas"
+
+#~ msgid "Show translated page in browser"
+#~ msgstr "Mostrar no navegador a páxina traducida"
+
+#~ msgid "Show Translation To..."
+#~ msgstr "Mostrar a tradución en..."
+
+#~ msgid "Show translation in browser"
+#~ msgstr "Mostrar a tradución no navegador"
+
+#~ msgid "Tracker 0.6"
+#~ msgstr "Tracker 0.6"
+
+#~ msgid "Tracker tags"
+#~ msgstr "Etiquetas de Tracker"
+
+#~ msgid "Tracker Tags"
+#~ msgstr "Etiquetas de Tracker"
+
+#~ msgid "Browse Tracker's tags"
+#~ msgstr "Examinar as etiquetas de Tracker"
+
+#~ msgid "Tag %s"
+#~ msgstr "Etiqueta %s"
+
+#~ msgid "Objects tagged %s with Tracker"
+#~ msgstr "Obxectos etiquetados %s con Tracker"
+
+#~ msgid "Add Tag..."
+#~ msgstr "Engadir unha etiqueta..."
+
+#~ msgid "Add tracker tag to file"
+#~ msgstr "Engadir unha etiqueta de tracker ao ficheiro"
+
+#~ msgid "Remove Tag..."
+#~ msgstr "Eliminar a etiqueta..."
+
+#~ msgid "Remove tracker tag from file"
+#~ msgstr "Eliminar a etiqueta de tracker do ficheiro"
 
 #~ msgid "<b>Directories</b>"
 #~ msgstr "<b>Directorios</b>"

--- a/po/nb.po
+++ b/po/nb.po
@@ -1,14 +1,14 @@
 # Norwegian bokmål translation of kupfer
 # Copyright (C) 2007--2010 Ulrik Sverdrup <ulrik.sverdrup@gmail.com>
 # This file is distributed under the same license as the Kupfer package.
-# Kjartan Maraas <kmaraas@gnome.org>, 2005-2010.
+# Kjartan Maraas <kmaraas@gnome.org>, 2005-2012.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: kupfer\n"
-"Report-Msgid-Bugs-To: http://bugs.launchpad.net/kupfer\n"
-"POT-Creation-Date: 2011-04-14 21:40+0200\n"
-"PO-Revision-Date: 2011-03-28 20:33+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2012-08-23 09:47+0200\n"
+"PO-Revision-Date: 2012-08-23 09:52+0200\n"
 "Last-Translator: Kjartan Maraas <kmaraas@gnome.org>\n"
 "Language-Team: Norwegian bokmål <i18n-nb@lister.ping.uio.no>\n"
 "Language: \n"
@@ -17,18 +17,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../auxdata/kupfer.desktop.in.h:1
-msgid "Application Launcher"
-msgstr "Programstarter"
-
-#: ../auxdata/kupfer.desktop.in.h:2
-msgid "Convenient command and access tool for applications and documents"
-msgstr "Praktiskt kommandoverktøy for programmer og dokumenter "
-
-#: ../auxdata/kupfer.desktop.in.h:3 ../kupfer/version.py:15
+#: ../auxdata/kupfer.desktop.in.h:1 ../kupfer/version.py:15
 #: ../kupfer/plugin/core/contents.py:91
 msgid "Kupfer"
 msgstr "Kupfer"
+
+#: ../auxdata/kupfer.desktop.in.h:2
+msgid "Application Launcher"
+msgstr "Programstarter"
+
+#: ../auxdata/kupfer.desktop.in.h:3
+msgid "Convenient command and access tool for applications and documents"
+msgstr "Praktiskt kommandoverktøy for programmer og dokumenter "
 
 #: ../auxdata/kupfer-exec.desktop.in.h:1
 msgid "Execute in Kupfer"
@@ -38,110 +38,135 @@ msgstr "Kjør i Kupfer"
 msgid "Saved Kupfer Command"
 msgstr ""
 
-#: ../data/preferences.ui.h:1
-msgid "<b>Browser Keyboard Shortcuts</b>"
-msgstr ""
-
-#: ../data/preferences.ui.h:2
-msgid "<b>Global Keyboard Shortcuts</b>"
-msgstr ""
-
-#: ../data/preferences.ui.h:3
-msgid "<b>Start</b>"
-msgstr "<b>Start</b>"
-
-#: ../data/preferences.ui.h:4 ../kupfer/obj/sources.py:150
-msgid "Catalog"
-msgstr "Katalog"
-
-#: ../data/preferences.ui.h:5
-msgid "Desktop Environment"
-msgstr ""
-
-#: ../data/preferences.ui.h:6
-msgid "Folders whose files are always available in the catalog."
-msgstr ""
-
-#: ../data/preferences.ui.h:7
-msgid "General"
-msgstr "Generelt"
-
-#: ../data/preferences.ui.h:8
-msgid "Icon set:"
-msgstr ""
-
-#: ../data/preferences.ui.h:9
-msgid "Inclusion in Top Level Searches"
-msgstr ""
-
-#: ../data/preferences.ui.h:10
-msgid "Indexed Folders"
-msgstr "Indekserte mapper"
-
-#: ../data/preferences.ui.h:11
-msgid "Keyboard"
-msgstr "Tastatur"
-
-#: ../data/preferences.ui.h:12 ../kupfer/plugin/core/contents.py:78
-msgid "Kupfer Preferences"
-msgstr "Brukervalg for Kupfer"
-
-#: ../data/preferences.ui.h:13
-msgid ""
-"Marked sources have their objects included in top level searches.\n"
-"An unmarked source's contents are only available by locating its subcatalog."
-msgstr ""
-
-#: ../data/preferences.ui.h:15
-msgid "Plugins"
-msgstr "Tillegg"
-
-#: ../data/preferences.ui.h:16 ../kupfer/ui/preferences.py:844
-msgid "Reset"
-msgstr "Nullstill"
-
-#: ../data/preferences.ui.h:17
-msgid "Show icon in notification area"
-msgstr "Vis ikon i statusfeltet"
-
-#: ../data/preferences.ui.h:18
-msgid "Start automatically on login"
-msgstr "Start automatisk ved innlogging"
-
-#: ../data/preferences.ui.h:19
-msgid "Terminal emulator:"
-msgstr "Terminalemulator:"
-
-#: ../data/preferences.ui.h:20
-msgid "Use single keystroke commands (Space, /, period, comma etc.)"
-msgstr ""
-
 #: ../data/credentials_dialog.ui.h:1
 msgid "User credentials"
 msgstr "Brukerinformasjon"
 
 #: ../data/credentials_dialog.ui.h:2
-msgid "_Change"
-msgstr "_Bruk"
+msgid "_User:"
+msgstr "Br_uker:"
 
 #: ../data/credentials_dialog.ui.h:3
 msgid "_Password:"
 msgstr "_Passord:"
 
 #: ../data/credentials_dialog.ui.h:4
-msgid "_User:"
-msgstr "Br_uker:"
+msgid "_Change"
+msgstr "_Bruk"
 
 #: ../data/getkey_dialog.ui.h:1
-msgid "Keybinding could not be bound"
-msgstr "Tastaturbinding kunne ikke bindes"
+msgid "Set Keyboard Shortcut"
+msgstr ""
 
 #: ../data/getkey_dialog.ui.h:2
 msgid "Please press desired key combination"
 msgstr ""
 
 #: ../data/getkey_dialog.ui.h:3
-msgid "Set Keyboard Shortcut"
+msgid "Keybinding could not be bound"
+msgstr "Tastaturbinding kunne ikke bindes"
+
+#: ../data/preferences.ui.h:1 ../kupfer/plugin/core/contents.py:78
+msgid "Kupfer Preferences"
+msgstr "Brukervalg for Kupfer"
+
+#: ../data/preferences.ui.h:2
+msgid "Start automatically on login"
+msgstr "Start automatisk ved innlogging"
+
+#: ../data/preferences.ui.h:3
+msgid "<b>Start</b>"
+msgstr "<b>Start</b>"
+
+#: ../data/preferences.ui.h:4
+msgid "Show icon in notification area"
+msgstr "Vis ikon i statusfeltet"
+
+#: ../data/preferences.ui.h:5
+msgid "Icon set:"
+msgstr ""
+
+#: ../data/preferences.ui.h:6
+msgid "Terminal emulator:"
+msgstr "Terminalemulator:"
+
+#: ../data/preferences.ui.h:7
+msgid "Desktop Environment"
+msgstr ""
+
+#: ../data/preferences.ui.h:8 ../kupfer/plugin/gmail/__init__.py:60
+msgid "General"
+msgstr "Generelt"
+
+#: ../data/preferences.ui.h:9
+msgid "<b>Global Keyboard Shortcuts</b>"
+msgstr ""
+
+#: ../data/preferences.ui.h:10 ../kupfer/ui/preferences.py:849
+msgid "Reset"
+msgstr "Nullstill"
+
+#: ../data/preferences.ui.h:11
+msgid "<b>Browser Keyboard Shortcuts</b>"
+msgstr ""
+
+#: ../data/preferences.ui.h:12
+msgid "Use single keystroke commands (Space, /, period, comma etc.)"
+msgstr ""
+
+#: ../data/preferences.ui.h:13
+msgid "Keyboard"
+msgstr "Tastatur"
+
+#: ../data/preferences.ui.h:14
+msgid "Plugins"
+msgstr "Tillegg"
+
+#: ../data/preferences.ui.h:15
+msgid "Inclusion in Top Level Searches"
+msgstr ""
+
+#: ../data/preferences.ui.h:16
+msgid ""
+"Marked sources have their objects included in top level searches.\n"
+"An unmarked source's contents are only available by locating its subcatalog."
+msgstr ""
+
+#: ../data/preferences.ui.h:18
+msgid "Indexed Folders"
+msgstr "Indekserte mapper"
+
+#: ../data/preferences.ui.h:19
+msgid "Folders whose files are always available in the catalog."
+msgstr ""
+
+#: ../data/preferences.ui.h:20 ../kupfer/obj/sources.py:157
+msgid "Catalog"
+msgstr "Katalog"
+
+#: ../kupfer/core/commandexec.py:239
+#, python-format
+msgid "Could not to carry out '%s'"
+msgstr "Kunne ikke utføre «%s»"
+
+#: ../kupfer/core/commandexec.py:268
+#, python-format
+msgid "\"%s\" produced a result"
+msgstr ""
+
+#: ../kupfer/core/execfile.py:30
+#, python-format
+msgid "No permission to run \"%s\" (not executable)"
+msgstr ""
+
+#: ../kupfer/core/execfile.py:47
+#, python-format
+msgid "Command in \"%s\" is not available"
+msgstr ""
+
+#: ../kupfer/keyrelay.py:62
+#, python-format
+msgid "Keyboard relay is active for display %s"
 msgstr ""
 
 #: ../kupfer/main.py:43
@@ -156,27 +181,29 @@ msgstr "liste tilgjenelige tillegg"
 msgid "enable debug info"
 msgstr "aktiver felsøkingsinformasjon"
 
-#: ../kupfer/main.py:46
-msgid "run keyboard shortcut relay service on this display"
+#. TRANS: --exec-helper=HELPER is an internal command
+#. TRANS: that executes a helper program that is part of kupfer
+#: ../kupfer/main.py:49
+msgid "run plugin helper"
 msgstr ""
 
-#: ../kupfer/main.py:49
+#: ../kupfer/main.py:52
 msgid "show usage help"
 msgstr "vis brukshjelp"
 
-#: ../kupfer/main.py:50
+#: ../kupfer/main.py:53
 msgid "show version information"
 msgstr "vis versjonsinformasjon"
 
-#: ../kupfer/main.py:56
+#: ../kupfer/main.py:59
 msgid "Usage: kupfer [ OPTIONS | FILE ... ]"
 msgstr "Bruk: kupfer [ VALG | FIL ... ]"
 
-#: ../kupfer/main.py:67
+#: ../kupfer/main.py:70
 msgid "Available plugins:"
 msgstr "Tilgjengelige tillegg:"
 
-#: ../kupfer/main.py:114
+#: ../kupfer/main.py:121
 #, python-format
 msgid ""
 "%(PROGRAM_NAME)s: %(SHORT_DESCRIPTION)s\n"
@@ -271,19 +298,19 @@ msgstr "Skriv for å søke i %s"
 msgid "No action"
 msgstr "Ingen handling"
 
-#: ../kupfer/ui/browser.py:1461
+#: ../kupfer/ui/browser.py:1513
 #, python-format
 msgid "Make \"%(action)s\" Default for \"%(object)s\""
 msgstr ""
 
 #. TRANS: Removing learned and/or configured bonus search score
-#: ../kupfer/ui/browser.py:1471
+#: ../kupfer/ui/browser.py:1523
 #, python-format
 msgid "Forget About \"%s\""
 msgstr ""
 
 #. TRANS: Names of global keyboard shortcuts
-#: ../kupfer/ui/browser.py:1903 ../kupfer/ui/preferences.py:58
+#: ../kupfer/ui/browser.py:1960 ../kupfer/ui/preferences.py:58
 msgid "Show Main Interface"
 msgstr ""
 
@@ -332,29 +359,39 @@ msgstr "Kilder"
 msgid "Actions"
 msgstr "Handlinger"
 
+#: ../kupfer/ui/preferences.py:575
+#, python-format
+msgid "Using encrypted password storage: %s"
+msgstr ""
+
+#: ../kupfer/ui/preferences.py:577
+#, python-format
+msgid "Using password storage: %s"
+msgstr ""
+
 #. TRANS: Plugin-specific configuration (header)
-#: ../kupfer/ui/preferences.py:589
+#: ../kupfer/ui/preferences.py:594
 msgid "Configuration"
 msgstr "Konfigurasjon"
 
-#: ../kupfer/ui/preferences.py:609
+#: ../kupfer/ui/preferences.py:614
 msgid "Set username and password"
 msgstr "Sett brukernavn og passord"
 
 #. TRANS: File Chooser Title
-#: ../kupfer/ui/preferences.py:663
+#: ../kupfer/ui/preferences.py:668
 msgid "Choose a Directory"
 msgstr "Velg en katalog"
 
-#: ../kupfer/ui/preferences.py:842
+#: ../kupfer/ui/preferences.py:847
 msgid "Reset all shortcuts to default values?"
 msgstr ""
 
-#: ../kupfer/ui/preferences.py:850 ../kupfer/plugin/custom_terminal.py:12
+#: ../kupfer/ui/preferences.py:855 ../kupfer/plugin/custom_terminal.py:12
 msgid "Command"
 msgstr "Kommando"
 
-#: ../kupfer/ui/preferences.py:851
+#: ../kupfer/ui/preferences.py:856
 msgid "Shortcut"
 msgstr ""
 
@@ -390,39 +427,13 @@ msgstr ""
 msgid "Could not find running Kupfer"
 msgstr ""
 
-#: ../kupfer/keyrelay.py:62
-#, python-format
-msgid "Keyboard relay is active for display %s"
-msgstr ""
-
-#: ../kupfer/core/commandexec.py:239
-#, python-format
-msgid "Could not to carry out '%s'"
-msgstr "Kunne ikke utføre «%s»"
-
-#: ../kupfer/core/commandexec.py:268
-#, python-format
-msgid "\"%s\" produced a result"
-msgstr ""
-
-#: ../kupfer/core/execfile.py:30
-#, python-format
-msgid "No permission to run \"%s\" (not executable)"
-msgstr ""
-
-#: ../kupfer/core/execfile.py:47
-#, python-format
-msgid "Command in \"%s\" is not available"
-msgstr ""
-
 #: ../kupfer/obj/base.py:457 ../kupfer/plugin/core/text.py:22
-#, fuzzy
 msgid "Text"
-msgstr "Vis tekst"
+msgstr "Tekst"
 
 #: ../kupfer/obj/compose.py:15
 msgid "Run after Delay..."
-msgstr "Kjør etter ventetid..."
+msgstr "Kjør etter ventetid …"
 
 #: ../kupfer/obj/compose.py:36
 msgid "Perform command after a specified time interval"
@@ -436,13 +447,48 @@ msgstr "Flere objekter"
 #, python-format
 msgid "%s object"
 msgid_plural "%s objects"
-msgstr[0] "et objekt"
+msgstr[0] "%s objekt"
 msgstr[1] "%s objekter"
 
-#: ../kupfer/obj/contacts.py:87 ../kupfer/plugin/pidgin.py:156
+#: ../kupfer/obj/contacts.py:129 ../kupfer/plugin/pidgin.py:156
 #, python-format
 msgid "[%(status)s] %(userid)s/%(service)s"
 msgstr ""
+
+#: ../kupfer/obj/contacts.py:131
+msgid "unknown"
+msgstr ""
+
+#: ../kupfer/obj/contacts.py:144
+#, fuzzy
+msgid "Aim"
+msgstr "Vim"
+
+#: ../kupfer/obj/contacts.py:151
+#, fuzzy
+msgid "Google Talk"
+msgstr "Google Picasa"
+
+#: ../kupfer/obj/contacts.py:159
+msgid "ICQ"
+msgstr ""
+
+#: ../kupfer/obj/contacts.py:166
+msgid "MSN"
+msgstr ""
+
+#: ../kupfer/obj/contacts.py:173
+msgid "QQ"
+msgstr ""
+
+#: ../kupfer/obj/contacts.py:180
+msgid "Yahoo"
+msgstr ""
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/obj/contacts.py:187 ../kupfer/plugin/skype.py:2
+msgid "Skype"
+msgstr "Skype"
 
 #: ../kupfer/obj/exceptions.py:19
 #, python-format
@@ -454,8 +500,8 @@ msgid "Can not be used with multiple objects"
 msgstr ""
 
 #: ../kupfer/obj/fileactions.py:30 ../kupfer/plugin/notes.py:89
-#: ../kupfer/plugin/gnome_terminal.py:36 ../kupfer/plugin/gtg.py:108
-#: ../kupfer/plugin/zim.py:107
+#: ../kupfer/plugin/gnome_terminal.py:36 ../kupfer/plugin/gtg.py:135
+#: ../kupfer/plugin/zim.py:176
 msgid "Open"
 msgstr "Åpne"
 
@@ -471,102 +517,102 @@ msgstr "Vennligst bruk «%s»"
 
 #: ../kupfer/obj/fileactions.py:45 ../kupfer/plugin/applications.py:109
 msgid "Set Default Application..."
-msgstr "Velg standardprogram"
+msgstr "Velg standardprogram …"
 
 #: ../kupfer/obj/fileactions.py:71
 msgid "Open with default application"
 msgstr "Åpne med standardprogram"
 
-#: ../kupfer/obj/fileactions.py:77
+#: ../kupfer/obj/fileactions.py:74
 msgid "Reveal"
 msgstr "Vis"
 
-#: ../kupfer/obj/fileactions.py:86
+#: ../kupfer/obj/fileactions.py:83
 msgid "Open parent folder"
 msgstr "Åpne foreldermappe"
 
-#: ../kupfer/obj/fileactions.py:92
+#: ../kupfer/obj/fileactions.py:89
 msgid "Open Terminal Here"
 msgstr "Åpne terminal her"
 
-#: ../kupfer/obj/fileactions.py:105
+#: ../kupfer/obj/fileactions.py:102
 msgid "Open this location in a terminal"
 msgstr "Åpne plassen i en terminal"
 
-#: ../kupfer/obj/fileactions.py:113
+#: ../kupfer/obj/fileactions.py:110
 msgid "Run in Terminal"
 msgstr "Kjør i terminal"
 
-#: ../kupfer/obj/fileactions.py:113
+#: ../kupfer/obj/fileactions.py:110
 msgid "Run (Execute)"
 msgstr "Kjør"
 
-#: ../kupfer/obj/fileactions.py:133
+#: ../kupfer/obj/fileactions.py:130
 msgid "Run this program in a Terminal"
 msgstr "Kjør dette programmet i en terminal"
 
-#: ../kupfer/obj/fileactions.py:135
+#: ../kupfer/obj/fileactions.py:132
 msgid "Run this program"
 msgstr "Kjør dette programmet"
 
-#: ../kupfer/obj/objects.py:248 ../kupfer/plugin/windows.py:105
-#: ../kupfer/plugin/windows.py:264
+#: ../kupfer/obj/objects.py:252 ../kupfer/plugin/windows.py:105
+#: ../kupfer/plugin/windows.py:264 ../kupfer/plugin/vim/plugin.py:172
 msgid "Go To"
 msgstr "Gå til"
 
-#: ../kupfer/obj/objects.py:274
+#: ../kupfer/obj/objects.py:278
 msgid "Open URL"
 msgstr "Åpne URL"
 
-#: ../kupfer/obj/objects.py:285
+#: ../kupfer/obj/objects.py:289
 msgid "Open URL with default viewer"
 msgstr ""
 
-#: ../kupfer/obj/objects.py:299
+#: ../kupfer/obj/objects.py:303
 msgid "Launch"
 msgstr "Start"
 
-#: ../kupfer/obj/objects.py:312
+#: ../kupfer/obj/objects.py:316
 msgid "Show application window"
 msgstr "Vis programvindu"
 
-#: ../kupfer/obj/objects.py:313
+#: ../kupfer/obj/objects.py:317
 msgid "Launch application"
 msgstr "Start program"
 
-#: ../kupfer/obj/objects.py:324
+#: ../kupfer/obj/objects.py:328
 msgid "Launch Again"
 msgstr "Start igjen"
 
-#: ../kupfer/obj/objects.py:331
+#: ../kupfer/obj/objects.py:335
 msgid "Launch another instance of this application"
 msgstr ""
 
-#: ../kupfer/obj/objects.py:337 ../kupfer/plugin/windows.py:37
+#: ../kupfer/obj/objects.py:341 ../kupfer/plugin/windows.py:37
 msgid "Close"
 msgstr "Lukk"
 
-#: ../kupfer/obj/objects.py:345
+#: ../kupfer/obj/objects.py:349
 #, fuzzy
 msgid "Attempt to close all application windows"
 msgstr "Vis programvindu"
 
 #. TRANS: 'Run' as in Perform a (saved) command
-#: ../kupfer/obj/objects.py:392
+#: ../kupfer/obj/objects.py:398
 msgid "Run"
 msgstr "Kjør"
 
-#: ../kupfer/obj/objects.py:402
+#: ../kupfer/obj/objects.py:408
 msgid "Perform command"
 msgstr "Utfør kommando"
 
-#: ../kupfer/obj/objects.py:416
+#: ../kupfer/obj/objects.py:421
 msgid "(Empty Text)"
 msgstr "(Tom tekst)"
 
 #. TRANS: This is description for a TextLeaf, a free-text search
 #. TRANS: The plural parameter is the number of lines %(num)d
-#: ../kupfer/obj/objects.py:432
+#: ../kupfer/obj/objects.py:451
 #, python-format
 msgid "\"%(text)s\""
 msgid_plural "(%(num)d lines) \"%(text)s\""
@@ -584,24 +630,24 @@ msgstr ""
 msgid "Recursive source of %(dir)s, (%(levels)d levels)"
 msgstr ""
 
-#: ../kupfer/obj/sources.py:103
+#: ../kupfer/obj/sources.py:108
 #, python-format
 msgid "Directory source %s"
 msgstr ""
 
-#: ../kupfer/obj/sources.py:113
+#: ../kupfer/obj/sources.py:119
 msgid "Home Folder"
 msgstr "Hjemmemappe"
 
-#: ../kupfer/obj/sources.py:124
+#: ../kupfer/obj/sources.py:130
 msgid "Catalog Index"
 msgstr "Katalogindeks"
 
-#: ../kupfer/obj/sources.py:139
+#: ../kupfer/obj/sources.py:145
 msgid "An index of all available sources"
 msgstr "En indeks med tilgjengelige kilder"
 
-#: ../kupfer/obj/sources.py:170
+#: ../kupfer/obj/sources.py:177
 msgid "Root catalog"
 msgstr "Rotkatalog"
 
@@ -619,111 +665,29 @@ msgstr "Tillegg %s er ikke konfigurert"
 msgid "Invalid user credentials for %s"
 msgstr "Ugyldig påloggingsinformasjon for %s"
 
-#: ../kupfer/plugin/core/alternatives.py:7
-msgid "GTK+"
-msgstr "GTK+"
+#: ../kupfer/plugin/applications.py:2 ../kupfer/plugin/applications.py:38
+msgid "Applications"
+msgstr "Programmer"
 
-#: ../kupfer/plugin/core/alternatives.py:13
-msgid "GNOME Terminal"
-msgstr "GNOME-terminal"
+#: ../kupfer/plugin/applications.py:8 ../kupfer/plugin/applications.py:74
+msgid "All applications and preferences"
+msgstr "Alle programmer og brukervalg"
 
-#: ../kupfer/plugin/core/alternatives.py:22
-msgid "XFCE Terminal"
-msgstr "XFCE-terminal"
-
-#: ../kupfer/plugin/core/alternatives.py:31
-msgid "LXTerminal"
-msgstr "LXTerminal"
-
-#: ../kupfer/plugin/core/alternatives.py:40
-msgid "X Terminal"
-msgstr "X-terminal"
-
-#: ../kupfer/plugin/core/alternatives.py:49
-msgid "Urxvt"
-msgstr "Urxvt"
-
-#: ../kupfer/plugin/core/commands.py:13 ../kupfer/plugin/core/commands.py:32
-msgid "Save As..."
-msgstr "Lagre som..."
-
-#: ../kupfer/plugin/core/contents.py:41
-msgid "Quit"
-msgstr "Avslutt"
-
-#: ../kupfer/plugin/core/contents.py:46
-msgid "Quit Kupfer"
-msgstr "Avslutt Kupfer"
-
-#: ../kupfer/plugin/core/contents.py:52
-msgid "About Kupfer"
-msgstr "Om Kupfer"
-
-#: ../kupfer/plugin/core/contents.py:59
-msgid "Show information about Kupfer authors and license"
-msgstr "Vis informasjon om Kupfers utviklere og lisens"
-
-#: ../kupfer/plugin/core/contents.py:65
-msgid "Kupfer Help"
-msgstr "Hjelp med Kupfer"
-
-#: ../kupfer/plugin/core/contents.py:72
-msgid "Get help with Kupfer"
-msgstr "Få hjelp med Kupfer"
-
-#: ../kupfer/plugin/core/contents.py:85
-msgid "Show preferences window for Kupfer"
-msgstr "Vis Kupfers brukervalg"
-
-#: ../kupfer/plugin/core/__init__.py:65
-msgid "Search Contents"
-msgstr "Søk i innhold"
-
-#: ../kupfer/plugin/core/__init__.py:83
-msgid "Search inside this catalog"
-msgstr "Søk i denne katalogen"
-
-#: ../kupfer/plugin/core/__init__.py:91
-msgid "Copy"
-msgstr "Kopier"
-
-#: ../kupfer/plugin/core/__init__.py:106
-msgid "Copy to clipboard"
-msgstr "Kopier til utklippstavlen"
-
-#: ../kupfer/plugin/core/__init__.py:128
-msgid "Rescan"
-msgstr "Søk på nytt"
-
-#: ../kupfer/plugin/core/__init__.py:143
-msgid "Force reindex of this source"
+#: ../kupfer/plugin/applications.py:23
+msgid "Applications for Desktop Environment"
 msgstr ""
 
-#: ../kupfer/plugin/core/selection.py:8 ../kupfer/plugin/core/selection.py:36
-msgid "Selected Text"
-msgstr "Markert tekst"
+#: ../kupfer/plugin/applications.py:83
+msgid "Open With..."
+msgstr "Åpne med …"
 
-#: ../kupfer/plugin/core/selection.py:23
-#, python-format
-msgid "Selected Text \"%s\""
-msgstr "Markert tekst «%s»"
+#: ../kupfer/plugin/applications.py:105
+msgid "Open with any application"
+msgstr "Åpne med valgfritt program"
 
-#: ../kupfer/plugin/core/internal.py:13
-msgid "Last Command"
-msgstr "Siste kommando"
-
-#: ../kupfer/plugin/core/internal.py:24
-msgid "Internal Kupfer Objects"
-msgstr "Interne Kupfer-objekter"
-
-#: ../kupfer/plugin/core/internal.py:46 ../kupfer/plugin/core/internal.py:48
-msgid "Last Result"
-msgstr "Siste resultat"
-
-#: ../kupfer/plugin/core/internal.py:66
-#, fuzzy
-msgid "Command Results"
-msgstr "Kommandolinje"
+#: ../kupfer/plugin/applications.py:124
+msgid "Set default application to open this file type"
+msgstr ""
 
 #: ../kupfer/plugin/archivemanager.py:1
 msgid "Archive Manager"
@@ -757,36 +721,12 @@ msgstr ""
 
 #: ../kupfer/plugin/archivemanager.py:92
 msgid "Create Archive In..."
-msgstr "Lag arkiv i..."
+msgstr "Lag arkiv i …"
 
 #. TRANS: Default filename (no extension) for 'Create Archive In...'
 #: ../kupfer/plugin/archivemanager.py:115
 msgid "Archive"
 msgstr "Arkiv"
-
-#: ../kupfer/plugin/applications.py:2 ../kupfer/plugin/applications.py:38
-msgid "Applications"
-msgstr "Programmer"
-
-#: ../kupfer/plugin/applications.py:8 ../kupfer/plugin/applications.py:74
-msgid "All applications and preferences"
-msgstr "Alle programmer og brukervalg"
-
-#: ../kupfer/plugin/applications.py:23
-msgid "Applications for Desktop Environment"
-msgstr ""
-
-#: ../kupfer/plugin/applications.py:83
-msgid "Open With..."
-msgstr "Åpne med..."
-
-#: ../kupfer/plugin/applications.py:105
-msgid "Open with any application"
-msgstr "Åpne med valgfritt program"
-
-#: ../kupfer/plugin/applications.py:124
-msgid "Set default application to open this file type"
-msgstr ""
 
 #: ../kupfer/plugin/calculator.py:2 ../kupfer/plugin/calculator.py:69
 msgid "Calculator"
@@ -800,39 +740,59 @@ msgstr ""
 msgid "Calculate"
 msgstr "Beregn"
 
-#: ../kupfer/plugin/clipboard.py:1 ../kupfer/plugin/clipboard.py:71
+#: ../kupfer/plugin/clipboard.py:1 ../kupfer/plugin/clipboard.py:112
 msgid "Clipboards"
 msgstr "Utklippstavler"
 
-#: ../kupfer/plugin/clipboard.py:4 ../kupfer/plugin/clipboard.py:111
-msgid "Recent clipboards"
-msgstr "Nylige utklippstavler"
+#: ../kupfer/plugin/clipboard.py:4
+msgid "Recent clipboards and clipboard proxy objects"
+msgstr ""
 
-#: ../kupfer/plugin/clipboard.py:20
-msgid "Number of recent clipboards"
+#: ../kupfer/plugin/clipboard.py:24
+#, fuzzy
+msgid "Number of recent clipboards to remember"
 msgstr "Antall nylige utklippstavler"
 
-#: ../kupfer/plugin/clipboard.py:26
-msgid "Include recent selections"
-msgstr "Inkluder nylige markeringer"
+#: ../kupfer/plugin/clipboard.py:30
+msgid "Include selected text in clipboard history"
+msgstr ""
 
-#: ../kupfer/plugin/clipboard.py:32
+#: ../kupfer/plugin/clipboard.py:36
 #, fuzzy
-msgid "Copy selection to primary clipboard"
+msgid "Copy selected text to primary clipboard"
 msgstr "Kopier til utklippstavlen"
 
-#: ../kupfer/plugin/clipboard.py:44
+#: ../kupfer/plugin/clipboard.py:47
+msgid "Selected Text"
+msgstr "Markert tekst"
+
+#: ../kupfer/plugin/clipboard.py:57
 #, python-format
 msgid "Clipboard \"%(desc)s\""
 msgid_plural "Clipboard with %(num)d lines \"%(desc)s\""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../kupfer/plugin/clipboard.py:51
+#: ../kupfer/plugin/clipboard.py:64
+#, fuzzy
+msgid "Clipboard Text"
+msgstr "Utklippstavler"
+
+#: ../kupfer/plugin/clipboard.py:74
+#, fuzzy
+msgid "Clipboard File"
+msgstr "Utklippstavler"
+
+#: ../kupfer/plugin/clipboard.py:84
+#, fuzzy
+msgid "Clipboard Files"
+msgstr "Utklippstavler"
+
+#: ../kupfer/plugin/clipboard.py:92
 msgid "Clear"
 msgstr "Tøm"
 
-#: ../kupfer/plugin/clipboard.py:63
+#: ../kupfer/plugin/clipboard.py:104
 #, fuzzy
 msgid "Remove all recent clipboards"
 msgstr "Antall nylige utklippstavler"
@@ -888,6 +848,107 @@ msgstr ""
 #, fuzzy
 msgid "Run command-line programs"
 msgstr "Kjør dette programmet"
+
+#: ../kupfer/plugin/core/alternatives.py:7
+msgid "GTK+"
+msgstr "GTK+"
+
+#: ../kupfer/plugin/core/alternatives.py:13
+msgid "GNOME Terminal"
+msgstr "GNOME-terminal"
+
+#: ../kupfer/plugin/core/alternatives.py:22
+msgid "XFCE Terminal"
+msgstr "XFCE-terminal"
+
+#: ../kupfer/plugin/core/alternatives.py:31
+msgid "LXTerminal"
+msgstr "LXTerminal"
+
+#: ../kupfer/plugin/core/alternatives.py:40
+msgid "X Terminal"
+msgstr "X-terminal"
+
+#: ../kupfer/plugin/core/alternatives.py:49
+msgid "Urxvt"
+msgstr "Urxvt"
+
+#: ../kupfer/plugin/core/alternatives.py:58
+msgid "Konsole"
+msgstr ""
+
+#: ../kupfer/plugin/core/commands.py:13 ../kupfer/plugin/core/commands.py:32
+msgid "Save As..."
+msgstr "Lagre som …"
+
+#: ../kupfer/plugin/core/contents.py:41
+msgid "Quit"
+msgstr "Avslutt"
+
+#: ../kupfer/plugin/core/contents.py:46
+msgid "Quit Kupfer"
+msgstr "Avslutt Kupfer"
+
+#: ../kupfer/plugin/core/contents.py:52
+msgid "About Kupfer"
+msgstr "Om Kupfer"
+
+#: ../kupfer/plugin/core/contents.py:59
+msgid "Show information about Kupfer authors and license"
+msgstr "Vis informasjon om Kupfers utviklere og lisens"
+
+#: ../kupfer/plugin/core/contents.py:65
+msgid "Kupfer Help"
+msgstr "Hjelp med Kupfer"
+
+#: ../kupfer/plugin/core/contents.py:72
+msgid "Get help with Kupfer"
+msgstr "Få hjelp med Kupfer"
+
+#: ../kupfer/plugin/core/contents.py:85
+msgid "Show preferences window for Kupfer"
+msgstr "Vis Kupfers brukervalg"
+
+#: ../kupfer/plugin/core/__init__.py:64
+msgid "Search Contents"
+msgstr "Søk i innhold"
+
+#: ../kupfer/plugin/core/__init__.py:82
+msgid "Search inside this catalog"
+msgstr "Søk i denne katalogen"
+
+#: ../kupfer/plugin/core/__init__.py:90
+msgid "Copy"
+msgstr "Kopier"
+
+#: ../kupfer/plugin/core/__init__.py:105
+msgid "Copy to clipboard"
+msgstr "Kopier til utklippstavlen"
+
+#: ../kupfer/plugin/core/__init__.py:127
+msgid "Rescan"
+msgstr "Søk på nytt"
+
+#: ../kupfer/plugin/core/__init__.py:142
+msgid "Force reindex of this source"
+msgstr ""
+
+#: ../kupfer/plugin/core/internal.py:13
+msgid "Last Command"
+msgstr "Siste kommando"
+
+#: ../kupfer/plugin/core/internal.py:24
+msgid "Internal Kupfer Objects"
+msgstr "Interne Kupfer-objekter"
+
+#: ../kupfer/plugin/core/internal.py:46 ../kupfer/plugin/core/internal.py:48
+msgid "Last Result"
+msgstr "Siste resultat"
+
+#: ../kupfer/plugin/core/internal.py:66
+#, fuzzy
+msgid "Command Results"
+msgstr "Kommandolinje"
 
 #: ../kupfer/plugin/dictionary.py:1 ../kupfer/plugin/dictionary.py:21
 msgid "Dictionary"
@@ -989,31 +1050,31 @@ msgid "More file actions"
 msgstr "Vis tidligere brukte handlinger"
 
 #: ../kupfer/plugin/fileactions.py:40 ../kupfer/plugin/windows.py:122
-#: ../kupfer/plugin/thunar.py:210
+#: ../kupfer/plugin/thunar.py:211
 msgid "Move To..."
-msgstr "Flytt til..."
+msgstr "Flytt til …"
 
-#: ../kupfer/plugin/fileactions.py:67 ../kupfer/plugin/thunar.py:252
+#: ../kupfer/plugin/fileactions.py:67 ../kupfer/plugin/thunar.py:253
 msgid "Move file to new location"
 msgstr ""
 
 #: ../kupfer/plugin/fileactions.py:80 ../kupfer/plugin/fileactions.py:103
 msgid "Rename To..."
-msgstr "Endre navn til..."
+msgstr "Endre navn til …"
 
-#: ../kupfer/plugin/fileactions.py:145 ../kupfer/plugin/thunar.py:165
+#: ../kupfer/plugin/fileactions.py:145 ../kupfer/plugin/thunar.py:166
 msgid "Copy To..."
-msgstr "Kopier til..."
+msgstr "Kopier til …"
 
-#: ../kupfer/plugin/fileactions.py:186 ../kupfer/plugin/thunar.py:206
+#: ../kupfer/plugin/fileactions.py:186 ../kupfer/plugin/thunar.py:207
 msgid "Copy file to a chosen location"
 msgstr ""
 
-#: ../kupfer/plugin/firefox.py:4 ../kupfer/plugin/firefox.py:36
+#: ../kupfer/plugin/firefox.py:4 ../kupfer/plugin/firefox.py:61
 msgid "Firefox Bookmarks"
 msgstr "Firefox-bokmerker"
 
-#: ../kupfer/plugin/firefox.py:6 ../kupfer/plugin/firefox.py:120
+#: ../kupfer/plugin/firefox.py:6 ../kupfer/plugin/firefox.py:147
 msgid "Index of Firefox bookmarks"
 msgstr ""
 
@@ -1021,23 +1082,17 @@ msgstr ""
 msgid "Include visited sites"
 msgstr ""
 
-#: ../kupfer/plugin/nautilusselection.py:1
-#: ../kupfer/plugin/nautilusselection.py:46
-msgid "Selected File"
-msgstr "Markert fil"
+#: ../kupfer/plugin/firefox.py:44
+#, fuzzy
+msgid "Firefox tag"
+msgstr "Firefox-bokmerker"
 
-#: ../kupfer/plugin/nautilusselection.py:3
-msgid "Provides current nautilus selection, using Kupfer's Nautilus Extension"
+#. TRANS: Multihead refers to support for multiple computer displays
+#. TRANS: In this case, it only concerns the special configuration
+#. TRANS: with multiple X "screens"
+#: ../kupfer/plugin/multihead.py:4
+msgid "Multihead Support"
 msgstr ""
-
-#: ../kupfer/plugin/nautilusselection.py:25
-#, python-format
-msgid "Selected File \"%s\""
-msgstr "Markert fil «%s»"
-
-#: ../kupfer/plugin/nautilusselection.py:34
-msgid "Selected Files"
-msgstr "Markerte filer"
 
 #: ../kupfer/plugin/notes.py:6 ../kupfer/plugin/notes.py:178
 #: ../kupfer/plugin/notes.py:230
@@ -1229,7 +1284,7 @@ msgstr ""
 
 #: ../kupfer/plugin/session_support.py:31
 msgid "Log Out..."
-msgstr "Logg ut..."
+msgstr "Logg ut …"
 
 #: ../kupfer/plugin/session_support.py:34
 msgid "Log out or change user"
@@ -1237,7 +1292,7 @@ msgstr ""
 
 #: ../kupfer/plugin/session_support.py:41
 msgid "Shut Down..."
-msgstr "Slå av..."
+msgstr "Slå av …"
 
 #: ../kupfer/plugin/session_support.py:44
 msgid "Shut down, restart or suspend computer"
@@ -1266,7 +1321,7 @@ msgid "Show Text"
 msgstr "Vis tekst"
 
 #: ../kupfer/plugin/show_text.py:7 ../kupfer/plugin/show_text.py:31
-#: ../kupfer/plugin/show_text.py:52
+#: ../kupfer/plugin/show_text.py:58
 msgid "Display text in a window"
 msgstr "Vis tekst i et vindu"
 
@@ -1274,7 +1329,7 @@ msgstr "Vis tekst i et vindu"
 msgid "Large Type"
 msgstr "Vis med stor tekst"
 
-#: ../kupfer/plugin/show_text.py:60
+#: ../kupfer/plugin/show_text.py:66
 msgid "Show Notification"
 msgstr "Vis varsling"
 
@@ -1664,7 +1719,7 @@ msgid "Claws Mail Contacts and Actions"
 msgstr ""
 
 #: ../kupfer/plugin/clawsmail.py:26 ../kupfer/plugin/evolution.py:24
-#: ../kupfer/plugin/operamail.py:26 ../kupfer/plugin/thunderbird.py:25
+#: ../kupfer/plugin/operamail.py:26 ../kupfer/plugin/thunderbird.py:31
 msgid "Compose New Email"
 msgstr ""
 
@@ -1682,7 +1737,7 @@ msgstr ""
 
 #: ../kupfer/plugin/clawsmail.py:56 ../kupfer/plugin/defaultmail.py:18
 #: ../kupfer/plugin/evolution.py:40 ../kupfer/plugin/operamail.py:41
-#: ../kupfer/plugin/thunderbird.py:41
+#: ../kupfer/plugin/thunderbird.py:47
 msgid "Compose Email"
 msgstr ""
 
@@ -1747,6 +1802,15 @@ msgstr "Devhelp"
 msgid "Search in Devhelp"
 msgstr "Søk i Devhelp"
 
+#: ../kupfer/plugin/duckduckgo.py:5 ../kupfer/plugin/duckduckgo.py:19
+#, fuzzy
+msgid "DuckDuckGo Search"
+msgstr "Google søk"
+
+#: ../kupfer/plugin/duckduckgo.py:8 ../kupfer/plugin/duckduckgo.py:30
+msgid "Search the web securely with DuckDuckGo"
+msgstr ""
+
 #. -*- coding: UTF-8 -*-
 #. vim: set noexpandtab ts=8 sw=8:
 #: ../kupfer/plugin/empathy.py:3
@@ -1757,55 +1821,55 @@ msgstr "Empathy"
 msgid "Access to Empathy Contacts"
 msgstr ""
 
-#: ../kupfer/plugin/empathy.py:25 ../kupfer/plugin/pidgin.py:29
+#: ../kupfer/plugin/empathy.py:26 ../kupfer/plugin/pidgin.py:29
 msgid "Show offline contacts"
 msgstr "Vis frakoblede kontakter"
 
-#: ../kupfer/plugin/empathy.py:34 ../kupfer/plugin/gajim.py:26
+#: ../kupfer/plugin/empathy.py:35 ../kupfer/plugin/gajim.py:26
 #: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:30
 msgid "Available"
 msgstr "Tilgjengelig"
 
-#: ../kupfer/plugin/empathy.py:35 ../kupfer/plugin/gajim.py:28
+#: ../kupfer/plugin/empathy.py:36 ../kupfer/plugin/gajim.py:28
 #: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:32
 msgid "Away"
 msgstr "Borte"
 
-#: ../kupfer/plugin/empathy.py:36 ../kupfer/plugin/gajim.py:30
+#: ../kupfer/plugin/empathy.py:37 ../kupfer/plugin/gajim.py:30
 #: ../kupfer/plugin/skype.py:34
 msgid "Busy"
 msgstr "Opptatt"
 
-#: ../kupfer/plugin/empathy.py:37 ../kupfer/plugin/gajim.py:29
+#: ../kupfer/plugin/empathy.py:38 ../kupfer/plugin/gajim.py:29
 #: ../kupfer/plugin/skype.py:33
 msgid "Not Available"
 msgstr "Ikke tilgjengelig"
 
-#: ../kupfer/plugin/empathy.py:38 ../kupfer/plugin/gajim.py:31
+#: ../kupfer/plugin/empathy.py:39 ../kupfer/plugin/gajim.py:31
 #: ../kupfer/plugin/skype.py:35
 msgid "Invisible"
 msgstr "Usynlig"
 
-#: ../kupfer/plugin/empathy.py:39 ../kupfer/plugin/gajim.py:32
+#: ../kupfer/plugin/empathy.py:40 ../kupfer/plugin/gajim.py:32
 #: ../kupfer/plugin/skype.py:36
 msgid "Offline"
 msgstr "Frakoblet"
 
-#: ../kupfer/plugin/empathy.py:96 ../kupfer/plugin/gajim.py:90
-#: ../kupfer/plugin/pidgin.py:97 ../kupfer/plugin/skype.py:204
+#: ../kupfer/plugin/empathy.py:100 ../kupfer/plugin/gajim.py:93
+#: ../kupfer/plugin/pidgin.py:97 ../kupfer/plugin/skype.py:197
 msgid "Open Chat"
 msgstr "Åpne prat"
 
-#: ../kupfer/plugin/empathy.py:129 ../kupfer/plugin/gajim.py:118
-#: ../kupfer/plugin/skype.py:250
+#: ../kupfer/plugin/empathy.py:133 ../kupfer/plugin/gajim.py:121
+#: ../kupfer/plugin/skype.py:243
 msgid "Change Global Status To..."
 msgstr ""
 
-#: ../kupfer/plugin/empathy.py:171
+#: ../kupfer/plugin/empathy.py:175
 msgid "Empathy Contacts"
 msgstr "Empathy-kontakter"
 
-#: ../kupfer/plugin/empathy.py:237
+#: ../kupfer/plugin/empathy.py:249
 msgid "Empathy Account Status"
 msgstr ""
 
@@ -1863,17 +1927,120 @@ msgstr ""
 msgid "Free for Chat"
 msgstr "Ledig for prat"
 
-#: ../kupfer/plugin/gajim.py:146
+#: ../kupfer/plugin/gajim.py:149
 msgid "Gajim Contacts"
 msgstr "Gajim-kontakter"
 
-#: ../kupfer/plugin/gajim.py:210
+#: ../kupfer/plugin/gajim.py:213
 msgid "Gajim Account Status"
 msgstr ""
 
 #. TRANS: "Glob" is the matching files like a shell with "*.py" etc.
 #: ../kupfer/plugin/glob.py:3 ../kupfer/plugin/glob.py:17
 msgid "Glob"
+msgstr ""
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/gmail/__init__.py:2 ../kupfer/plugin/gmail/__init__.py:234
+msgid "Gmail"
+msgstr "Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:5
+msgid "Load contacts and compose new email in Gmail"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:33
+msgid "Load contacts' pictures"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:39
+#, fuzzy
+msgid "Load additional information"
+msgstr "vis versjonsinformasjon"
+
+#: ../kupfer/plugin/gmail/__init__.py:50
+msgid "Work email"
+msgstr "E-post på arbeid"
+
+#: ../kupfer/plugin/gmail/__init__.py:51
+msgid "Home email"
+msgstr "E-post hjemme"
+
+#: ../kupfer/plugin/gmail/__init__.py:52
+msgid "Other email"
+msgstr "Annen e-post"
+
+#: ../kupfer/plugin/gmail/__init__.py:54
+msgid "Work address"
+msgstr "Adresse på arbeid"
+
+#: ../kupfer/plugin/gmail/__init__.py:55
+msgid "Home address"
+msgstr "Hjemmeadresse"
+
+#: ../kupfer/plugin/gmail/__init__.py:56
+msgid "Other address"
+msgstr "Annen adresse"
+
+#: ../kupfer/plugin/gmail/__init__.py:58
+msgid "Car phone"
+msgstr "Biltelefon"
+
+#: ../kupfer/plugin/gmail/__init__.py:59
+msgid "Fax"
+msgstr "Faks"
+
+#: ../kupfer/plugin/gmail/__init__.py:61
+msgid "Home phone"
+msgstr "Hjemmetelefon"
+
+#: ../kupfer/plugin/gmail/__init__.py:62
+msgid "Home fax"
+msgstr "Faks hjemme"
+
+#: ../kupfer/plugin/gmail/__init__.py:63
+msgid "Internal phone"
+msgstr "Intern telefon"
+
+#: ../kupfer/plugin/gmail/__init__.py:64
+msgid "Mobile"
+msgstr "Mobil"
+
+#: ../kupfer/plugin/gmail/__init__.py:65
+msgid "Other"
+msgstr "Annet"
+
+#: ../kupfer/plugin/gmail/__init__.py:66
+msgid "VOIP"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:67
+#, fuzzy
+msgid "Work phone"
+msgstr "Arbeidsområder"
+
+#: ../kupfer/plugin/gmail/__init__.py:68
+msgid "Work fax"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:93
+msgid "Compose Email in Gmail"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:117
+msgid "Open web browser and compose new email in Gmail"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:123
+msgid "Edit Contact in Gmail"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:133
+msgid "Open web browser and edit contact in Gmail"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:263
+msgid "Contacts from Google services (Gmail)"
 msgstr ""
 
 #: ../kupfer/plugin/gnome_terminal.py:1 ../kupfer/plugin/gnome_terminal.py:56
@@ -1883,31 +2050,6 @@ msgstr "Åpne terminal her"
 
 #: ../kupfer/plugin/gnome_terminal.py:3
 msgid "Launch GNOME Terminal profiles"
-msgstr ""
-
-#. -*- coding: UTF-8 -*-
-#: ../kupfer/plugin/gmail/__init__.py:2 ../kupfer/plugin/gmail/__init__.py:144
-msgid "Gmail"
-msgstr "Gmail"
-
-#: ../kupfer/plugin/gmail/__init__.py:5
-msgid "Load contacts and compose new email in Gmail"
-msgstr ""
-
-#: ../kupfer/plugin/gmail/__init__.py:32
-msgid "Load contacts' pictures"
-msgstr ""
-
-#: ../kupfer/plugin/gmail/__init__.py:51
-msgid "Compose Email in GMail"
-msgstr ""
-
-#: ../kupfer/plugin/gmail/__init__.py:74
-msgid "Open web browser and compose new email in GMail"
-msgstr ""
-
-#: ../kupfer/plugin/gmail/__init__.py:177
-msgid "Contacts from Google services (Gmail)"
 msgstr ""
 
 #. -*- coding: UTF-8 -*-
@@ -1995,7 +2137,6 @@ msgid "Search Google with results shown directly"
 msgstr ""
 
 #: ../kupfer/plugin/google_search.py:58 ../kupfer/plugin/locate.py:46
-#: ../kupfer/plugin/tracker.py:72 ../kupfer/plugin/tracker.py:113
 #: ../kupfer/plugin/tracker1.py:168 ../kupfer/plugin/tracker1.py:179
 #, python-format
 msgid "Results for \"%s\""
@@ -2011,49 +2152,6 @@ msgstr ""
 msgid "%s total found"
 msgstr ""
 
-#: ../kupfer/plugin/google_translate.py:6
-msgid "Google Translate"
-msgstr ""
-
-#: ../kupfer/plugin/google_translate.py:8
-#: ../kupfer/plugin/google_translate.py:153
-msgid "Translate text with Google Translate"
-msgstr ""
-
-#: ../kupfer/plugin/google_translate.py:83
-msgid "Google Translate connection timed out"
-msgstr ""
-
-#: ../kupfer/plugin/google_translate.py:86
-msgid "Error connecting to Google Translate"
-msgstr ""
-
-#: ../kupfer/plugin/google_translate.py:136
-#: ../kupfer/plugin/google_translate.py:223
-msgid "Translate To..."
-msgstr "Oversett til..."
-
-#: ../kupfer/plugin/google_translate.py:179
-#, python-format
-msgid "Translate into %s"
-msgstr "Oversett til %s"
-
-#: ../kupfer/plugin/google_translate.py:203
-msgid "Languages"
-msgstr "Språk"
-
-#: ../kupfer/plugin/google_translate.py:238
-msgid "Show translated page in browser"
-msgstr ""
-
-#: ../kupfer/plugin/google_translate.py:255
-msgid "Show Translation To..."
-msgstr ""
-
-#: ../kupfer/plugin/google_translate.py:271
-msgid "Show translation in browser"
-msgstr ""
-
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/gtg.py:2
 msgid "Getting Things GNOME"
@@ -2063,54 +2161,54 @@ msgstr ""
 msgid "Browse and create new tasks in GTG"
 msgstr ""
 
-#: ../kupfer/plugin/gtg.py:87
+#: ../kupfer/plugin/gtg.py:114
 #, python-format
 msgid "due: %s"
 msgstr ""
 
-#: ../kupfer/plugin/gtg.py:89
+#: ../kupfer/plugin/gtg.py:116
 #, python-format
 msgid "start: %s"
 msgstr ""
 
-#: ../kupfer/plugin/gtg.py:91
+#: ../kupfer/plugin/gtg.py:118
 #, python-format
 msgid "tags: %s"
 msgstr ""
 
-#: ../kupfer/plugin/gtg.py:118
+#: ../kupfer/plugin/gtg.py:148
 msgid "Open task in Getting Things GNOME!"
 msgstr ""
 
-#: ../kupfer/plugin/gtg.py:125
+#: ../kupfer/plugin/gtg.py:155
 msgid "Delete"
 msgstr ""
 
-#: ../kupfer/plugin/gtg.py:135
+#: ../kupfer/plugin/gtg.py:168
 msgid "Permanently remove this task"
 msgstr ""
 
-#: ../kupfer/plugin/gtg.py:140
+#: ../kupfer/plugin/gtg.py:173
 msgid "Mark Done"
 msgstr ""
 
-#: ../kupfer/plugin/gtg.py:149
+#: ../kupfer/plugin/gtg.py:182
 msgid "Mark this task as done"
 msgstr "Merk denne oppgaven som utført"
 
-#: ../kupfer/plugin/gtg.py:154
+#: ../kupfer/plugin/gtg.py:187
 msgid "Dismiss"
 msgstr ""
 
-#: ../kupfer/plugin/gtg.py:163
+#: ../kupfer/plugin/gtg.py:196
 msgid "Mark this task as not to be done anymore"
 msgstr ""
 
-#: ../kupfer/plugin/gtg.py:168
+#: ../kupfer/plugin/gtg.py:201
 msgid "Create Task"
 msgstr "Lag oppgave"
 
-#: ../kupfer/plugin/gtg.py:182
+#: ../kupfer/plugin/gtg.py:218
 msgid "Create new task in Getting Things GNOME"
 msgstr ""
 
@@ -2161,7 +2259,7 @@ msgstr "Send melding til en Gwibber-konto"
 
 #: ../kupfer/plugin/gwibber.py:243 ../kupfer/plugin/pidgin.py:120
 msgid "Send Message..."
-msgstr "Send melding..."
+msgstr "Send melding …"
 
 #: ../kupfer/plugin/gwibber.py:273
 msgid "Send message to selected Gwibber account"
@@ -2190,7 +2288,7 @@ msgstr ""
 #: ../kupfer/plugin/gwibber.py:376
 #, fuzzy
 msgid "Retweet To..."
-msgstr "Endre navn til..."
+msgstr "Endre navn til …"
 
 #: ../kupfer/plugin/gwibber.py:407
 msgid "Retweet message to all Gwibber accounts"
@@ -2360,23 +2458,14 @@ msgstr ""
 msgid "OpenOffice / LibreOffice"
 msgstr ""
 
-#: ../kupfer/plugin/openoffice.py:5 ../kupfer/plugin/openoffice.py:135
+#: ../kupfer/plugin/openoffice.py:5 ../kupfer/plugin/openoffice.py:136
 #, fuzzy
 msgid "Recently used documents in OpenOffice/LibreOffice"
 msgstr "Siste dokumenter"
 
-#: ../kupfer/plugin/openoffice.py:83
+#: ../kupfer/plugin/openoffice.py:84
 msgid "OpenOffice/LibreOffice Recent Items"
 msgstr ""
-
-#: ../kupfer/plugin/opera.py:4 ../kupfer/plugin/opera.py:22
-msgid "Opera Bookmarks"
-msgstr "Opera-bokmerker"
-
-#: ../kupfer/plugin/opera.py:6 ../kupfer/plugin/opera.py:54
-#, fuzzy
-msgid "Index of Opera bookmarks"
-msgstr "Åpne bokmerke %s"
 
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/operamail.py:2
@@ -2400,6 +2489,15 @@ msgstr "Rediger kontakt %s"
 #, fuzzy
 msgid "Contacts from Opera Mail"
 msgstr "E-post (adressebok)"
+
+#: ../kupfer/plugin/opera.py:4 ../kupfer/plugin/opera.py:22
+msgid "Opera Bookmarks"
+msgstr "Opera-bokmerker"
+
+#: ../kupfer/plugin/opera.py:6 ../kupfer/plugin/opera.py:54
+#, fuzzy
+msgid "Index of Opera bookmarks"
+msgstr "Åpne bokmerke %s"
 
 #: ../kupfer/plugin/pidgin.py:3
 msgid "Pidgin"
@@ -2431,6 +2529,10 @@ msgstr ""
 #: ../kupfer/plugin/putty.py:46 ../kupfer/plugin/tsclient.py:50
 msgid "Start Session"
 msgstr "Start økt"
+
+#: ../kupfer/plugin/qsicons/__init__.py:24
+msgid "Quicksilver Icons"
+msgstr ""
 
 #: ../kupfer/plugin/quickview.py:1
 msgid "Quick Image Viewer"
@@ -2481,7 +2583,7 @@ msgstr "Skjermøkter"
 msgid "Attach"
 msgstr "Fest"
 
-#: ../kupfer/plugin/sendkeys.py:2 ../kupfer/plugin/sendkeys.py:49
+#: ../kupfer/plugin/sendkeys.py:2 ../kupfer/plugin/sendkeys.py:52
 msgid "Send Keys"
 msgstr "Send taster"
 
@@ -2489,23 +2591,23 @@ msgstr "Send taster"
 msgid "Send synthetic keyboard events using xautomation"
 msgstr ""
 
-#: ../kupfer/plugin/sendkeys.py:25
+#: ../kupfer/plugin/sendkeys.py:28
 msgid "Paste to Foreground Window"
 msgstr ""
 
-#: ../kupfer/plugin/sendkeys.py:43
+#: ../kupfer/plugin/sendkeys.py:46
 msgid "Copy to clipboard and send Ctrl+V to foreground window"
 msgstr ""
 
-#: ../kupfer/plugin/sendkeys.py:85
+#: ../kupfer/plugin/sendkeys.py:101
 msgid "Send keys to foreground window"
 msgstr ""
 
-#: ../kupfer/plugin/sendkeys.py:90
+#: ../kupfer/plugin/sendkeys.py:106
 msgid "Type Text"
 msgstr "Skriv tekst"
 
-#: ../kupfer/plugin/sendkeys.py:111
+#: ../kupfer/plugin/sendkeys.py:127
 msgid "Type the text to foreground window"
 msgstr ""
 
@@ -2563,17 +2665,12 @@ msgstr "Tjenester"
 #: ../kupfer/plugin/show_qrcode.py:5 ../kupfer/plugin/show_qrcode.py:25
 #, fuzzy
 msgid "Show QRCode"
-msgstr "Vis tekst"
+msgstr "Vis QRCode"
 
 #: ../kupfer/plugin/show_qrcode.py:9 ../kupfer/plugin/show_qrcode.py:60
 #, fuzzy
 msgid "Display text as QRCode in a window"
 msgstr "Vis tekst i et vindu"
-
-#. -*- coding: UTF-8 -*-
-#: ../kupfer/plugin/skype.py:2
-msgid "Skype"
-msgstr "Skype"
 
 #: ../kupfer/plugin/skype.py:5
 msgid "Access to Skype contacts"
@@ -2587,24 +2684,24 @@ msgstr ""
 msgid "Logged Out"
 msgstr "Logget ut"
 
-#: ../kupfer/plugin/skype.py:183
+#: ../kupfer/plugin/skype.py:179
 #, python-format
 msgid "[%(status)s] %(userid)s"
 msgstr ""
 
-#: ../kupfer/plugin/skype.py:225
+#: ../kupfer/plugin/skype.py:218
 msgid "Call"
 msgstr ""
 
-#: ../kupfer/plugin/skype.py:239
+#: ../kupfer/plugin/skype.py:232
 msgid "Place a call to contact"
 msgstr ""
 
-#: ../kupfer/plugin/skype.py:274
+#: ../kupfer/plugin/skype.py:267
 msgid "Skype Contacts"
 msgstr ""
 
-#: ../kupfer/plugin/skype.py:294
+#: ../kupfer/plugin/skype.py:287
 msgid "Skype Statuses"
 msgstr ""
 
@@ -2637,6 +2734,19 @@ msgstr ""
 msgid "No D-Bus connection to desktop session"
 msgstr ""
 
+#: ../kupfer/plugin_support.py:171
+msgid "GNOME Keyring"
+msgstr "GNOME-nøkkelring"
+
+#: ../kupfer/plugin_support.py:172
+msgid "KWallet"
+msgstr ""
+
+#: ../kupfer/plugin_support.py:173
+#, fuzzy
+msgid "Unencrypted File"
+msgstr "Markert fil"
+
 #: ../kupfer/plugin/templates.py:1 ../kupfer/plugin/templates.py:107
 msgid "Document Templates"
 msgstr "Dokumentmaler"
@@ -2660,7 +2770,7 @@ msgstr "Ny mappe"
 
 #: ../kupfer/plugin/templates.py:57
 msgid "Create New Document..."
-msgstr "Lag nytt dokument..."
+msgstr "Lag nytt dokument …"
 
 #: ../kupfer/plugin/templates.py:96
 msgid "Create a new document from template"
@@ -2690,36 +2800,45 @@ msgstr "Skriv til …"
 msgid "Get Text Contents"
 msgstr "Hent tekstinnhold"
 
-#: ../kupfer/plugin/thunar.py:1 ../kupfer/plugin/thunar.py:184
-#: ../kupfer/plugin/thunar.py:224 ../kupfer/plugin/thunar.py:283
+#: ../kupfer/plugin/thunar.py:1 ../kupfer/plugin/thunar.py:185
+#: ../kupfer/plugin/thunar.py:225 ../kupfer/plugin/thunar.py:278
+#: ../kupfer/plugin/thunar.py:329
 msgid "Thunar"
 msgstr "Thunar"
 
-#: ../kupfer/plugin/thunar.py:10
+#: ../kupfer/plugin/thunar.py:11
 msgid "File manager Thunar actions"
 msgstr ""
 
-#: ../kupfer/plugin/thunar.py:66
+#: ../kupfer/plugin/thunar.py:67
 msgid "Select in File Manager"
 msgstr ""
 
-#: ../kupfer/plugin/thunar.py:94
+#: ../kupfer/plugin/thunar.py:95
 msgid "Show Properties"
 msgstr "Vis egenskaper"
 
-#: ../kupfer/plugin/thunar.py:117
+#: ../kupfer/plugin/thunar.py:118
 msgid "Show information about file in file manager"
 msgstr ""
 
-#: ../kupfer/plugin/thunar.py:126
+#: ../kupfer/plugin/thunar.py:127
 msgid "Send To..."
 msgstr "Send til …"
 
-#: ../kupfer/plugin/thunar.py:258
+#: ../kupfer/plugin/thunar.py:259
+msgid "Symlink In..."
+msgstr ""
+
+#: ../kupfer/plugin/thunar.py:300
+msgid "Create a symlink to file in a chosen location"
+msgstr ""
+
+#: ../kupfer/plugin/thunar.py:304
 msgid "Empty Trash"
 msgstr "Tøm papirkurven"
 
-#: ../kupfer/plugin/thunar.py:298
+#: ../kupfer/plugin/thunar.py:344
 msgid "Thunar Send To Objects"
 msgstr ""
 
@@ -2731,15 +2850,15 @@ msgstr "Thunderbird"
 msgid "Thunderbird/Icedove Contacts and Actions"
 msgstr ""
 
-#: ../kupfer/plugin/thunderbird.py:32
+#: ../kupfer/plugin/thunderbird.py:38
 msgid "Compose a new message in Thunderbird"
 msgstr ""
 
-#: ../kupfer/plugin/thunderbird.py:66
+#: ../kupfer/plugin/thunderbird.py:74
 msgid "Thunderbird Address Book"
 msgstr "Thunderbird adressebok"
 
-#: ../kupfer/plugin/thunderbird.py:91
+#: ../kupfer/plugin/thunderbird.py:99
 msgid "Contacts from Thunderbird Address Book"
 msgstr ""
 
@@ -2771,7 +2890,7 @@ msgstr ""
 
 #: ../kupfer/plugin/top.py:49
 msgid "Send Signal..."
-msgstr "Send signal"
+msgstr "Send signal …"
 
 #: ../kupfer/plugin/top.py:79
 msgid "Signals"
@@ -2791,70 +2910,28 @@ msgstr ""
 msgid "Running tasks for current user"
 msgstr ""
 
-#: ../kupfer/plugin/tracker.py:5
-msgid "Tracker 0.6"
+#: ../kupfer/plugin/tracker1.py:10
+msgid "Tracker"
 msgstr ""
 
-#: ../kupfer/plugin/tracker.py:15 ../kupfer/plugin/tracker1.py:18
+#: ../kupfer/plugin/tracker1.py:18
 msgid "Tracker desktop search integration"
 msgstr ""
 
-#: ../kupfer/plugin/tracker.py:41 ../kupfer/plugin/tracker1.py:49
+#: ../kupfer/plugin/tracker1.py:49
 msgid "Search in Tracker"
 msgstr ""
 
-#: ../kupfer/plugin/tracker.py:46 ../kupfer/plugin/tracker1.py:54
+#: ../kupfer/plugin/tracker1.py:54
 msgid "Open Tracker Search Tool and search for this term"
 msgstr ""
 
-#: ../kupfer/plugin/tracker.py:55 ../kupfer/plugin/tracker1.py:62
+#: ../kupfer/plugin/tracker1.py:62
 msgid "Get Tracker Results..."
 msgstr ""
 
-#: ../kupfer/plugin/tracker.py:64 ../kupfer/plugin/tracker1.py:71
+#: ../kupfer/plugin/tracker1.py:71
 msgid "Show Tracker results for query"
-msgstr ""
-
-#: ../kupfer/plugin/tracker.py:165 ../kupfer/plugin/tracker.py:171
-msgid "Tracker tags"
-msgstr ""
-
-#: ../kupfer/plugin/tracker.py:180
-msgid "Tracker Tags"
-msgstr ""
-
-#: ../kupfer/plugin/tracker.py:186
-msgid "Browse Tracker's tags"
-msgstr ""
-
-#: ../kupfer/plugin/tracker.py:197 ../kupfer/plugin/tracker.py:204
-#, python-format
-msgid "Tag %s"
-msgstr ""
-
-#: ../kupfer/plugin/tracker.py:211
-#, python-format
-msgid "Objects tagged %s with Tracker"
-msgstr ""
-
-#: ../kupfer/plugin/tracker.py:223
-msgid "Add Tag..."
-msgstr ""
-
-#: ../kupfer/plugin/tracker.py:249
-msgid "Add tracker tag to file"
-msgstr ""
-
-#: ../kupfer/plugin/tracker.py:255
-msgid "Remove Tag..."
-msgstr ""
-
-#: ../kupfer/plugin/tracker.py:274
-msgid "Remove tracker tag from file"
-msgstr ""
-
-#: ../kupfer/plugin/tracker1.py:10
-msgid "Tracker"
 msgstr ""
 
 #. FIXME: Port tracker tag sources and actions
@@ -2910,6 +2987,47 @@ msgstr ""
 msgid "Saved sessions in Terminal Server Client"
 msgstr ""
 
+#: ../kupfer/plugin/vim/__init__.py:1
+msgid "Vim"
+msgstr "Vim"
+
+#: ../kupfer/plugin/vim/__init__.py:4
+#, fuzzy
+msgid "Recently used documents in Vim"
+msgstr "Siste dokumenter"
+
+#: ../kupfer/plugin/vim/plugin.py:56
+#, fuzzy
+msgid "Vim Recent Documents"
+msgstr "Nylig brukte dokumenter"
+
+#: ../kupfer/plugin/vim/plugin.py:219
+msgid "Close (Save All)"
+msgstr "Lukk (lagre alle)"
+
+#: ../kupfer/plugin/vim/plugin.py:237
+msgid "Send..."
+msgstr "Send …"
+
+#: ../kupfer/plugin/vim/plugin.py:264
+#, fuzzy
+msgid "Send ex command"
+msgstr "Skallkommando"
+
+#: ../kupfer/plugin/vim/plugin.py:272
+msgid "Insert in Vim..."
+msgstr ""
+
+#: ../kupfer/plugin/vim/plugin.py:309
+#, fuzzy
+msgid "Active Vim Sessions"
+msgstr "Skjermøkter"
+
+#: ../kupfer/plugin/vim/plugin.py:338
+#, python-format
+msgid "Vim Session %s"
+msgstr "Vim-økt %s"
+
 #: ../kupfer/plugin/vinagre.py:4
 msgid "Vinagre"
 msgstr "Vinagre"
@@ -2925,20 +3043,6 @@ msgstr "Start Vinagre-økt"
 #: ../kupfer/plugin/vinagre.py:72
 msgid "Vinagre Bookmarks"
 msgstr "Vinagre-bokmerker"
-
-#: ../kupfer/plugin/vim.py:1
-msgid "Vim"
-msgstr "Vim"
-
-#: ../kupfer/plugin/vim.py:3
-#, fuzzy
-msgid "Recently used documents in Vim"
-msgstr "Siste dokumenter"
-
-#: ../kupfer/plugin/vim.py:46
-#, fuzzy
-msgid "Vim Recent Documents"
-msgstr "Nylig brukte dokumenter"
 
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/virtualbox/__init__.py:3
@@ -2994,47 +3098,72 @@ msgstr ""
 msgid "Zim"
 msgstr ""
 
-#: ../kupfer/plugin/zim.py:10
+#: ../kupfer/plugin/zim.py:11
 msgid "Access to Pages stored in Zim - A Desktop Wiki and Outliner"
 msgstr ""
 
-#: ../kupfer/plugin/zim.py:28
+#: ../kupfer/plugin/zim.py:30
 msgid "Page names start with :colon"
 msgstr ""
 
-#: ../kupfer/plugin/zim.py:58
+#: ../kupfer/plugin/zim.py:36
+msgid "Default page name for quick notes"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:38
+#, python-format
+msgid "Note %x %X"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:39
+msgid ""
+"Strftime tags can be used: %H - hour, %M - minutes, etc\n"
+"Please check python documentation for details.\n"
+"NOTE: comma will be replaced by _"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:45
+msgid "Default namespace for quick notes"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:80
 #, python-format
 msgid "Zim Page from Notebook \"%s\""
 msgstr ""
 
-#: ../kupfer/plugin/zim.py:67
+#: ../kupfer/plugin/zim.py:89
 #, fuzzy
 msgid "Create Zim Page"
 msgstr "Opprett dokument"
 
-#: ../kupfer/plugin/zim.py:74
+#: ../kupfer/plugin/zim.py:96
 msgid "Create page in default notebook"
 msgstr ""
 
-#: ../kupfer/plugin/zim.py:84
+#: ../kupfer/plugin/zim.py:108
 msgid "Create Zim Page In..."
 msgstr ""
 
-#: ../kupfer/plugin/zim.py:122
+#: ../kupfer/plugin/zim.py:132
+msgid "Insert QuickNote into Zim"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:142
+msgid "Quick note selected text into Zim notebook"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:191
 msgid "Create Subpage..."
 msgstr ""
 
-#: ../kupfer/plugin/zim.py:243
+#: ../kupfer/plugin/zim.py:370
 msgid "Zim Notebooks"
 msgstr ""
 
-#: ../kupfer/plugin/zim.py:259
+#: ../kupfer/plugin/zim.py:387
 msgid "Zim Pages"
 msgstr "Zim-sider"
 
-#: ../kupfer/plugin/zim.py:287
+#: ../kupfer/plugin/zim.py:415
 msgid "Pages stored in Zim Notebooks"
 msgstr ""
-
-#~ msgid "Text Matches"
-#~ msgstr "Treff i tekst"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kupfer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-02-25 21:08+0100\n"
-"PO-Revision-Date: 2012-02-25 21:09+0100\n"
+"POT-Creation-Date: 2012-07-13 01:52+0200\n"
+"PO-Revision-Date: 2012-07-13 01:53+0200\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: Polish <gnomepl@aviary.pl>\n"
 "Language: pl\n"
@@ -21,18 +21,18 @@ msgstr ""
 "X-Poedit-Language: Polish\n"
 "X-Poedit-Country: Poland\n"
 
-#: ../auxdata/kupfer.desktop.in.h:1
-msgid "Application Launcher"
-msgstr "Aktywator programów"
-
-#: ../auxdata/kupfer.desktop.in.h:2
-msgid "Convenient command and access tool for applications and documents"
-msgstr "Wygodne narzędzie do uruchamiania programów i otwierania dokumentów"
-
-#: ../auxdata/kupfer.desktop.in.h:3 ../kupfer/version.py:15
+#: ../auxdata/kupfer.desktop.in.h:1 ../kupfer/version.py:15
 #: ../kupfer/plugin/core/contents.py:91
 msgid "Kupfer"
 msgstr "Kupfer"
+
+#: ../auxdata/kupfer.desktop.in.h:2
+msgid "Application Launcher"
+msgstr "Aktywator programów"
+
+#: ../auxdata/kupfer.desktop.in.h:3
+msgid "Convenient command and access tool for applications and documents"
+msgstr "Wygodne narzędzie do uruchamiania programów i otwierania dokumentów"
 
 #: ../auxdata/kupfer-exec.desktop.in.h:1
 msgid "Execute in Kupfer"
@@ -47,79 +47,91 @@ msgid "User credentials"
 msgstr "Dane użytkownika"
 
 #: ../data/credentials_dialog.ui.h:2
-msgid "_Change"
-msgstr "_Zmień"
+msgid "_User:"
+msgstr "_Użytkownik:"
 
 #: ../data/credentials_dialog.ui.h:3
 msgid "_Password:"
 msgstr "_Hasło:"
 
 #: ../data/credentials_dialog.ui.h:4
-msgid "_User:"
-msgstr "_Użytkownik:"
+msgid "_Change"
+msgstr "_Zmień"
 
 #: ../data/getkey_dialog.ui.h:1
-msgid "Keybinding could not be bound"
-msgstr "Przypisanie klawisza się nie powiodło"
+msgid "Set Keyboard Shortcut"
+msgstr "Wybór klawisza skrótu"
 
 #: ../data/getkey_dialog.ui.h:2
 msgid "Please press desired key combination"
 msgstr "Proszę nacisnąć żądaną kombinację klawiszy"
 
 #: ../data/getkey_dialog.ui.h:3
-msgid "Set Keyboard Shortcut"
-msgstr "Wybór klawisza skrótu"
+msgid "Keybinding could not be bound"
+msgstr "Przypisanie klawisza się nie powiodło"
 
-#: ../data/preferences.ui.h:1
-msgid "<b>Browser Keyboard Shortcuts</b>"
-msgstr "<b>Skróty klawiszowe przeglądarki</b>"
+#: ../data/preferences.ui.h:1 ../kupfer/plugin/core/contents.py:78
+msgid "Kupfer Preferences"
+msgstr "Preferencje programu Kupfer"
 
 #: ../data/preferences.ui.h:2
-msgid "<b>Global Keyboard Shortcuts</b>"
-msgstr "<b>Globalne skróty klawiszowe</b>"
+msgid "Start automatically on login"
+msgstr "Automatycznie uruchamianie po zalogowaniu"
 
 #: ../data/preferences.ui.h:3
 msgid "<b>Start</b>"
 msgstr "<b>Początek</b>"
 
-#: ../data/preferences.ui.h:4 ../kupfer/obj/sources.py:156
-msgid "Catalog"
-msgstr "Katalog"
+#: ../data/preferences.ui.h:4
+msgid "Show icon in notification area"
+msgstr "Ikona w obszarze powiadamiania"
 
 #: ../data/preferences.ui.h:5
-msgid "Desktop Environment"
-msgstr "Środowisko graficzne"
-
-#: ../data/preferences.ui.h:6
-msgid "Folders whose files are always available in the catalog."
-msgstr ""
-"Katalogi, których pliki będą zawsze dostępne w katalogu programu Kupfer."
-
-#: ../data/preferences.ui.h:7 ../kupfer/plugin/gmail/__init__.py:60
-msgid "General"
-msgstr "Ogólne"
-
-#: ../data/preferences.ui.h:8
 msgid "Icon set:"
 msgstr "Zestaw ikon:"
 
-#: ../data/preferences.ui.h:9
-msgid "Inclusion in Top Level Searches"
-msgstr "Zawartość najwyższego poziomu katalogu"
+#: ../data/preferences.ui.h:6
+msgid "Terminal emulator:"
+msgstr "Emulator terminala:"
 
-#: ../data/preferences.ui.h:10
-msgid "Indexed Folders"
-msgstr "Indeksowane katalogi"
+#: ../data/preferences.ui.h:7
+msgid "Desktop Environment"
+msgstr "Środowisko graficzne"
+
+#: ../data/preferences.ui.h:8 ../kupfer/plugin/gmail/__init__.py:60
+msgid "General"
+msgstr "Ogólne"
+
+#: ../data/preferences.ui.h:9
+msgid "<b>Global Keyboard Shortcuts</b>"
+msgstr "<b>Globalne skróty klawiszowe</b>"
+
+#: ../data/preferences.ui.h:10 ../kupfer/ui/preferences.py:849
+msgid "Reset"
+msgstr "Przywróć"
 
 #: ../data/preferences.ui.h:11
+msgid "<b>Browser Keyboard Shortcuts</b>"
+msgstr "<b>Skróty klawiszowe przeglądarki</b>"
+
+#: ../data/preferences.ui.h:12
+msgid "Use single keystroke commands (Space, /, period, comma etc.)"
+msgstr ""
+"Włączenie jednoklawiszowych poleceń (spacja, /, kropka, przecinek itp.)"
+
+#: ../data/preferences.ui.h:13
 msgid "Keyboard"
 msgstr "Klawiatura"
 
-#: ../data/preferences.ui.h:12 ../kupfer/plugin/core/contents.py:78
-msgid "Kupfer Preferences"
-msgstr "Preferencje programu Kupfer"
+#: ../data/preferences.ui.h:14
+msgid "Plugins"
+msgstr "Wtyczki"
 
-#: ../data/preferences.ui.h:13
+#: ../data/preferences.ui.h:15
+msgid "Inclusion in Top Level Searches"
+msgstr "Zawartość najwyższego poziomu katalogu"
+
+#: ../data/preferences.ui.h:16
 msgid ""
 "Marked sources have their objects included in top level searches.\n"
 "An unmarked source's contents are only available by locating its subcatalog."
@@ -128,30 +140,18 @@ msgstr ""
 "wyszukiwania.\n"
 "Zawartość odznaczonych źródeł jest dostępna jedynie przez podkatalogi listy."
 
-#: ../data/preferences.ui.h:15
-msgid "Plugins"
-msgstr "Wtyczki"
-
-#: ../data/preferences.ui.h:16 ../kupfer/ui/preferences.py:849
-msgid "Reset"
-msgstr "Przywróć"
-
-#: ../data/preferences.ui.h:17
-msgid "Show icon in notification area"
-msgstr "Ikona w obszarze powiadamiania"
-
 #: ../data/preferences.ui.h:18
-msgid "Start automatically on login"
-msgstr "Automatycznie uruchamianie po zalogowaniu"
+msgid "Indexed Folders"
+msgstr "Indeksowane katalogi"
 
 #: ../data/preferences.ui.h:19
-msgid "Terminal emulator:"
-msgstr "Emulator terminala:"
-
-#: ../data/preferences.ui.h:20
-msgid "Use single keystroke commands (Space, /, period, comma etc.)"
+msgid "Folders whose files are always available in the catalog."
 msgstr ""
-"Włączenie jednoklawiszowych poleceń (spacja, /, kropka, przecinek itp.)"
+"Katalogi, których pliki będą zawsze dostępne w katalogu programu Kupfer."
+
+#: ../data/preferences.ui.h:20 ../kupfer/obj/sources.py:157
+msgid "Catalog"
+msgstr "Katalog"
 
 #: ../kupfer/core/commandexec.py:239
 #, python-format
@@ -526,7 +526,7 @@ msgid "Can not be used with multiple objects"
 msgstr "Nie może być użyte z wieloma obiektami"
 
 #: ../kupfer/obj/fileactions.py:30 ../kupfer/plugin/notes.py:89
-#: ../kupfer/plugin/gnome_terminal.py:36 ../kupfer/plugin/gtg.py:108
+#: ../kupfer/plugin/gnome_terminal.py:36 ../kupfer/plugin/gtg.py:135
 #: ../kupfer/plugin/zim.py:176
 msgid "Open"
 msgstr "Otwórz"
@@ -623,21 +623,21 @@ msgid "Attempt to close all application windows"
 msgstr "Próbuje zamknąć wszystkie okna programu"
 
 #. TRANS: 'Run' as in Perform a (saved) command
-#: ../kupfer/obj/objects.py:396
+#: ../kupfer/obj/objects.py:398
 msgid "Run"
 msgstr "Uruchom"
 
-#: ../kupfer/obj/objects.py:406
+#: ../kupfer/obj/objects.py:408
 msgid "Perform command"
 msgstr "Wykonuje polecenie"
 
-#: ../kupfer/obj/objects.py:419
+#: ../kupfer/obj/objects.py:421
 msgid "(Empty Text)"
 msgstr "(Brak tekstu)"
 
 #. TRANS: This is description for a TextLeaf, a free-text search
 #. TRANS: The plural parameter is the number of lines %(num)d
-#: ../kupfer/obj/objects.py:449
+#: ../kupfer/obj/objects.py:451
 #, python-format
 msgid "\"%(text)s\""
 msgid_plural "(%(num)d lines) \"%(text)s\""
@@ -661,19 +661,19 @@ msgstr "Rekurencyjne źródło %(dir)s, (%(levels)d poziomów)"
 msgid "Directory source %s"
 msgstr "Źródło katalogu %s"
 
-#: ../kupfer/obj/sources.py:118
+#: ../kupfer/obj/sources.py:119
 msgid "Home Folder"
 msgstr "Katalog domowy"
 
-#: ../kupfer/obj/sources.py:129
+#: ../kupfer/obj/sources.py:130
 msgid "Catalog Index"
 msgstr "Indeks katalogu"
 
-#: ../kupfer/obj/sources.py:144
+#: ../kupfer/obj/sources.py:145
 msgid "An index of all available sources"
 msgstr "Indeks wszystkich dostępnych źródeł"
 
-#: ../kupfer/obj/sources.py:176
+#: ../kupfer/obj/sources.py:177
 msgid "Root catalog"
 msgstr "Katalog główny"
 
@@ -893,6 +893,10 @@ msgstr "X Terminal"
 msgid "Urxvt"
 msgstr "Urxvt"
 
+#: ../kupfer/plugin/core/alternatives.py:58
+msgid "Konsole"
+msgstr "Konsole"
+
 #: ../kupfer/plugin/core/commands.py:13 ../kupfer/plugin/core/commands.py:32
 msgid "Save As..."
 msgstr "Zapisz jako..."
@@ -1082,11 +1086,11 @@ msgstr "Skopiuj do..."
 msgid "Copy file to a chosen location"
 msgstr "Kopiuje plik do wybranego położenia"
 
-#: ../kupfer/plugin/firefox.py:4 ../kupfer/plugin/firefox.py:36
+#: ../kupfer/plugin/firefox.py:4 ../kupfer/plugin/firefox.py:61
 msgid "Firefox Bookmarks"
 msgstr "Zakładki programu Firefox"
 
-#: ../kupfer/plugin/firefox.py:6 ../kupfer/plugin/firefox.py:120
+#: ../kupfer/plugin/firefox.py:6 ../kupfer/plugin/firefox.py:147
 msgid "Index of Firefox bookmarks"
 msgstr "Indeks zakładek programu Firefox"
 
@@ -1094,32 +1098,16 @@ msgstr "Indeks zakładek programu Firefox"
 msgid "Include visited sites"
 msgstr "Dołączenie odwiedzonych miejsc"
 
+#: ../kupfer/plugin/firefox.py:44
+msgid "Firefox tag"
+msgstr "Etykieta programu Firefox"
+
 #. TRANS: Multihead refers to support for multiple computer displays
 #. TRANS: In this case, it only concerns the special configuration
 #. TRANS: with multiple X "screens"
 #: ../kupfer/plugin/multihead.py:4
 msgid "Multihead Support"
 msgstr "Obsługa wielu ekranów"
-
-#: ../kupfer/plugin/nautilusselection.py:1
-#: ../kupfer/plugin/nautilusselection.py:46
-msgid "Selected File"
-msgstr "Zaznaczony plik"
-
-#: ../kupfer/plugin/nautilusselection.py:3
-msgid "Provides current nautilus selection, using Kupfer's Nautilus Extension"
-msgstr ""
-"Bieżące zaznaczenie w programie Nautilus (z pomocą rozszerzenia Kupfer dla "
-"programu Nautilus)"
-
-#: ../kupfer/plugin/nautilusselection.py:25
-#, python-format
-msgid "Selected File \"%s\""
-msgstr "Zaznaczony plik \"%s\""
-
-#: ../kupfer/plugin/nautilusselection.py:34
-msgid "Selected Files"
-msgstr "Zaznaczone pliki"
 
 #: ../kupfer/plugin/notes.py:6 ../kupfer/plugin/notes.py:178
 #: ../kupfer/plugin/notes.py:230
@@ -1748,7 +1736,7 @@ msgid "Claws Mail Contacts and Actions"
 msgstr "Kontakty i działania programu Claws Mail"
 
 #: ../kupfer/plugin/clawsmail.py:26 ../kupfer/plugin/evolution.py:24
-#: ../kupfer/plugin/operamail.py:26 ../kupfer/plugin/thunderbird.py:25
+#: ../kupfer/plugin/operamail.py:26 ../kupfer/plugin/thunderbird.py:31
 msgid "Compose New Email"
 msgstr "Napisz nową wiadomość e-mail"
 
@@ -1766,7 +1754,7 @@ msgstr "Pobiera wiadomości ze wszystkich kont programu Claws Mail"
 
 #: ../kupfer/plugin/clawsmail.py:56 ../kupfer/plugin/defaultmail.py:18
 #: ../kupfer/plugin/evolution.py:40 ../kupfer/plugin/operamail.py:41
-#: ../kupfer/plugin/thunderbird.py:41
+#: ../kupfer/plugin/thunderbird.py:47
 msgid "Compose Email"
 msgstr "Utwórz wiadomość e-mail"
 
@@ -1846,55 +1834,55 @@ msgstr "Empathy"
 msgid "Access to Empathy Contacts"
 msgstr "Dostęp do kontaktów programu Empathy"
 
-#: ../kupfer/plugin/empathy.py:25 ../kupfer/plugin/pidgin.py:29
+#: ../kupfer/plugin/empathy.py:26 ../kupfer/plugin/pidgin.py:29
 msgid "Show offline contacts"
 msgstr "Wyświetlanie kontaktów offline"
 
-#: ../kupfer/plugin/empathy.py:34 ../kupfer/plugin/gajim.py:26
+#: ../kupfer/plugin/empathy.py:35 ../kupfer/plugin/gajim.py:26
 #: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:30
 msgid "Available"
 msgstr "Dostępny"
 
-#: ../kupfer/plugin/empathy.py:35 ../kupfer/plugin/gajim.py:28
+#: ../kupfer/plugin/empathy.py:36 ../kupfer/plugin/gajim.py:28
 #: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:32
 msgid "Away"
 msgstr "Zaraz wracam"
 
-#: ../kupfer/plugin/empathy.py:36 ../kupfer/plugin/gajim.py:30
+#: ../kupfer/plugin/empathy.py:37 ../kupfer/plugin/gajim.py:30
 #: ../kupfer/plugin/skype.py:34
 msgid "Busy"
 msgstr "Zajęty"
 
-#: ../kupfer/plugin/empathy.py:37 ../kupfer/plugin/gajim.py:29
+#: ../kupfer/plugin/empathy.py:38 ../kupfer/plugin/gajim.py:29
 #: ../kupfer/plugin/skype.py:33
 msgid "Not Available"
 msgstr "Nieobecny"
 
-#: ../kupfer/plugin/empathy.py:38 ../kupfer/plugin/gajim.py:31
+#: ../kupfer/plugin/empathy.py:39 ../kupfer/plugin/gajim.py:31
 #: ../kupfer/plugin/skype.py:35
 msgid "Invisible"
 msgstr "Niewidoczny"
 
-#: ../kupfer/plugin/empathy.py:39 ../kupfer/plugin/gajim.py:32
+#: ../kupfer/plugin/empathy.py:40 ../kupfer/plugin/gajim.py:32
 #: ../kupfer/plugin/skype.py:36
 msgid "Offline"
 msgstr "Rozłączony"
 
-#: ../kupfer/plugin/empathy.py:96 ../kupfer/plugin/gajim.py:93
+#: ../kupfer/plugin/empathy.py:100 ../kupfer/plugin/gajim.py:93
 #: ../kupfer/plugin/pidgin.py:97 ../kupfer/plugin/skype.py:197
 msgid "Open Chat"
 msgstr "Rozpocznij rozmowę"
 
-#: ../kupfer/plugin/empathy.py:129 ../kupfer/plugin/gajim.py:121
+#: ../kupfer/plugin/empathy.py:133 ../kupfer/plugin/gajim.py:121
 #: ../kupfer/plugin/skype.py:243
 msgid "Change Global Status To..."
 msgstr "Zmień globalny stan na..."
 
-#: ../kupfer/plugin/empathy.py:171
+#: ../kupfer/plugin/empathy.py:175
 msgid "Empathy Contacts"
 msgstr "Kontakty programu Empathy"
 
-#: ../kupfer/plugin/empathy.py:237
+#: ../kupfer/plugin/empathy.py:249
 msgid "Empathy Account Status"
 msgstr "Stan konta programu Empathy"
 
@@ -2165,7 +2153,6 @@ msgstr "Wyszukuje w serwisie Google i bezpośrednio wyświetla wyniki"
 
 #: ../kupfer/plugin/google_search.py:58 ../kupfer/plugin/locate.py:46
 #: ../kupfer/plugin/tracker1.py:168 ../kupfer/plugin/tracker1.py:179
-#: ../kupfer/plugin/tracker.py:72 ../kupfer/plugin/tracker.py:113
 #, python-format
 msgid "Results for \"%s\""
 msgstr "Wyniki dla \"%s\""
@@ -2189,54 +2176,54 @@ msgstr "Getting Things GNOME"
 msgid "Browse and create new tasks in GTG"
 msgstr "Przeglądanie i tworzenie nowych zadań w programie GTG"
 
-#: ../kupfer/plugin/gtg.py:87
+#: ../kupfer/plugin/gtg.py:114
 #, python-format
 msgid "due: %s"
 msgstr "do: %s"
 
-#: ../kupfer/plugin/gtg.py:89
+#: ../kupfer/plugin/gtg.py:116
 #, python-format
 msgid "start: %s"
 msgstr "początek: %s"
 
-#: ../kupfer/plugin/gtg.py:91
+#: ../kupfer/plugin/gtg.py:118
 #, python-format
 msgid "tags: %s"
 msgstr "etykiety: %s"
 
-#: ../kupfer/plugin/gtg.py:118
+#: ../kupfer/plugin/gtg.py:148
 msgid "Open task in Getting Things GNOME!"
 msgstr "Otwiera zadanie w programie Getting Things GNOME"
 
-#: ../kupfer/plugin/gtg.py:125
+#: ../kupfer/plugin/gtg.py:155
 msgid "Delete"
 msgstr "Usuń"
 
-#: ../kupfer/plugin/gtg.py:135
+#: ../kupfer/plugin/gtg.py:168
 msgid "Permanently remove this task"
 msgstr "Trwale usuwa to zadanie"
 
-#: ../kupfer/plugin/gtg.py:140
+#: ../kupfer/plugin/gtg.py:173
 msgid "Mark Done"
 msgstr "Wykonane"
 
-#: ../kupfer/plugin/gtg.py:149
+#: ../kupfer/plugin/gtg.py:182
 msgid "Mark this task as done"
 msgstr "Oznacza zadanie jako wykonane"
 
-#: ../kupfer/plugin/gtg.py:154
+#: ../kupfer/plugin/gtg.py:187
 msgid "Dismiss"
 msgstr "Pomiń"
 
-#: ../kupfer/plugin/gtg.py:163
+#: ../kupfer/plugin/gtg.py:196
 msgid "Mark this task as not to be done anymore"
 msgstr "Oznacza zadanie jako zadanie do pominięcia"
 
-#: ../kupfer/plugin/gtg.py:168
+#: ../kupfer/plugin/gtg.py:201
 msgid "Create Task"
 msgstr "Utwórz zadanie"
 
-#: ../kupfer/plugin/gtg.py:182
+#: ../kupfer/plugin/gtg.py:218
 msgid "Create new task in Getting Things GNOME"
 msgstr "Tworzy nowe zadanie w programie Getting Things GNOME"
 
@@ -2486,11 +2473,11 @@ msgstr "Ignorowanie wielkości liter podczas wyszukiwania plików"
 msgid "OpenOffice / LibreOffice"
 msgstr "OpenOffice.org/LibreOffice"
 
-#: ../kupfer/plugin/openoffice.py:5 ../kupfer/plugin/openoffice.py:135
+#: ../kupfer/plugin/openoffice.py:5 ../kupfer/plugin/openoffice.py:136
 msgid "Recently used documents in OpenOffice/LibreOffice"
 msgstr "Ostatnio używane dokumenty programu OpenOffice.org/LibreOffice"
 
-#: ../kupfer/plugin/openoffice.py:83
+#: ../kupfer/plugin/openoffice.py:84
 msgid "OpenOffice/LibreOffice Recent Items"
 msgstr "Ostatnie dokumenty programu OpenOffice.org/LibreOffice"
 
@@ -2874,15 +2861,15 @@ msgstr "Thunderbird"
 msgid "Thunderbird/Icedove Contacts and Actions"
 msgstr "Kontakty i działania programu Thunderbird/Icedove"
 
-#: ../kupfer/plugin/thunderbird.py:32
+#: ../kupfer/plugin/thunderbird.py:38
 msgid "Compose a new message in Thunderbird"
 msgstr "Tworzy nową wiadomość w programie Thunderbird"
 
-#: ../kupfer/plugin/thunderbird.py:66
+#: ../kupfer/plugin/thunderbird.py:74
 msgid "Thunderbird Address Book"
 msgstr "Książka adresowa programu Thunderbird"
 
-#: ../kupfer/plugin/thunderbird.py:91
+#: ../kupfer/plugin/thunderbird.py:99
 msgid "Contacts from Thunderbird Address Book"
 msgstr "Kontakty z książki adresowej programu Thunderbird"
 
@@ -2938,68 +2925,29 @@ msgstr "Uruchomione zadania bieżącego użytkownika"
 msgid "Tracker"
 msgstr "Tracker"
 
-#: ../kupfer/plugin/tracker1.py:18 ../kupfer/plugin/tracker.py:15
+#: ../kupfer/plugin/tracker1.py:18
 msgid "Tracker desktop search integration"
 msgstr "Integracja z programem Tracker"
 
-#: ../kupfer/plugin/tracker1.py:49 ../kupfer/plugin/tracker.py:41
+#: ../kupfer/plugin/tracker1.py:49
 msgid "Search in Tracker"
 msgstr "Znajdź w programie Tracker"
 
-#: ../kupfer/plugin/tracker1.py:54 ../kupfer/plugin/tracker.py:46
+#: ../kupfer/plugin/tracker1.py:54
 msgid "Open Tracker Search Tool and search for this term"
 msgstr "Otwiera narzędzie Tracker i wyszukuje to wyrażenie"
 
-#: ../kupfer/plugin/tracker1.py:62 ../kupfer/plugin/tracker.py:55
+#: ../kupfer/plugin/tracker1.py:62
 msgid "Get Tracker Results..."
 msgstr "Pobierz wyniki programu Tracker..."
 
-#: ../kupfer/plugin/tracker1.py:71 ../kupfer/plugin/tracker.py:64
+#: ../kupfer/plugin/tracker1.py:71
 msgid "Show Tracker results for query"
 msgstr "Wyświetla wyniki wyszukiwania programu Tracker dla zapytania"
 
-#: ../kupfer/plugin/tracker.py:5
-msgid "Tracker 0.6"
-msgstr "Tracker 0.6"
-
-#: ../kupfer/plugin/tracker.py:165 ../kupfer/plugin/tracker.py:171
-msgid "Tracker tags"
-msgstr "Etykiety programu Tracker"
-
-#: ../kupfer/plugin/tracker.py:180
-msgid "Tracker Tags"
-msgstr "Etykiety programu Tracker"
-
-#: ../kupfer/plugin/tracker.py:186
-msgid "Browse Tracker's tags"
-msgstr "Przegląda etykiety programu Tracker"
-
-#: ../kupfer/plugin/tracker.py:197 ../kupfer/plugin/tracker.py:204
-#, python-format
-msgid "Tag %s"
-msgstr "Etykieta %s"
-
-#: ../kupfer/plugin/tracker.py:211
-#, python-format
-msgid "Objects tagged %s with Tracker"
-msgstr "Obiekty zawierające etykietę %s w programie Tracker"
-
-#: ../kupfer/plugin/tracker.py:223
-msgid "Add Tag..."
-msgstr "Dodaj etykietę..."
-
-#: ../kupfer/plugin/tracker.py:249
-msgid "Add tracker tag to file"
-msgstr "Dodaje etykietę programu Tracker do pliku"
-
-#: ../kupfer/plugin/tracker.py:255
-msgid "Remove Tag..."
-msgstr "Usuń etykietę..."
-
-#: ../kupfer/plugin/tracker.py:274
-msgid "Remove tracker tag from file"
-msgstr "Usuwa etykietę programu Tracker z pliku"
-
+#. FIXME: Port tracker tag sources and actions
+#. to the new, much more powerful sparql + dbus API
+#. (using tracker-tag as in 0.6 is a plain hack and a dead end)
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/truecrypt.py:3
 msgid "TrueCrypt"

--- a/po/pl.po
+++ b/po/pl.po
@@ -4,12 +4,16 @@
 # pomóc w jego rozwijaniu i pielęgnowaniu, napisz do nas:
 # gnomepl@aviary.pl
 # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+# Maciej Kwiatkowski <kfiadeg@gmail.com>, 2009.
+# Karol Będkowski <karol.bedkowski@gmail.com>, 2009-2011.
+# Piotr Drąg <piotrdrag@gmail.com>, 2011-2012.
+# Aviary.pl <gnomepl@aviary.pl>, 2011-2012.
 msgid ""
 msgstr ""
 "Project-Id-Version: kupfer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-07-13 01:52+0200\n"
-"PO-Revision-Date: 2012-07-13 01:53+0200\n"
+"POT-Creation-Date: 2012-09-04 18:18+0200\n"
+"PO-Revision-Date: 2012-09-04 18:21+0200\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: Polish <gnomepl@aviary.pl>\n"
 "Language: pl\n"
@@ -410,8 +414,9 @@ msgstr "Skrót klawiszowy"
 msgid "translator-credits"
 msgstr ""
 "Maciej Kwiatkowski <kfiadeg@gmail.com>, 2009\n"
-"Karol Będkowski <karol.bedkowski@gmail.com>, 2009, 2010, 2011\n"
-"Aviary.pl <gnomepl@aviary.pl>, 2011, 2012"
+"Karol Będkowski <karol.bedkowski@gmail.com>, 2009-2011\n"
+"Piotr Drąg <piotrdrag@gmail.com>, 2011-2012\n"
+"Aviary.pl <gnomepl@aviary.pl>, 2011-2012"
 
 #: ../kupfer/version.py:78
 msgid "A free software (GPLv3+) launcher"


### PR DESCRIPTION
Adds a text entry for each command in the plugin preferences (not very aligned, though - is there a way to fix that?).

The Gnome/Xfce plugins launch a dialogue for log out/shut down with with further options, so this commit renames the classes in session_support for these and creates extra classes for each individual command they each cover. (That is, log out covers log out and switch user, and shut down covers shut down, reboot and suspend.)

The system-switch-user and system-suspend icons don't seem to be in the freedesktop icon naming spec, but I have them on my machine - should they be changed?
