### PR TITLE
update prefs plugins sidebar on keyboard events

### DIFF
--- a/kupfer/ui/preferences.py
+++ b/kupfer/ui/preferences.py
@@ -367,6 +367,7 @@ class PreferencesWindowController (pretty.OutputMixin):
 		self.store.set_value(it, checkcol, plugin_is_enabled)
 		setctl = settings.GetSettingsController()
 		setctl.set_plugin_enabled(plugin_id, plugin_is_enabled)
+		self.plugin_sidebar_update(plugin_id)
 
 	def _id_for_table_path(self, path):
 		it = self.store.get_iter(path)


### PR DESCRIPTION
The sidebar on the preferences plugins tab (containing plugin
information) only updates on mouse actions, but should also update
to reflect activation/deactivation of plugins by the keyboard
(space, enter) - and maybe other means I don't know of.

The way I've done this means the sidebar update function gets called
twice if you click a checkbox with the mouse - is there an easy way
around that? Does it matter?
