### PR TITLE
Fix "Lock screen" for recent Xubuntu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
-kupfer is a simple, flexible, launcher for Gnome
+kupfer is a simple, flexible launcher for GNOME
 ++++++++++++++++++++++++++++++++++++++++++++++++
 
-:Homepage:  http://kaizer.se/wiki/kupfer/
+:Homepage:  https://wiki.gnome.org/Apps/Kupfer
 :Credits:   Copyright 2007–2011 Ulrik Sverdrup <ulrik.sverdrup@gmail.com>
 :Licence:   GNU General Public License v3 (or any later version)
 

--- a/help/C/plugin-calculator.page
+++ b/help/C/plugin-calculator.page
@@ -64,7 +64,7 @@
      </list>
      <p>
        The Calculator lets you also calculate expression without "=" on the 
-       beginning as long it have inside one of operators: +, -, *, /, ^, |, &, ~.
+       beginning as long it have inside one of operators: +, -, *, /, ^, |, &amp;, ~.
      </p>
    </section>
   

--- a/help/Makefile.am
+++ b/help/Makefile.am
@@ -33,7 +33,7 @@ DOC_PAGES = \
 	plugin-websearch.page
 
 
-DOC_LINGUAS = cs de es fr it pl ro sl
+DOC_LINGUAS = cs de el es fr it pl ro sl
 
 
 # dist-hook: doc-dist-hook

--- a/help/cs/cs.po
+++ b/help/cs/cs.po
@@ -7,8 +7,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: kupfer master\n"
-"POT-Creation-Date: 2013-01-22 20:43+0000\n"
-"PO-Revision-Date: 2013-02-14 18:55+0100\n"
+"POT-Creation-Date: 2014-03-23 21:59+0000\n"
+"PO-Revision-Date: 2013-03-24 06:06+0100\n"
 "Last-Translator: Marek Černocký <marek@manet.cz>\n"
 "Language-Team: čeština <gnome-cs-list@gnome.org>\n"
 "Language: cs\n"
@@ -627,10 +627,11 @@ msgstr ""
 #: C/plugin-calculator.page:65(p)
 msgid ""
 "The Calculator lets you also calculate expression without \"=\" on the "
-"beginning as long it have inside one of operators: +, -, *, /, ^, |, , ~."
+"beginning as long it have inside one of operators: +, -, *, /, ^, |, &amp;, "
+"~."
 msgstr ""
 "Kalkulačka umožňuje vypočítat výraz i bez znaku „=“ na začátku, stačí když "
-"obsahuje jeden z operátorů: +, -, *, /, ^, |, , ~."
+"obsahuje jeden z operátorů: +, -, *, /, ^, |, &amp;, ~."
 
 #: C/plugin-applications.page:7(desc)
 msgid "Using the applications plugin."
@@ -1797,6 +1798,6 @@ msgstr ""
 "katalogu složky pracovní plochy je vždy aktuální."
 
 #. Put one translator per line, in the form of NAME <EMAIL>, YEAR1, YEAR2
-#: C/index.page:0(None)
+#: C/generalusage.page:0(None)
 msgid "translator-credits"
 msgstr "Marek Černocký <marek@manet.cz>"

--- a/help/cs/cs.po
+++ b/help/cs/cs.po
@@ -2,27 +2,27 @@
 # Copyright (C) 2010 kupfer's COPYRIGHT HOLDER
 # This file is distributed under the same license as the kupfer help.
 #
-# Marek Černocký <marek@manet.cz>, 2010, 2011.
+# Marek Černocký <marek@manet.cz>, 2010, 2011, 2013.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: kupfer master\n"
-"POT-Creation-Date: 2011-03-29 19:29+0000\n"
-"PO-Revision-Date: 2011-04-24 10:58+0200\n"
+"POT-Creation-Date: 2013-01-22 20:43+0000\n"
+"PO-Revision-Date: 2013-02-14 18:55+0100\n"
 "Last-Translator: Marek Černocký <marek@manet.cz>\n"
-"Language-Team: Czech <gnome-cs-list@gnome.org>\n"
+"Language-Team: čeština <gnome-cs-list@gnome.org>\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cs\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"X-Generator: Gtranslator 2.91.6\n"
 
 #: C/plugin-websearch.page:7(desc)
 msgid "Using the search the web plugin."
 msgstr "Používání zásuvného modulu Prohledat web."
 
 #: C/plugin-websearch.page:10(app)
-#| msgid "Search the Web Search Engines"
 msgid "Search the Web"
 msgstr "Prohledat web"
 
@@ -64,7 +64,6 @@ msgstr ""
 "hledání ve webovém prohlížeči."
 
 #: C/plugin-websearch.page:29(title)
-#| msgid "Search the Web Search Engines"
 msgid "Search Engines"
 msgstr "Vyhledávací stroje"
 
@@ -266,7 +265,6 @@ msgid "Notes"
 msgstr "Poznámky"
 
 #: C/plugin-notes.page:13(title)
-#| msgid "Plugins"
 msgid "Notes Plugin"
 msgstr "Zásuvný modul Poznámky"
 
@@ -311,7 +309,6 @@ msgid "Simply search for the note title in <app>Kupfer</app>"
 msgstr "Prostě nadpis poznámky v aplikaci <app>Kupfer</app> hledejte"
 
 #: C/plugin-notes.page:45(title)
-#| msgid "Descend into an object with content"
 msgid "Finding a note by content"
 msgstr "Hledání poznámky podle obsahu"
 
@@ -485,7 +482,6 @@ msgid "Favorites"
 msgstr "Oblíbené"
 
 #: C/plugin-favorites.page:13(title)
-#| msgid "Calculator Plugin"
 msgid "Favorites Plugin"
 msgstr "Zásuvný modul Oblíbené"
 
@@ -502,7 +498,6 @@ msgstr ""
 "ozdobeny symbolem hvězdičky."
 
 #: C/plugin-favorites.page:25(p)
-#| msgid "Introduction to <app>Kupfer</app>."
 msgid "Find an object in <app>Kupfer</app>"
 msgstr "Najděte v aplikaci <app>Kupfer</app> nějaký objekt"
 
@@ -551,12 +546,10 @@ msgstr ""
 "získají e-mailové adresy z oblíbených."
 
 #: C/plugin-calculator.page:7(desc)
-#| msgid "Calculator Plugin"
 msgid "Using the calculator plugin."
 msgstr "Používání zásuvného modulu Kalkulačka."
 
 #: C/plugin-calculator.page:10(app)
-#| msgid "Calculator Plugin"
 msgid "Calculator"
 msgstr "Kalkulačka"
 
@@ -591,11 +584,6 @@ msgid "Press <key>Return</key> to get the result."
 msgstr "Zmáčkněte <key>Enter</key> a obdržíte výsledek"
 
 #: C/plugin-calculator.page:38(p)
-#| msgid ""
-#| "The Calculator uses python's math and complex math modules, and parses "
-#| "expressions as Python expressions. You may use common mathematical "
-#| "functions, such as sqrt, sin, exp and log; the command <cmd>=help</cmd> "
-#| "will show a list of all defined functions and constants."
 msgid ""
 "The Calculator uses python's math and complex math modules, and parses "
 "expressions as Python expressions. You may use common mathematical "
@@ -610,9 +598,6 @@ msgstr ""
 "funkcí a konstant."
 
 #: C/plugin-calculator.page:47(p)
-#| msgid ""
-#| "Notice that the power operator in Python is double stars, for example "
-#| "=3**3 will evaluate to 27."
 msgid ""
 "Notice that the power operator in Python is double stars, for example "
 "<code>=3**3</code> will evaluate to 27."
@@ -639,6 +624,14 @@ msgstr ""
 "Poslední výsledek je uchován pod názvem _ (podtržítko, stejně jako v konzole "
 "Python)."
 
+#: C/plugin-calculator.page:65(p)
+msgid ""
+"The Calculator lets you also calculate expression without \"=\" on the "
+"beginning as long it have inside one of operators: +, -, *, /, ^, |, , ~."
+msgstr ""
+"Kalkulačka umožňuje vypočítat výraz i bez znaku „=“ na začátku, stačí když "
+"obsahuje jeden z operátorů: +, -, *, /, ^, |, , ~."
+
 #: C/plugin-applications.page:7(desc)
 msgid "Using the applications plugin."
 msgstr "Používání zásuvného modulu Aplikace."
@@ -648,7 +641,6 @@ msgid "Applications"
 msgstr "Aplikace"
 
 #: C/plugin-applications.page:13(title)
-#| msgid "Calculator Plugin"
 msgid "Applications Plugin"
 msgstr "Zásuvný modul Aplikace"
 
@@ -674,7 +666,6 @@ msgid "Opening a file with a specific application"
 msgstr "Otevření souboru pomocí zadané aplikace"
 
 #: C/plugin-applications.page:36(p)
-#| msgid "Introduction to <app>Kupfer</app>."
 msgid "Select a file in <app>Kupfer</app>"
 msgstr "V aplikaci <app>Kupfer</app> vyberte soubor"
 
@@ -715,7 +706,6 @@ msgid "Selecting default application for a file type or folders"
 msgstr "Výběr výchozí aplikace pro typ souboru a složky"
 
 #: C/plugin-applications.page:66(p)
-#| msgid "Introduction to <app>Kupfer</app>."
 msgid "Select a file or folder in <app>Kupfer</app>"
 msgstr "V aplikaci <app>Kupfer</app> vyberte soubor nebo složku"
 
@@ -734,7 +724,6 @@ msgstr ""
 "něm vyberte aplikaci, pomocí níž se má soubor vždy otevírat."
 
 #: C/plugin-applications.page:85(title)
-#| msgid "Configuration files and paths"
 msgid "Configuration"
 msgstr "Nastavení"
 
@@ -757,12 +746,10 @@ msgid "More advanced usage information."
 msgstr "Další pokročilé informace o používání."
 
 #: C/moreusage.page:10(title)
-#| msgid "Using <app>Kupfer</app> plugins."
 msgid "Using <app>Kupfer</app> in Depth"
 msgstr "Použití aplikace <app>Kupfer</app> do hloubky"
 
 #: C/moreusage.page:13(title)
-#| msgid "Adding your actions and scripts"
 msgid "Adding Applications and Scripts"
 msgstr "Přidávání aplikací a skriptů"
 
@@ -775,11 +762,6 @@ msgstr ""
 "nastavené jako viditelné ve vašem editoru nabídky."
 
 #: C/moreusage.page:18(p)
-#| msgid ""
-#| "If you want to add a custom application, or an application called with "
-#| "special options, you can create a new launcher for it and place it in one "
-#| "of the standard places for applications, for example <file>~/.local/share/"
-#| "applications</file>, where <app>Kupfer</app> will find it."
 msgid ""
 "If you want to add an application manually, you can create a new <code>."
 "desktop</code> file and place it in one of the standard directories for "
@@ -897,7 +879,6 @@ msgstr ""
 "aplikaci Kupfer; článek je v angličtině)."
 
 #: C/moreusage.page:80(title)
-#| msgid "Grab current selection"
 msgid "Grab Current Selection"
 msgstr "Zachytávání aktuálního výběru"
 
@@ -924,7 +905,6 @@ msgid "See <link xref=\"keyboard\"/>"
 msgstr "Viz <link xref=\"keyboard\"/>"
 
 #: C/moreusage.page:94(title)
-#| msgid "Command line connection"
 msgid "Command-line Connection"
 msgstr "Napojení na příkazový řádek"
 
@@ -937,10 +917,6 @@ msgstr ""
 "app>, pokud již běží, pokud neběží, tak ji spustí."
 
 #: C/moreusage.page:99(p)
-#| msgid ""
-#| "For example, if you are using the shell in a directory where you have a "
-#| "file called \"report.pdf\", you can focus this file in <app>Kupfer</app> "
-#| "by running <cmd>kupfer report.pdf</cmd>."
 msgid ""
 "The command <cmd>kupfer</cmd> can be used to send files or text from the "
 "command-line to <app>Kupfer</app>. For example, if you are using the shell "
@@ -1045,7 +1021,6 @@ msgstr ""
 "již běžela aplikace Kupfer)."
 
 #: C/managing-plugins.page:7(desc)
-#| msgid "Introduction to <app>Kupfer</app>."
 msgid "Using plugins with <app>Kupfer</app>."
 msgstr "Používání zásuvných modulů v aplikaci <app>Kupfer</app>."
 
@@ -1068,7 +1043,6 @@ msgid "Configuring Plugins"
 msgstr "Nastavování zásuvných modulů"
 
 #: C/managing-plugins.page:21(title)
-#| msgid "Using <app>Kupfer</app> plugins."
 msgid "Open <app>Kupfer Preferences</app> to the Plugins tab"
 msgstr "Otevřete <app>Předvolby Kupfer</app> na kartě Zásuvné moduly"
 
@@ -1097,7 +1071,6 @@ msgstr ""
 "Zmáčknutím <key>Enter</key> jej pak otevřete."
 
 #: C/managing-plugins.page:33(p)
-#| msgid "<key>↑</key> or <keyseq><key>Shift</key><key>Space</key></keyseq>"
 msgid "Use the keyboard shortcut <keyseq><key>Ctrl</key><key>;</key></keyseq>"
 msgstr ""
 "Použijte klávesovou zkratku <keyseq><key>Ctrl</key><key>;</key></keyseq>"
@@ -1172,7 +1145,6 @@ msgstr ""
 "nebo aplikaci <app>Kupfer</app>."
 
 #: C/managing-plugins.page:79(title)
-#| msgid "Calculator Plugin"
 msgid "Installing more Plugins"
 msgstr "Instalace dalších zásuvných modulů"
 
@@ -1200,7 +1172,6 @@ msgstr ""
 "programům. Neinstalujte neověřené zásuvné moduly."
 
 #: C/managing-plugins.page:95(title)
-#| msgid "Plugins"
 msgid "Creating Plugins"
 msgstr "Vytváření zásuvných modulů"
 
@@ -1320,7 +1291,6 @@ msgstr ""
 "podmínek, které si zvolíte, bez dalších omezení."
 
 #: C/keyboard.page:7(desc)
-#| msgid "Global Keyboard Shortcuts"
 msgid "Complete keyboard shortcuts reference."
 msgstr "Úplný přehled klávesových zkratek."
 
@@ -1333,7 +1303,6 @@ msgid "Keyboard Interface"
 msgstr "Obsluha z klávesnice"
 
 #: C/keyboard.page:14(p)
-#| msgid "In command mode, some keystrokes have special meanings:"
 msgid "In command mode, the following keystrokes have special meanings:"
 msgstr "V příkazovém režimu mají následující klávesy speciální význam:"
 
@@ -1419,9 +1388,6 @@ msgid "Additionally:"
 msgstr "Navíc:"
 
 #: C/keyboard.page:72(p) C/generalusage.page:66(p)
-#| msgid ""
-#| "Additionally, the key <key>Return</key> activates the current selection: "
-#| "the command is executed. <key>Escape</key> clears the current selection."
 msgid ""
 "<key>Return</key> activates the current selection: the command is executed."
 msgstr "<key>Enter</key> aktivuje aktuální výběr: příkaz je proveden."
@@ -1447,7 +1413,6 @@ msgstr ""
 "<app>Předvolbách Kupfer</app>."
 
 #: C/keyboard.page:86(title)
-#| msgid "Global Keyboard Shortcuts"
 msgid "Kupfer's Keyboard Shortcuts"
 msgstr "Klávesové zkratky aplikace Kupfer"
 
@@ -1551,7 +1516,6 @@ msgid "Show Help"
 msgstr "Zobrazit nápovědu"
 
 #: C/keyboard.page:139(title)
-#| msgid "Additional Keyboard Shortcuts"
 msgid "How to configure a keyboard shortcut"
 msgstr "Jak nastavit klávesové zkratky"
 
@@ -1600,7 +1564,6 @@ msgid "Space"
 msgstr "Mezerník"
 
 #: C/keyboard.page:175(p)
-#| msgid "Introduction to <app>Kupfer</app>."
 msgid "Show/hide <app>Kupfer</app>"
 msgstr "Zobrazit/skrýt aplikaci <app>Kupfer</app>"
 
@@ -1613,7 +1576,6 @@ msgid "Show <app>Kupfer</app> with 'Selection' object focused"
 msgstr "Zobrazit aplikaci <app>Kupfer</app> se zaměřeným objektem „Výběr“"
 
 #: C/keyboard.page:183(title)
-#| msgid "Global Keyboard Shortcuts"
 msgid "How to configure a global keyboard shortcut"
 msgstr "Jak nastavit globální klávesové zkratky"
 
@@ -1669,9 +1631,6 @@ msgid "Introduction"
 msgstr "Úvod"
 
 #: C/introduction.page:12(p)
-#| msgid ""
-#| "<app>Kupfer</app> is to the largest part a keyboard-managed interface to "
-#| "applications and documents."
 msgid ""
 "<app>Kupfer</app> is an interface for quick and convenient access to "
 "applications and their documents."
@@ -1700,9 +1659,6 @@ msgstr ""
 "<em>jako při zábavě</em> a zároveň <em>odlišně</em>."
 
 #: C/introduction.page:26(p)
-#| msgid ""
-#| "For more information about <app>Kupfer</app>, visit its <link href="
-#| "\"http://kaizer.se/wiki/kupfer/\">homepage</link>."
 msgid ""
 "For up-to-date information about <app>Kupfer</app>, visit its <link href="
 "\"http://kaizer.se/wiki/kupfer/\">homepage</link>."
@@ -1731,7 +1687,6 @@ msgid "Creative Commons Share Alike 3.0"
 msgstr "Creative Commons Share Alike 3.0"
 
 #: C/index.page:21(title)
-#| msgid "Kupfer manual"
 msgid "Kupfer Manual"
 msgstr "Příručka aplikace Kupfer"
 
@@ -1744,7 +1699,6 @@ msgid "About Specific Plugins"
 msgstr "O konkrétních zásuvných modulech"
 
 #: C/generalusage.page:7(desc)
-#| msgid "Introduction to <app>Kupfer</app>."
 msgid "How to start using <app>Kupfer</app>."
 msgstr "Jak začít používat aplikaci <app>Kupfer</app>."
 
@@ -1778,7 +1732,6 @@ msgid "In command mode, some keystrokes have special meanings:"
 msgstr "V příkazovém režimu mají některé klávesy speciální význam:"
 
 #: C/generalusage.page:71(p)
-#| msgid "<key>↑</key> or <keyseq><key>Shift</key><key>Space</key></keyseq>"
 msgid ""
 "By default you show <app>Kupfer</app> using the global keyboard shortcut "
 "<keyseq><key>Ctrl</key><key>Space</key></keyseq>."
@@ -1821,13 +1774,6 @@ msgstr ""
 "Jedná se například o dokumenty nebo programy."
 
 #: C/generalusage.page:96(p)
-#| msgid ""
-#| "Objects in the catalog that have content, like folders, are marked with "
-#| "an arrow. Pressing <key>right-arrow</key> will enter these objects. Much "
-#| "of the catalog is composed of subcatalogs; plugin subcatalogs do in "
-#| "general list objects that are also available directly from the top level. "
-#| "Subcatalogs can be used for a narrower view or search scope, when using "
-#| "Kupfer."
 msgid ""
 "Objects in the catalog that have content, like folders, are marked with an "
 "arrow. Pressing <key>→</key> will enter these objects. Much of the catalog "
@@ -1843,9 +1789,6 @@ msgstr ""
 "rozsahu v aplikaci Kupfer."
 
 #: C/generalusage.page:105(p)
-#| msgid ""
-#| "Most subcatalogs update their content automatically. For example, the "
-#| "Desktop folder catalog is always uptodate."
 msgid ""
 "Most subcatalogs update their content automatically. For example, the "
 "Desktop folder source is always up-to-date."
@@ -1857,210 +1800,3 @@ msgstr ""
 #: C/index.page:0(None)
 msgid "translator-credits"
 msgstr "Marek Černocký <marek@manet.cz>"
-
-#~ msgid "Using <app>Kupfer</app> more conveniently."
-#~ msgstr "Jak používat aplikaci <app>Kupfer</app> pohodlněji."
-
-#~ msgid ""
-#~ "Kupfer listens to global shortcuts, even if Kupfer is not currently in "
-#~ "the foreground. The most important global shortcut is the shortcut to "
-#~ "show and hide Kupfer's command window which by default is "
-#~ "<keyseq><key>Ctrl</key><key>Space</key></keyseq>."
-#~ msgstr ""
-#~ "Aplikace Kupfer naslouchá globálním klávesovým zkratkám, i když není "
-#~ "zrovna v popředí. Nejdůležitější globální klávesová zkratka je ta, která "
-#~ "zobrazuje a skrývá příkazové okno aplikace kupfer a ve výchozím nastavení "
-#~ "je to <keyseq><key>Ctrl</key><key>Mezerník</key></keyseq>."
-
-#~ msgid "Global Keyboard Shortcuts are configured in Kupfer's preferences."
-#~ msgstr ""
-#~ "Globální klávesové zkratky se nastavují v předvolbách aplikace Kupfer."
-
-#~ msgid ""
-#~ "The Triggers plugin allows to configure actions to be activated by global "
-#~ "shortcuts, but triggers can only be configured in that plugin."
-#~ msgstr ""
-#~ "Zásuvný modul Spouštěče umožňuje nastavit akce, které se mají aktivovat "
-#~ "globálními klávesovými zkratkami, ale spouštěče lze v tomto zásuvném "
-#~ "modulu pouze nastavovat."
-
-#~ msgid ""
-#~ "Additional keyboard shortcuts that work with Kupfer when it is in the "
-#~ "foreground can be configured in Kupfer's preferences."
-#~ msgstr ""
-#~ "Doplňující klávesové zkratky, které fungují v aplikaci Kupfer, pokud je "
-#~ "na popředí, je možné nastavit v předvolbách aplikace Kupfer."
-
-#~ msgid ""
-#~ "Install custom plugins in the folder <file>~/.local/share/kupfer/plugins/"
-#~ "</file>"
-#~ msgstr ""
-#~ "Vlastní zásuvné moduly instalujte do <file>~/.local/share/kupfer/plugins/"
-#~ "</file>"
-
-#~ msgid ""
-#~ "Kupfer cache, config and data are located in the directories <file>~/."
-#~ "cache/kupfer</file>, <file>~/.config/kupfer</file> and <file>~/.local/"
-#~ "share/kupfer</file>."
-#~ msgstr ""
-#~ "Mezipaměť, nastavení a data aplikace Kupfer jsou uložené v <file>~/.cache/"
-#~ "kupfer</file>, <file>~/.config/kupfer</file> a <file>~/.local/share/"
-#~ "kupfer</file>."
-
-#~ msgid ""
-#~ "You can install custom plugins into ~/.local/share/kupfer/plugins; adding "
-#~ "to <app>Kupfer</app>'s object knowledge can be surprisingly easy, just "
-#~ "look at the default plugins if you want to create new."
-#~ msgstr ""
-#~ "Vlastní zásuvné moduly si můžete nainstalovat do ~/.local/share/kupfer/"
-#~ "plugins. Pokud chcete vytvořit nový zásuvný modul, stačí se podívat jak "
-#~ "vypadá výchozí a zjistíte, že postup přidávání do objektu aplikace "
-#~ "<app>Kupfer</app> je nečekaně jednoduchý."
-
-#~ msgid "Open Terminal Here"
-#~ msgstr "Otevřít terminál zde"
-
-#~ msgid ""
-#~ "Open terminal first calls <cmd>xdg-terminal</cmd>, then <cmd>gnome-"
-#~ "terminal</cmd>. xdg-terminal is a script to find the user's configured "
-#~ "terminal program for his/her Desktop Environment. Install <cmd>xdg-"
-#~ "terminal</cmd> if you need this (or install a symlink <em>called</em> xdg-"
-#~ "terminal)."
-#~ msgstr ""
-#~ "Otevře terminál nejdříve voláním <cmd>xdg-terminal</cmd> a potom "
-#~ "<cmd>gnome-terminal</cmd>. xdg-terminal je skript, který najde "
-#~ "uživatelovo nastavení programu terminálu pro jeho pracovní prostředí. "
-#~ "Pokud to tak potřebujete, nainstalujte <cmd>xdg-terminal</cmd> (nebo "
-#~ "vytvořte symbolický odkaz <em>nazvaný</em> xdg-terminal)."
-
-#~ msgid ""
-#~ "To use <app>Kupfer</app> like a pro, you can configure a \"Magic "
-#~ "Keybinding\" for <app>Kupfer</app>. GUI configuration is not yet "
-#~ "supported, but edit the configuration file <file>~/.config/kupfer/kupfer."
-#~ "cfg</file> to include the following:"
-#~ msgstr ""
-#~ "Abyste používali aplikaci <app>Kupfer</app> jako profesionál, můžete si "
-#~ "pro ni nastavit „magické klávesové zkratky“. Nastavení v grafickém "
-#~ "prostředí zatím není podporováno, ale můžete upravit soubor nastavení "
-#~ "<file>~/.config/kupfer/kupfer.cfg</file>, tak že do něj vložíte "
-#~ "následující:"
-
-#~ msgid ""
-#~ "\n"
-#~ "[Kupfer]\n"
-#~ "keybinding = &lt;Control&gt;space\n"
-#~ "magickeybinding = &lt;Ctrl&gt;&lt;Alt&gt;space\n"
-#~ "  "
-#~ msgstr ""
-#~ "\n"
-#~ "[Kupfer]\n"
-#~ "keybinding = &lt;Control&gt;space\n"
-#~ "magickeybinding = &lt;Ctrl&gt;&lt;Alt&gt;space\n"
-#~ "  "
-
-#~ msgid ""
-#~ "Now, pressing <keyseq><key>Ctrl</key><key>Alt</key><key>Space</key></"
-#~ "keyseq> will summon <app>Kupfer</app> with the current selection in "
-#~ "focus. Make sure you have installed <app>Kupfer</app>'s nautilus plugin, "
-#~ "then both the currently selected file in Nautilus, or the currently "
-#~ "selected text in the front application will be selected."
-#~ msgstr ""
-#~ "Nyní stisknutí <keyseq><key>Ctrl</key><key>Alt</key><key>Mezerník</key></"
-#~ "keyseq> bude aplikace <app>Kupfer</app> zavolána s aktuálním výběrem v "
-#~ "zaměření. Ujistěte se, že máte nainstalovaný zásuvný modul <app>Kupfer</"
-#~ "app> pro Nautilus, takže potom může být vybrán jak právě vybraný soubor "
-#~ "ve správci souborů Nautilus, tak právě vybraný text v aktivní aplikaci."
-
-#~ msgid ""
-#~ "Now you can select a word in, say, a web browser, use <keyseq><key>Ctrl</"
-#~ "key><key>Alt</key><key>Space</key></keyseq>, and select action <gui>Look "
-#~ "Up</gui> to look up the selected word. Or select an image file, use "
-#~ "<keyseq><key>Ctrl</key><key>Alt</key><key>Space</key></keyseq>, select "
-#~ "action <gui>Scale</gui> with object <gui>1000</gui> to scale the image to "
-#~ "1000 pixels wide!"
-#~ msgstr ""
-#~ "Nyní můžete vybrat nějaké slovo, řekněme ve webovém prohlížeči, použít "
-#~ "<keyseq><key>Ctrl</key><key>Alt</key><key>Mezerník</key></keyseq> a "
-#~ "vybrat akci <gui>Vyhledat</gui> k vyhledání vybraného slova. Nebo vybrat "
-#~ "nějaký soubor s obrázkem, použít <keyseq><key>Ctrl</key><key>Alt</"
-#~ "key><key>Mezerník</key></keyseq> a vybrat akci <gui>Změnit měřítko</gui> "
-#~ "s objektem <gui>1000</gui> ke změně velikosti obrázku na 1000 pixelů na "
-#~ "šířku."
-
-#~ msgid ""
-#~ "An example useful script is <link href=\"http://kaizer.se/wiki/code/"
-#~ "rhrating.py/\"> here</link> which changes the rating of <app>Rhythmbox</"
-#~ "app>'s currently playing song; I have added five scriptlets calling "
-#~ "<file>rhrating.py</file> with numbers from 0 to 5 to my catalog to "
-#~ "quickly rate tracks. (This is something that might be integrated into "
-#~ "<app>Kupfer</app> later)"
-#~ msgstr ""
-#~ "<link href=\"http://kaizer.se/wiki/code/rhrating.py/\">Zde</link> je "
-#~ "ukázkový příklad skriptu, který mění hodnocení skladby právě přehrávané v "
-#~ "aplikaci <app>Rhythmbox</app>. Když si přidáte pět skriptů nazvaných "
-#~ "<file>rhrating.py</file> s čísly od 0 do 5 do svého katalogu, můžete "
-#~ "rychle hodnotit skladby. (Jedná se o něco, co může být do aplikace "
-#~ "<app>Kupfer</app> později zaintegrováno.)"
-
-#~ msgid ""
-#~ "<app>Kupfer</app> is its own remote control. When <app>Kupfer</app> is "
-#~ "already running, <app>Kupfer</app> on the command-line will focus its "
-#~ "window, but there is more you can do: If you invoke <cmd><app>kupfer</"
-#~ "app><var>QUERY</var></cmd> where <var>QUERY</var> is a text string or a "
-#~ "filename, <app>Kupfer</app> will focus, and select this item. This way, "
-#~ "you can quickly invoke <app>Kupfer</app> actions even on objects from a "
-#~ "shell-based context."
-#~ msgstr ""
-#~ "Aplikace <app>Kupfer</app> dělá dálkové ovládání sama sobě. Když aplikace "
-#~ "<app>Kupfer</app> již běží, předá při spuštění programu <app>Kupfer</app> "
-#~ "na příkazovém řádku zaměření svému oknu, ale umí i další věci: Když "
-#~ "vyvoláte <cmd><app>kupfer</app> <var>DOTAZ</var></cmd>, kde <var>DOTAZ</"
-#~ "var> je textový řetězec nebo název souboru, aplikace <app>Kupfer</app> "
-#~ "získá zaměření a vybere tuto položku. Tímto způsobem můžete rychle "
-#~ "vyvolat akce aplikace <app>Kupfer</app> i pro objekty z kontextu "
-#~ "vycházejícího z shellu."
-
-#~ msgid ""
-#~ "You can also pipe the output of a command into <app>Kupfer</app> to send "
-#~ "text to the already running instance of <app>Kupfer</app>."
-#~ msgstr ""
-#~ "Můžete také použít na výstupu příkazu rouru napojenou na program "
-#~ "<app>Kupfer</app> a tak poslat text do již běžící instance aplikace "
-#~ "<app>Kupfer</app>."
-
-#~ msgid "Legal Information."
-#~ msgstr "právní informace"
-
-#~ msgid ""
-#~ "<app>Kupfer</app> is a program to change, speed up and make everything "
-#~ "about files and programs more fun on your computer. <app>Kupfer</app> is "
-#~ "a launcher; you typically use it to summon an application or a document "
-#~ "quickly by typing parts of its name. It can also do more than getting at "
-#~ "something quickly: there are different plugins for accessing more objects "
-#~ "and running custom commands."
-#~ msgstr ""
-#~ "<app>Kupfer</app> je program sloužící ke změnám, zrychlení práce a "
-#~ "provádění všeho možného se soubory a programy na vašem počítači a to vše "
-#~ "zábavnějším způsobem. <app>Kupfer</app> je spouštěč, který typicky "
-#~ "použijete k rychlému vyvolání aplikace nebo dokumentu tak, že začnete "
-#~ "psát jeho název. Umí toho ale víc, než jen rychlý přístup k souboru. Jsou "
-#~ "zde různé zásuvné moduly pro přístup k dalším objektům a spouštění "
-#~ "vlastních příkazů."
-
-#~ msgid ""
-#~ "<app>Kupfer</app> is written using Python and has a flexible "
-#~ "architecture; the implementation is simple and makes the easy things work "
-#~ "first. One goal is that new plugins can be written quickly without too "
-#~ "much programming."
-#~ msgstr ""
-#~ "Aplikace <app>Kupfer</app> je napsána v jazyce Python a má flexibilní "
-#~ "architekturu. Provedení je jednoduché a věci prostě pracují na poprvé. "
-#~ "Jedním z cílů je, aby šli rychle, bez zdlouhavého programování, psát nové "
-#~ "zásuvné moduly."
-
-#~ msgid ""
-#~ "The program is very inspired by <link href=\"http://www.blacktree.com/"
-#~ "\">Quicksilver</link>."
-#~ msgstr ""
-#~ "Program je silně inspirován aplikací <link href=\"http://www.blacktree."
-#~ "com/\">Quicksilver</link>."

--- a/help/el/el.po
+++ b/help/el/el.po
@@ -1,0 +1,1859 @@
+# Greek translation for kupfer.
+# Copyright (C) 2014 kupfer's COPYRIGHT HOLDER
+# This file is distributed under the same license as the kupfer package.
+# MarMav <mavridou@gmail.com>, 2014.
+# Dimitris Spingos (Δημήτρης Σπίγγος) <dmtrs32@gmail.com>, 2014.
+msgid ""
+msgstr ""
+"Project-Id-Version: kupfer master\n"
+"POT-Creation-Date: 2014-04-07 21:56+0000\n"
+"PO-Revision-Date: 2014-04-08 11:03+0300\n"
+"Last-Translator: Dimitris Spingos (Δημήτρης Σπίγγος) <dmtrs32@gmail.com>\n"
+"Language-Team: team@lists.gnome.gr\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Virtaal 0.7.0\n"
+
+#: C/plugin-websearch.page:7(desc)
+msgid "Using the search the web plugin."
+msgstr "Χρησιμοποιώντας το πρόσθετο αναζήτησης στον ιστό."
+
+#: C/plugin-websearch.page:10(app)
+msgid "Search the Web"
+msgstr "Αναζήτηση στον ιστό"
+
+#: C/plugin-websearch.page:13(title) C/plugin-triggers.page:23(title)
+#: C/plugin-notes.page:22(title) C/plugin-nautilusselection.page:13(title)
+#: C/plugin-gwibber.page:25(title) C/plugin-favorites.page:22(title)
+#: C/plugin-calculator.page:21(title) C/plugin-applications.page:19(title)
+#: C/generalusage.page:10(title)
+msgid "Basic Usage"
+msgstr "Βασική χρήση"
+
+#: C/plugin-websearch.page:15(p)
+msgid "Activate Kupfer and make sure it is in free-text mode (press period)"
+msgstr ""
+"Ενεργοποιήστε το Kupfer και βεβαιωθείτε ότι βρίσκεται σε λειτουργία "
+"ελεύθερου κειμένου (πατήστε το πλήκτρο της τελείας)"
+
+#: C/plugin-websearch.page:17(p)
+msgid ""
+"Type in a search query and tap <key>Tab</key> to switch to the action pane."
+msgstr ""
+"Πληκτρολογήστε ένα ερώτημα αναζήτησης και πατήστε <key>Tab</key> για να "
+"μεταβείτε στο ενεργό παράθυρο."
+
+#: C/plugin-websearch.page:19(p)
+msgid ""
+"Type \"Search With\" to find Search the Web's action and tap <key>Tab</key> "
+"again to switch to the third pane (indirect object)."
+msgstr ""
+"Πληκτρολογήστε \"Αναζήτηση με\" για να βρείτε τη καρτέλα αναζήτηση στον ιστό "
+"και επιλέξτε <key>Tab</key> ξανά για να μεταβείτε στο τρίτο παράθυρο (έμμεσο "
+"αντικείμενο)."
+
+#: C/plugin-websearch.page:22(p)
+msgid ""
+"Select search engine with the arrow keys and type <key>Return</key> to open "
+"the search in a web browser."
+msgstr ""
+"Επιλέξτε τη μηχανή αναζήτησης με τα βελάκια και πληκτρολογήστε "
+"<key>Επιστροφή</key> για να ανοίξετε την αναζήτηση σε έναv περιηγητή ιστού."
+
+#: C/plugin-websearch.page:29(title)
+msgid "Search Engines"
+msgstr "Μηχανές Αναζήτησης"
+
+#: C/plugin-websearch.page:30(p)
+msgid ""
+"The Search the Web plugin uses <app>Firefox'</app> search engines, so you "
+"can add Search Engines directly in <app>Firefox</app> and <app>Kupfer</app> "
+"will find them later."
+msgstr ""
+"Το πρόσθετο αναζήτηση στον ιστό χρησιμοποιεί μηχανές αναζήτησης του "
+"<app>Firefox'</app>, έτσι ώστε να μπορείτε να προσθέσετε μηχανές αναζήτησης "
+"άμεσα και να τις βρείτε αργότερα στο <app>Firefox</app> και το <app>Kupfer</"
+"app>."
+
+#: C/plugin-websearch.page:35(p)
+msgid ""
+"You can also install custom search plugins directly, only for <app>Kupfer</"
+"app>, in the folder:"
+msgstr ""
+"Μπορείτε επίσης να εγκαταστήσετε προσαρμοσμένα πρόσθετα αναζήτησης άμεσα, "
+"μόνο για το <app>Kupfer</app>, στο φάκελο:"
+
+#: C/plugin-websearch.page:39(code)
+#, no-wrap
+msgid "~/.local/share/kupfer/searchplugins/"
+msgstr "~/.local/share/kupfer/searchplugins/"
+
+#: C/plugin-websearch.page:40(p)
+msgid "The search engine descriptions must written in OpenSearch format."
+msgstr ""
+"Οι περιγραφές των μηχανών αναζήτησης πρέπει να έχουν γραφτεί σε μορφή "
+"OpenSearch."
+
+#: C/plugin-triggers.page:7(desc)
+msgid "Using the triggers plugin."
+msgstr "Χρησιμοποιώντας το πρόσθετο εναύσματα."
+
+#: C/plugin-triggers.page:10(app) C/keyboard.page:213(title)
+msgid "Triggers"
+msgstr "Εναύσματα"
+
+#: C/plugin-triggers.page:13(title)
+msgid "Triggers Plugin"
+msgstr "Προσθετο Εναύσματα"
+
+#: C/plugin-triggers.page:14(p)
+msgid ""
+"With <app>Triggers</app> you can take a command you would normally perform "
+"in <app>Kupfer</app>, such as launching an application or opening a "
+"document, and bind a global key combination to run this command. As long as "
+"<app>Kupfer</app> is running, any application can have the current focus."
+msgstr ""
+"Με τα <app>Εναύσματα</app> μπορείτε να πάρετε μια εντολή που θα εκτελούσατε "
+"κανονικά στο <app>Kupfer</app>, όπως την εκκίνηση μιας εφαρμογής ή το "
+"άνοιγμα ενός εγγράφου, και να δεσμεύσετε ένα γενικό συνδυασμό πλήκτρων για "
+"να εκτελέσετε αυτήν την εντολή. Για όσο το <app>Kupfer</app> εκτελείται, "
+"οποιαδήποτε εφαρμογή μπορεί να έχει την τρέχουσα εστίαση."
+
+#: C/plugin-triggers.page:25(title)
+msgid "Creating a new trigger"
+msgstr "Δημιουργία ενός νέου εναύσματος"
+
+#: C/plugin-triggers.page:27(p)
+msgid "Set up a command in <app>Kupfer</app> that you want to run"
+msgstr "Ρύθμιση μιας εντολής στο <app>Kupfer</app> που θέλετε να εκτελέσετε"
+
+#: C/plugin-triggers.page:32(p)
+msgid ""
+"Press <keyseq><key>Ctrl</key><key>Return</key></keyseq> to create a "
+"<em>composed command</em>."
+msgstr ""
+"Πατήστε <keyseq><key>Ctrl</key><key>Επιστροφή</key></keyseq> για να "
+"δημιουργήσετε μια <em>Εντολή σύνθεσης</em>."
+
+#: C/plugin-triggers.page:38(p)
+msgid ""
+"Type <key>Tab</key> and select the action <em>Add Trigger...</em> and press "
+"<key>Return</key>"
+msgstr ""
+"Πατήστε <key>Tab</key> και επιλέξτε την ενέργεια <em>Προσθήκη εναύσματος...</"
+"em> και πιέστε <key>Επιστροφή</key>"
+
+#: C/plugin-triggers.page:44(p)
+msgid ""
+"Using the window that appears, press modifier keys and a letter or number "
+"key to set a global shortcut. An example is pressing and holding "
+"<keyseq><key>Ctrl</key><key>Alt</key></keyseq> and then pressing and "
+"releasing <key>R</key> to bind <keyseq><key>Ctrl</key><key>Alt</key><key>R</"
+"key></keyseq>."
+msgstr ""
+"Χρησιμοποιώντας το παράθυρο που εμφανίζεται, πατήστε τα πλήκτρα τροποποίησης "
+"και ένα γράμμα ή αριθμό για να ορίσετε μια γενική συντόμευση. Για παράδειγμα "
+"πατώντας και κρατώντας πατημένα τα <keyseq><key>Ctrl</key><key>Alt</key></"
+"keyseq> και, στη συνέχεια, πιέζοντας και αφήνοντας το <key>R</key> "
+"δεσμεύονται τα <keyseq><key>Ctrl</key><key>Alt</key><key>R</key></keyseq>."
+
+#: C/plugin-triggers.page:54(title)
+msgid "Removing a trigger"
+msgstr "Αφαίρεση εναύσματος"
+
+#: C/plugin-triggers.page:56(p)
+msgid ""
+"Find the source <em>Triggers</em> in <app>Kupfer</app> and press <key>→</"
+"key> to see its contents."
+msgstr ""
+"Βρείτε τα πηγαία <em>Εναύσματα</em> στο <app>Kupfer</app> και πιέστε <key>→</"
+"key> για να δείτε τα περιεχόμενά του."
+
+#: C/plugin-triggers.page:62(p)
+msgid ""
+"Find the active trigger in the list and use the action <em>Remove Trigger</"
+"em>."
+msgstr ""
+"Βρείτε το ενεργό έναυσμα στον κατάλογο και χρησιμοποιήσετε την ενέργεια "
+"<em>Αφαίρεση εναύσματος</em>."
+
+#: C/plugin-triggers.page:68(p)
+msgid ""
+"Since trigger keyboard shortcuts are global, they can be used from any "
+"application. Select shortcuts with care so that they do not conflict with "
+"other functions."
+msgstr ""
+"Δεδομένου ότι οι συντομεύσεις πληκτρολογίου των εναυσμάτων είναι γενικές, "
+"μπορούν να χρησιμοποιηθούν από οποιαδήποτε εφαρμογή. Επιλέξτε συντομεύσεις "
+"με προσοχή έτσι ώστε να μην έρχονται σε διένεξη με άλλες λειτουργίες."
+
+#: C/plugin-triggers.page:74(title) C/plugin-notes.page:60(title)
+#: C/plugin-gwibber.page:68(title) C/plugin-favorites.page:38(title)
+msgid "Power User Tips"
+msgstr "Συμβουλές για έμπειρους χρήστες"
+
+#: C/plugin-triggers.page:75(p)
+msgid ""
+"<em>Proxy objects</em> such as <em>Selected Text</em>, <em>Selected File</"
+"em>, <em>Frontmost Window</em>, <em>Last Command</em> et cetera allow very "
+"powerful triggers."
+msgstr ""
+"<em>Αντικείμενα μεσολάβησης</em> όπως <em>Eπιλεγμένο κείμενο</em>, "
+"<em>Επιλεγμένο αρχείο</em>, <em>Το πιο μπροστινό παράθυρο</em>, "
+"<em>Τελευταία εντολή</em> κ.λπ. επιτρέπουν τη χρήση πολύ ισχυρών εναυσμάτων."
+
+#: C/plugin-triggers.page:79(p)
+msgid ""
+"The application action <em>Launch</em> is special; if you bind a trigger "
+"using <em>Launch</em>, it will start the application if it is not running, "
+"but focus the application when it is already running. By contrast, <em>Start "
+"Again</em> will start the application if it is running or not."
+msgstr ""
+"Η χρήση της εφαρμογής <em>Εκκίνηση</em> είναι ειδική: εαν δευσμεύσετε ένα "
+"έναυσμα με την <em>Εκκίνηση</em>, θα ξεκινήσει η εφαρμογή, εάν δεν "
+"εκτελείται, αλλά θα εστιάσει στην εφαρμογή όταν εκτελείται ήδη. Αντίθετα, η "
+"<em>Έναρξη εκ νέου</em> θα ξεκινήσει την εφαρμογή είτε βρίσκεται σε "
+"λειτουργία είτε όχι."
+
+#: C/plugin-triggers.page:87(title)
+msgid "Example Triggers"
+msgstr "Παράδειγμα εναυσμάτων"
+
+#: C/plugin-triggers.page:90(em)
+msgid "Text Editor → Launch"
+msgstr "Επεξεργαστής κειμένου → Εκκίνηση"
+
+#: C/plugin-triggers.page:91(p)
+msgid ""
+"Start <em>Text Editor</em> or focus its window if it is already running."
+msgstr ""
+"Ξεκινήστε τον <em>Επεξεργαστή κειμένου</em> ή εστιάστε στο παράθυρό του, εάν "
+"είναι ήδη σε λειτουργία."
+
+#: C/plugin-triggers.page:97(em)
+msgid "Selected Text → Search With → Google"
+msgstr "Επιλεγμένο Κείμενο → Αναζήτηση με → Google"
+
+#: C/plugin-triggers.page:98(p)
+msgid "Search the web using the currently selected text."
+msgstr "Αναζήτηση στο διαδίκτυο χρησιμοποιώντας το επιλεγμένο κείμενο."
+
+#: C/plugin-triggers.page:100(em)
+msgid "Selected File → Move To → (Downloads Folder)"
+msgstr "Επιλεγμένο αρχείο → Μετακίνηση σε → (Φάκελος λήψεων)"
+
+#: C/plugin-triggers.page:101(p)
+msgid "Move the currently selected file to a specific folder"
+msgstr "Μετακινήστε το επιλεγμένο αρχείο σε ένα συγκεκριμένο φάκελο"
+
+#: C/plugin-triggers.page:105(em)
+msgid "Songs → Search Contents"
+msgstr "Τραγούδια → Αναζήτηση περιεχομένων"
+
+#: C/plugin-triggers.page:106(p)
+msgid ""
+"You may even add a trigger to open a specific subcatalog in Kupfer, for "
+"example Rhythmbox's songs."
+msgstr ""
+"Μπορείτε να προσθέσετε ακόμη και ένα έναυσμα για να ανοίξει ένα συγκεκριμένο "
+"υποκατάλογο στο Kupfer, για παράδειγμα, τα τραγούδια του Rhythmbox."
+
+#: C/plugin-notes.page:7(desc)
+msgid "Using the notes plugin."
+msgstr "Χρησιμοποιώντας το πρόσθετο σημειώσεις."
+
+#: C/plugin-notes.page:10(app) C/plugin-calculator.page:37(title)
+msgid "Notes"
+msgstr "Σημειώσεις"
+
+#: C/plugin-notes.page:13(title)
+msgid "Notes Plugin"
+msgstr "Πρόσθετο Σημειώσεις"
+
+#: C/plugin-notes.page:14(p)
+msgid ""
+"With <app>Notes</app> you can access or create new notes in either the "
+"program <app>Gnote</app> or <app>Tomboy</app>. <app>Notes</app> will work "
+"identically with either application—you can configure which one to use in "
+"the plugin's information pane in <app>Kupfer Preferences</app>."
+msgstr ""
+"Με το πρόσθετο <app>Σημειώσεις</app> μπορείτε να έχετε πρόσβαση ή να "
+"δημιουργήσετε νέες σημειώσεις είτε στο πρόγραμμα <app>Gnote</app> ή στο "
+"<app>Tomboy</app>. Το <app>Σημειώσεις</app> θα λειτουργήσει με τον ίδιο "
+"τρόπο και με τις δύο εφαρμογές: μπορείτε να ρυθμίσετε ποια να χρησιμοποιηθεί "
+"στο τμήμα πληροφοριών των πρόσθετων στο <app>Προτιμήσεις Kupfer</app>."
+
+#: C/plugin-notes.page:24(title)
+msgid "Creating a new note"
+msgstr "Δημιουργία νέας σημείωσης"
+
+#: C/plugin-notes.page:26(p)
+msgid ""
+"Activate Kupfer and type <key>.</key> to enter text mode, then type in a "
+"note title"
+msgstr ""
+"Ενεργοποιήστε το Kupfer και πληκτρολογήστε <key>.</key> για να εισέλθετε σε "
+"λειτουργία κειμένου, στη συνέχεια, πληκτρολογήστε έναν τίτλο σημείωσης"
+
+#: C/plugin-notes.page:32(p)
+msgid ""
+"Type <key>Tab</key> and select the action <em>Create Note</em> and press "
+"<key>Return</key>."
+msgstr ""
+"Πληκτρολογήστε <key>Tab</key> και επιλέξτε την ενέργεια <em>Δημιουργία "
+"Σημείωσης</em> και πιέστε <key>Επιστροφή</key>."
+
+#: C/plugin-notes.page:39(title)
+msgid "Finding a note by title"
+msgstr "Βρίσκοντας μια σημείωση από τον τίτλο"
+
+#: C/plugin-notes.page:41(p)
+msgid "Simply search for the note title in <app>Kupfer</app>"
+msgstr "Απλά κάνετε αναζήτηση στο <app>Kupfer</app> για τον τίτλο σημείωσης"
+
+#: C/plugin-notes.page:45(title)
+msgid "Finding a note by content"
+msgstr "Βρίσκοντας μια σημείωση από τον το περιεχόμενο"
+
+#: C/plugin-notes.page:47(p)
+msgid ""
+"Activate Kupfer and type <key>.</key> to enter text mode, then type in a "
+"search query"
+msgstr ""
+"Ενεργοποιήστε το Kupfer και πληκτρολογήστε <key>.</key> για να εισέλθετε στη "
+"λειτουργία κειμένου, στη συνέχεια, πληκτρολογήστε ένα ερώτημα αναζήτησης"
+
+#: C/plugin-notes.page:53(p)
+msgid ""
+"Type <key>Tab</key> and select the action <em>Get Note Search Results...</"
+"em> and press <key>Return</key>."
+msgstr ""
+"Πληκτρολογήστε <key>Tab</key> και επιλέξτε την ενέργεια <em>Λήψη "
+"αποτελεσμάτων αναζήτησης σημείωσης...</em> και πιέστε <key>Επιστροφή</key>."
+
+#: C/plugin-notes.page:63(p)
+msgid ""
+"You can use the <em>Selected Text</em> object and create a new note with the "
+"content of the selection."
+msgstr ""
+"Μπορείτε να χρησιμοποιήσετε το αντικείμενο <em>Επιλεγμένο κείμενο</em> και "
+"να δημιουργήσετε μια νέα σημείωση με το περιεχόμενο της επιλογής."
+
+#: C/plugin-nautilusselection.page:7(desc)
+msgid "Using the selected file plugin."
+msgstr "Χρησιμοποιώντας το πρόσθετο επιλεγμένου αρχείου."
+
+#: C/plugin-nautilusselection.page:10(app)
+msgid "Selected File"
+msgstr "Επιλεγμένο αρχείο"
+
+#: C/plugin-nautilusselection.page:14(p)
+msgid ""
+"Select a file in the file manager. Open <app>Kupfer</app> and search for the "
+"object <app>Selected File</app>, which represents the file or files that are "
+"selected."
+msgstr ""
+"Επιλέξτε ένα αρχείο στο διαχειριστή αρχείων. Ανοίξτε το <app>Kupfer</app> "
+"και αναζητήστε το αντικείμενο <app>Επιλεγμένο αρχείο</app>, το οποίο "
+"αντιπροσωπεύει το αρχείο ή τα αρχεία που έχουν επιλεγεί."
+
+#: C/plugin-nautilusselection.page:19(p)
+msgid ""
+"Instead of searching, you can press <keyseq><key>Ctrl</key><key>G</key></"
+"keyseq> to directly focus the selected file. See <link xref=\"keyboard\"/> "
+"for more information."
+msgstr ""
+"Αντί της αναζήτησης, μπορείτε να πατήσετε <keyseq><key>Ctrl</key><key>G</"
+"key></keyseq> για να εστιάσει άμεσα στο επιλεγμένο αρχείο. Δείτε στο <link "
+"xref=\"keyboard\"/> για περισσότερες πληροφορίες."
+
+#: C/plugin-nautilusselection.page:26(title)
+msgid "<app>Selected File</app> requires <app>Nautilus</app>"
+msgstr ""
+"Το πρόσθετο <app>Επιλεγμένο αρχείο</app> προϋποθέτει τον <app>Nautilus</app>"
+
+#: C/plugin-nautilusselection.page:27(p)
+msgid ""
+"The selected file plugin works with the <app>Nautilus</app> file browser and "
+"requires that the extension <cmd>kupfer_provider.py</cmd> is installed (it "
+"is normally installed together with <app>Kupfer</app>). After installing it "
+"for the first time, <app>Nautilus</app> must start anew before it is active."
+msgstr ""
+"Το πρόσθετο επιλεγμένο αρχείο λειτουργεί με τον περιηγητή αρχείων "
+"<app>Nautilus</app> και απαιτεί να είναι εγκατεστημένη η επέκταση "
+"<cmd>kupfer_provider.py</cmd> (εγκαθίσταται συνήθως μαζί με το <app>Kupfer</"
+"app>) . Μετά την εγκατάστασή του, για πρώτη φορά, ο <app>Nautilus</app> "
+"πρέπει να ξεκινήσει εκ νέου πριν να ενεργοποιηθεί."
+
+#: C/plugin-gwibber.page:7(desc)
+msgid "Using the Gwibber plugin."
+msgstr "Χρησιμοποιώντας το πρόσθετο Gwibber."
+
+#: C/plugin-gwibber.page:10(app)
+msgid "Gwibber"
+msgstr "Gwibber"
+
+#: C/plugin-gwibber.page:13(title)
+msgid "Gwibber Plugin"
+msgstr "Πρόσθετο Gwibber"
+
+#: C/plugin-gwibber.page:14(p)
+msgid ""
+"With the <app>Gwibber</app> plugin you can send messages to social networks "
+"such as Twitter or Identi.ca."
+msgstr ""
+"Με το πρόσθετο <app>Gwibber</app> μπορείτε να στείλετε μηνύματα σε κοινωνικά "
+"δίκτυα όπως το Twitter ή το Identi.ca."
+
+#: C/plugin-gwibber.page:18(p)
+msgid ""
+"The plugin requires that the application <app>Gwibber</app> is installed and "
+"configured for your user. <app>Kupfer</app> will start and use Gwibber's "
+"service in the background."
+msgstr ""
+"Το πρόσθετο προϋποθέτει ότι η εφαρμογή <app>Gwibber</app> έχει εγκατασταθεί "
+"και ρυθμιστεί για το δικό σας χρήστη. Το <app>Kupfer</app> θα ξεκινήσει και "
+"θα χρησιμοποιήσει την υπηρεσία Gwibber στο παρασκήνιο."
+
+#: C/plugin-gwibber.page:27(title)
+msgid "Sending a message to all services"
+msgstr "Αποστολή ενός μηνύματος σε όλες τις υπηρεσίες"
+
+#: C/plugin-gwibber.page:29(p)
+msgid ""
+"Activate Kupfer and type <key>.</key> to enter text mode, then type in a "
+"message."
+msgstr ""
+"Ενεργοποιήστε το Kupfer και πληκτρολογήστε <key>.</key> για να εισέλθετε στη "
+"λειτουργία κειμένου, στη συνέχεια, πληκτρολογήστε ένα μήνυμα."
+
+#: C/plugin-gwibber.page:35(p)
+msgid ""
+"Type <key>Tab</key> and select the action <em>Send Message</em> and press "
+"<key>Return</key>."
+msgstr ""
+"Πληκτρολογήστε <key>Tab</key> και επιλέξτε την ενέργεια <em>Αποστολή "
+"μηνύματος</em> και πιέστε <key>Επιστροφή</key>."
+
+#: C/plugin-gwibber.page:42(title)
+msgid "Sending a message to a specific service"
+msgstr "Αποστολή ενός μηνύματος σε μια συγκεκριμένη υπηρεσία"
+
+#: C/plugin-gwibber.page:44(p)
+msgid ""
+"Activate Kupfer and search for the service object, for example <em>Identi."
+"ca</em>"
+msgstr ""
+"Ενεργοποιήστε το Kupfer και αναζητήστε το αντικείμενο υπηρεσίας, για "
+"παράδειγμα, <em>Identi.ca</em>"
+
+#: C/plugin-gwibber.page:50(p)
+msgid "Type <key>Tab</key> and select the action <em>Send Message</em>."
+msgstr ""
+"Πληκτρολογήστε <key>Tab</key> και επιλέξτε την ενέργεια <em>Αποστολή "
+"μηνύματος</em>."
+
+#: C/plugin-gwibber.page:55(p)
+msgid ""
+"Type <key>Tab</key> to select the last pane, and type in a message. Press "
+"<key>Return</key> to send."
+msgstr ""
+"Πληκτρολογήστε <key>Tab</key> για να επιλέξετε το τελευταίο παράθυρο και "
+"πληκτρολογήστε ένα μήνυμα. Πατήστε <key>Επιστροφή</key> για να το στείλετε."
+
+#: C/plugin-gwibber.page:61(p)
+msgid ""
+"The plugin also provides a source for incoming messages, <em>Gwibber "
+"Messages</em> and more actions on messages such as <em>Reply</em>, <em>Send "
+"Private Message</em> etc."
+msgstr ""
+"Το πρόσθετο παρέχει επίσης μια πηγή για τα εισερχόμενα μηνύματα, "
+"<em>Μηνύματα Gwibber</em> και περισσότερες ενέργειες για μηνύματα όπως "
+"<em>Απάντηση</em>, <em>Αποστολή προσωπικού μηνύματος</em> κλπ."
+
+#: C/plugin-gwibber.page:71(p)
+msgid ""
+"You can use the <em>comma trick</em> if you want to send a message to more "
+"than one service, but not all, at the same time."
+msgstr ""
+"Μπορείτε να χρησιμοποιήσετε το <em>Τέχνασμα κόμμα</em> αν θέλετε να στείλετε "
+"ένα μήνυμα σε περισσότερες από μία υπηρεσίες, αλλά όχι σε όλες, την ίδια "
+"στιγμή."
+
+#: C/plugin-favorites.page:7(desc)
+msgid "Using the favorites plugin."
+msgstr "Χρησιμοποιώντας το πρόσθετο αγαπημένα."
+
+#: C/plugin-favorites.page:10(app)
+msgid "Favorites"
+msgstr "Αγαπημένα"
+
+#: C/plugin-favorites.page:13(title)
+msgid "Favorites Plugin"
+msgstr "Πρόσθετο αγαπημένων"
+
+#: C/plugin-favorites.page:14(p)
+msgid ""
+"With <app>Favorites</app> you mark objects, for example files, for quicker "
+"access. It is a sort of shelf on which you can store objects in Kupfer. "
+"Objects marked as favorites will also be ranked higher and are adorned with "
+"a star symbol."
+msgstr ""
+"Με το <app>Αγαπημένα</app> μαρκάρετε τα αντικείμενα, για παράδειγμα, τα "
+"αρχεία, για ταχύτερη πρόσβαση. Είναι ένα είδος ραφιού στο οποίο μπορείτε να "
+"αποθηκεύσετε αντικείμενα στο Kupfer. Αντικείμενα που χαρακτηρίζονται ως "
+"αγαπημένα θα κατατάσσονται επίσης σε υψηλότερη θέση και είναι διακοσμημένα "
+"με το σύμβολο αστέρι."
+
+#: C/plugin-favorites.page:25(p)
+msgid "Find an object in <app>Kupfer</app>"
+msgstr "Εύρεση αντικειμένου στο <app>Kupfer</app>"
+
+#: C/plugin-favorites.page:30(p)
+msgid ""
+"Type <key>Tab</key> and select either the action <em>Add to Favorites</em> "
+"or <em>Remove from Favorites</em>."
+msgstr ""
+"Πληκτρολογήστε <key>Tab</key> και επιλέξτε την ενέργεια <em>Προσθήκη στα "
+"αγαπημένα</em> ή <em>Αφαίρεση από τα αγαπημένα</em>."
+
+#: C/plugin-favorites.page:39(p)
+msgid ""
+"If you favorite an object, you can access it in more places. Not only in the "
+"\"Favorites\" subcatalog, but also as the indirect (secondary) object for "
+"some actions. For example:"
+msgstr ""
+"Αν προσθέσετε στα αγαπημένα ένα αντικείμενο, μπορείτε να έχετε πρόσβαση σε "
+"αυτό σε περισσότερα σημεία. Όχι μόνο στον υποκατάλογο \"Αγαπημένα\" , αλλά "
+"και ως έμμεσο (δευτερεύον) αντικείμενο για ορισμένες ενέργειες. Για "
+"παράδειγμα:"
+
+#: C/plugin-favorites.page:45(p)
+msgid "Command-lines from favorites are quick to access."
+msgstr "Γραμμές εντολών από τα αγαπημένα είναι άμεσα προσβάσιμα."
+
+#: C/plugin-favorites.page:46(p)
+msgid ""
+"When scaling images with the <em>Scale...</em> action from the <app>Image "
+"Tools</app> plugin. This action needs a size description as the third "
+"object, like \"1024\" or \"1200x800\". If you often scale to the same size, "
+"say \"1200x800\", add this to favorites, and it will always appear as a "
+"suggestion for the action."
+msgstr ""
+"Κλιμάκωση εικόνων με την ενέργεια <em>Κλιμάκωση...</em> από το πρόσθετο "
+"<app>Εργαλεία εικόνας</app>. Η ενέργεια αυτή χρειάζεται μια περιγραφή με το "
+"τρίτο αντικείμενο, όπως \"1024\" ή \"1200x800\". Αν έχετε συχνά κλιμάκωση "
+"στο ίδιο μέγεθος, για παράδειγμα \"1200x800\", προσθέστε την στα αγαπημένα, "
+"και θα εμφανίζεται πάντα ως προτεινόμενη για την ενέργεια."
+
+#: C/plugin-favorites.page:54(p)
+msgid ""
+"Actions needing an email address as the indirect object will pick up email "
+"addresses from favorites as well as well."
+msgstr ""
+"Ενέργειες που χρειάζονται μια διεύθυνση ηλεκτρονικού ταχυδρομείου ως έμμεσο "
+"αντικείμενο θα πάρουν επίσης τις διευθύνσεις ηλεκτρονικού ταχυδρομείου από "
+"τα αγαπημένα."
+
+#: C/plugin-calculator.page:7(desc)
+msgid "Using the calculator plugin."
+msgstr "Χρησιμοποιώντας το πρόσθετο αριθμομηχανής."
+
+#: C/plugin-calculator.page:10(app)
+msgid "Calculator"
+msgstr "Αριθμομηχανή"
+
+#: C/plugin-calculator.page:13(title)
+msgid "Calculator Plugin"
+msgstr "Πρόσθετο αριθμομηχανής"
+
+#: C/plugin-calculator.page:14(p)
+msgid ""
+"The calculator plugin lets you calculate expressions quickly. It can "
+"evaluate expressions entered as text starting with \"=\". Entering = from "
+"command mode will start text mode directly with = prefixed for quick access."
+msgstr ""
+"Το πρόσθετο αριθμομηχανής σας επιτρέπει να υπολογίσετε γρήγορα παραστάσεις. "
+"Μπορεί να αξιολογεί παραστάσεις που καταχωρούνται ως κείμενο αρχίζοντας με "
+"\"=\". Εισάγοντας = από την κατάσταση εντολών θα ξεκινήσει η λειτουργία "
+"κειμένου απευθείας με πρόθεμα = για γρήγορη πρόσβαση."
+
+#: C/plugin-calculator.page:23(p)
+msgid "Activate Kupfer and type <key>=</key>"
+msgstr "Ενεργοποιήστε το Kupfer και πληκτρολογήστε <key>=</key>"
+
+#: C/plugin-calculator.page:26(p)
+msgid ""
+"Type in a mathematical expression using <key>+</key>,<key>-</key>,<key>/</"
+"key>,<key>*</key> (and <key>**</key> for exponentiation)"
+msgstr ""
+"Πληκτρολογήστε μια μαθηματική παράσταση χρησιμοποιώντας τα <key>+</key>,"
+"<key>-</key>,<key>/</key>,<key>*</key> (και <key>**</key> για εκθέτη)"
+
+#: C/plugin-calculator.page:30(p)
+msgid "Press <key>Return</key> to get the result."
+msgstr "Πατήστε το <key>Επιστροφή</key> για να λάβετε το αποτέλεσμα."
+
+#: C/plugin-calculator.page:38(p)
+msgid ""
+"The Calculator uses python's math and complex math modules, and parses "
+"expressions as Python expressions. You may use common mathematical "
+"functions, such as <cmd>sqrt</cmd>, <cmd>sin</cmd>, <cmd>exp</cmd> and "
+"<cmd>log</cmd>; the command <cmd>=help</cmd> will show a list of all defined "
+"functions and constants."
+msgstr ""
+"Η Αριθμομηχανή χρησιμοποιεί τις ενότητες μιγαδικών μαθηματικών και python "
+"και αναλύει τις παραστάσεις ως παραστάσεις Python. Μπορείτε να "
+"χρησιμοποιήσετε κοινές μαθηματικές συναρτήσεις, όπως <cmd>sqrt</cmd>, "
+"<cmd>sin</cmd>, <cmd>exp</cmd> και <cmd>log</cmd>· η εντολή <cmd>=help</cmd> "
+"θα εμφανίσει μια λίστα με όλες τις προσδιορισμένες συναρτήσεις και σταθερές."
+
+#: C/plugin-calculator.page:47(p)
+msgid ""
+"Notice that the power operator in Python is double stars, for example "
+"<code>=3**3</code> will evaluate to 27."
+msgstr ""
+"Σημειώστε ότι ο τελεστής δύναμης στο Python είναι διπλά αστέρια, για "
+"παράδειγμα <code>=3**3</code> θα αξιολογηθεί σε 27."
+
+#: C/plugin-calculator.page:53(p)
+msgid "To calculate trig functions for angles, convert to radians first:"
+msgstr ""
+"Για να υπολογίσετε τριγωνομετρικές συναρτήσεις για τις γωνίες, μετατρέψετε "
+"πρώτα σε ακτίνια:"
+
+#: C/plugin-calculator.page:56(code)
+#, no-wrap
+msgid "sin(radians(30)) -&gt; 0.5"
+msgstr "sin(radians(30)) -&gt; 0.5"
+
+#: C/plugin-calculator.page:59(p)
+msgid ""
+"The last result is stored as the name _ (an underscore, just like in the "
+"Python console)."
+msgstr ""
+"Το τελευταίο αποτέλεσμα αποθηκεύεται ως όνομα _ (ένα χαρακτήρα υπογράμμισης, "
+"όπως ακριβώς και στην κονσόλα Python)."
+
+#: C/plugin-calculator.page:65(p)
+msgid ""
+"The Calculator lets you also calculate expression without \"=\" on the "
+"beginning as long it have inside one of operators: +, -, *, /, ^, |, &amp;, "
+"~."
+msgstr ""
+"Η Αριθμομηχανή σας επιτρέπει επίσης να υπολογίσετε μια παράσταση χωρίς \"=\" "
+"στην αρχή, εφόσον έχετε μέσα έναν από τους τελεστές: +, -, *, /, ^, |, , ~."
+
+#: C/plugin-applications.page:7(desc)
+msgid "Using the applications plugin."
+msgstr "Χρησιμοποιώντας το πρόσθετο εφαρμογές."
+
+#: C/plugin-applications.page:10(app)
+msgid "Applications"
+msgstr "Εφαρμογές"
+
+#: C/plugin-applications.page:13(title)
+msgid "Applications Plugin"
+msgstr "Πρόσθετο εφαρμογών"
+
+#: C/plugin-applications.page:14(p)
+msgid "<app>Applications</app> provides all installed programs."
+msgstr "Το <app>Εφαρμογές</app> παρέχει όλα τα εγκατεστημένα προγράμματα."
+
+#: C/plugin-applications.page:21(title)
+msgid "Launching an application"
+msgstr "Εκκίνηση μιας εφαρμογής"
+
+#: C/plugin-applications.page:23(p)
+msgid "Activate Kupfer and type an abbreviation of the application name"
+msgstr ""
+"Ενεργοποιήστε το Kupfer και πληκτρολογήστε μια συντομογραφία του ονόματος "
+"εφαρμογής"
+
+#: C/plugin-applications.page:28(p)
+msgid "Press <key>Return</key> to launch the application."
+msgstr "Πατήστε <key>Επιστροφή</key> για να ξεκινήσει η εφαρμογή."
+
+#: C/plugin-applications.page:34(title)
+msgid "Opening a file with a specific application"
+msgstr "Άνοιγμα ενός αρχείου με μια συγκεκριμένη εφαρμογή"
+
+#: C/plugin-applications.page:36(p)
+msgid "Select a file in <app>Kupfer</app>"
+msgstr "Επιλέξτε ένα αρχείο στο <app>Kupfer</app>"
+
+#: C/plugin-applications.page:41(p)
+msgid "Type <key>Tab</key> and select the action <em>Open With...</em>"
+msgstr ""
+"Πληκτρολογήστε <key>Tab</key> και επιλέξτε την ενέργεια <em>Άνοιγμα με ...</"
+"em>"
+
+#: C/plugin-applications.page:46(p)
+msgid ""
+"Type <key>Tab</key> to select the third (indirect object) pane and in it, "
+"select the application to open the file with."
+msgstr ""
+"Πληκτρολογήστε <key>Tab</key> για να επιλέξετε το τρίτο παράθυρο (έμμεσο "
+"αντικείμενο) και σε αυτό, επιλέξτε την εφαρμογή με την οποία να ανοίξει το "
+"αρχείο."
+
+#: C/plugin-applications.page:53(p)
+msgid ""
+"The action <em>Open</em> opens files and folders with the registered default "
+"application for that specific file type. This can be configured using the "
+"action <em>Set Default Application...</em>."
+msgstr ""
+"Η ενέργεια <em>Άνοιγμα</em> ανοίγει τα αρχεία και τους φακέλους με την "
+"εγγεγραμμένη προεπιλεγμένη εφαρμογή για το συγκεκριμένο τύπο αρχείου. Αυτό "
+"μπορεί να ρυθμιστεί χρησιμοποιώντας την ενέργεια <em>Ορισμός προεπιλεγμένης "
+"εφαρμογής...</em>."
+
+#: C/plugin-applications.page:58(p)
+msgid ""
+"The file type associations are provided by the desktop environment, and "
+"modifying them here will modify them on the desktop as well. This may not be "
+"true when not using GNOME or XFCE."
+msgstr ""
+"Οι συσχετισμοί του τύπου αρχείου παρέχονται από το περιβάλλον εργασίας, και "
+"η τροποποίηση τους εδώ θα τους τροποποιήσει επίσης και στην επιφάνεια "
+"εργασίας. Αυτό δεν μπορεί να είναι εφικτό όταν δεν χρησιμοποιείτε το GNOME ή "
+"το XFCE."
+
+#: C/plugin-applications.page:64(title)
+msgid "Selecting default application for a file type or folders"
+msgstr "Επιλέγοντας την προεπιλεγμένη εφαρμογή για έναν τύπο αρχείου ή φακέλων"
+
+#: C/plugin-applications.page:66(p)
+msgid "Select a file or folder in <app>Kupfer</app>"
+msgstr "Επιλέξτε ένα αρχείο ή φάκελο στο <app>Kupfer</app>"
+
+#: C/plugin-applications.page:71(p)
+msgid ""
+"Type <key>Tab</key> and select the action <em>Set Default Application...</em>"
+msgstr ""
+"Πληκτρολογήστε <key>Tab</key> και επιλέξτε την ενέργεια <em>Ορισμός "
+"προεπιλεγμένης εφαρμογής...</em>"
+
+#: C/plugin-applications.page:77(p)
+msgid ""
+"Type <key>Tab</key> to select the third (indirect object) pane and in it, "
+"select the application to always open the file type with."
+msgstr ""
+"Πληκτρολογήστε <key>Tab</key> για να επιλέξετε το τρίτο παράθυρο (έμμεσο "
+"αντικείμενο) και σε αυτό, επιλέξτε την εφαρμογή με την οποία θα ανοίγει "
+"πάντα ο τύπος του αρχείου."
+
+#: C/plugin-applications.page:85(title)
+msgid "Configuration"
+msgstr "Διαμόρφωση"
+
+#: C/plugin-applications.page:86(p)
+msgid ""
+"The configuration option <em>Applications for Desktop Environment</em> in "
+"the plugin's information pane in <app>Kupfer Preferences</app> determines "
+"how <app>Kupfer</app> should act with regard to the desktop environment "
+"configuration—certain applications request not to be shown depending on "
+"which desktop environment is used. By default, it behaves like GNOME."
+msgstr ""
+"Η επιλογή διαμόρφωσης <em>Εφαρμογές για το περιβάλλον επιφάνειας εργασίας</"
+"em> στο τμήμα πληροφοριών του πρόσθετου <app>Προτιμήσεις Kupfer</app> "
+"καθορίζει το πώς το <app>Kupfer</app> θα πρέπει να ενεργεί σε σχέση με τη "
+"διαμόρφωση του περιβάλλοντος εργασίας - ορισμένες εφαρμογές ζητείται να μην "
+"εμφανίζονται, ανάλογα με το περιβάλλον επιφάνειας εργασίας που "
+"χρησιμοποιείται. Από προεπιλογή, συμπεριφέρεται όπως το GNOME."
+
+#: C/moreusage.page:7(desc)
+msgid "More advanced usage information."
+msgstr "Περισσότερες προηγμένες πληροφορίες χρήσης."
+
+#: C/moreusage.page:10(title)
+msgid "Using <app>Kupfer</app> in Depth"
+msgstr "Χρησιμοποιώντας το <app>Kupfer</app> εις βάθος"
+
+#: C/moreusage.page:13(title)
+msgid "Adding Applications and Scripts"
+msgstr "Προσθέτοντας εφαρμογές και σενάρια"
+
+#: C/moreusage.page:14(p)
+msgid ""
+"<app>Kupfer</app> will show all applications that are configured visible in "
+"your menu editor."
+msgstr ""
+"Το <app>Kupfer</app> θα εμφανίσει όλες τις εφαρμογές που έχουν ρυθμιστεί ως "
+"ορατές στο μενού του επεξεργαστή σας."
+
+#: C/moreusage.page:18(p)
+msgid ""
+"If you want to add an application manually, you can create a new <code>."
+"desktop</code> file and place it in one of the standard directories for "
+"applications, for example <file>~/.local/share/applications</file>, where "
+"<app>Kupfer</app> will find it."
+msgstr ""
+"Αν θέλετε να προσθέσετε μια εφαρμογή χειροκίνητα, μπορείτε να δημιουργήσετε "
+"ένα νέο αρχείο <code>.desktop</code> και να το τοποθετήστε σε έναν από τους "
+"πρότυπους καταλόγους για εφαρμογές, για παράδειγμα στον <file>~/.local/share/"
+"applications</file>, όπου το <app>Kupfer</app> θα το βρεί."
+
+#: C/moreusage.page:24(p)
+msgid ""
+"If you have a collection of scripts that you want to call from <app>Kupfer</"
+"app>, you can add the scripts folder as a catalog directory to <app>Kupfer</"
+"app> in the preferences. Scripts that you add to <app>Kupfer</app>'s catalog "
+"this way can be run directly or in the terminal as long as they are "
+"executable."
+msgstr ""
+"Εάν έχετε μια συλλογή από σενάρια που θέλετε να καλέσετε από το <app>Kupfer</"
+"app>, μπορείτε να προσθέσετε το φάκελο σεναρίων ως μια λίστα καταλόγου στις "
+"προτιμήσεις του <app>Kupfer</app>. Σενάρια που θα προσθέσετε στον κατάλογο "
+"<app>Kupfer</app> με αυτόν τον τρόπο μπορούν να εκτελεσθούν απευθείας ή στο "
+"τερματικό για όσο διάστημα είναι εκτελέσιμα."
+
+#: C/moreusage.page:31(p)
+msgid ""
+"You can also save command-lines by using the action <em>Add to Favorites</"
+"em>."
+msgstr ""
+"Μπορείτε επίσης να αποθηκεύσετε γραμμές εντολών χρησιμοποιώντας την ενέργεια "
+"<em>Προσθήκη στα αγαπημένα</em>."
+
+#: C/moreusage.page:38(title)
+msgid "Opening Files and Folders"
+msgstr "Άνοιγμα αρχείων και φακέλων"
+
+#: C/moreusage.page:39(p)
+msgid ""
+"Using the action <em>Open</em>, files and folders are opened in their "
+"preferred application. The application associations can be changed, see "
+"<link xref=\"plugin-applications\"/>."
+msgstr ""
+"Χρησιμοποιώντας την ενέργεια <em>Άνοιγμα</em>, τα αρχεία και οι φάκελοι "
+"ανοίγουν με την προτιμώμενη εφαρμογή τους. Οι συσχετισμοί εφαρμογής μπορεί "
+"να αλλάξουν, δείτε στο <link xref=\"plugin-applications\"/>."
+
+#: C/moreusage.page:47(title)
+msgid "The <em>Comma Trick</em>"
+msgstr "Το <em>Τέχνασμα κόμμα</em>"
+
+#: C/moreusage.page:48(p)
+msgid ""
+"The comma trick allows the user to use actions on many objects at the same "
+"time."
+msgstr ""
+"Το τέχνασμα κόμμα επιτρέπει στο χρήστη να χρησιμοποιήσει ενέργειες σε πολλά "
+"αντικείμενα ταυτόχρονα."
+
+#: C/moreusage.page:52(p)
+msgid ""
+"Simply press comma <key>,</key> when an object is selected. The object is "
+"put on a \"stack\", and you can find yet another file or object, press comma "
+"to put it on the stack. When you subsequently invoke an action, the action "
+"is carried out on all of the objects at the same time."
+msgstr ""
+"Απλά πατήστε το κόμμα <key>,</key> όταν ένα αντικείμενο είναι επιλεγμένο . "
+"Το αντικείμενο τοποθετείται σε μια \"στοίβα\", και για να μπορείτε να βρείτε "
+"ακόμη ένα άλλο αρχείο ή ένα αντικείμενο, πατήστε το κόμμα για να το "
+"προσθέσετε στη στοίβα. Όταν, στη συνέχεια επικαλεσθείτε μια ενέργεια, αυτή "
+"διεξάγεται σε όλα τα αντικείμενα ταυτόχρονα."
+
+#: C/moreusage.page:58(p)
+msgid ""
+"Some actions are only \"multiplied\" when used with many objects, other are "
+"smarter than that:"
+msgstr ""
+"Ορισμένες ενέργειες είναι μόνο \"πολλαπλασιαζόμενες\" όταν χρησιμοποιούνται "
+"με πολλά αντικείμενα, ενώ άλλες είναι πιο εξελιγμένες:"
+
+#: C/moreusage.page:61(p)
+msgid ""
+"Selecting many files and using the Create Archive action, all files will be "
+"packed into the same archive."
+msgstr ""
+"Επιλέγοντας πολλά αρχεία και χρησιμοποιώντας τη Δημιουργία ενέργειας "
+"αρχείου, όλα τα αρχεία θα πρέπει περιέχονται πλέον στο ίδιο αρχείο."
+
+#: C/moreusage.page:63(p)
+msgid ""
+"If you select multiple contacts and use a Send Email action, it creates one "
+"email directed at all the contacts."
+msgstr ""
+"Εάν επιλέξετε πολλαπλές επαφές και χρησιμοποιήσετε μια ενέργεια Αποστολής "
+"μηνύματος, θα δημιουργεί ένα μήνυμα που θα απευθύνεται σε όλες τις επαφές."
+
+#: C/moreusage.page:65(p)
+msgid ""
+"If you select multiple subcatalogs (For example Firefox Bookmarks and "
+"Epiphany Bookmarks) and use Search Contents.., you get a subcatalog search "
+"restricted to the objects of those two catalogs! You can even bind a trigger "
+"to this command(!)"
+msgstr ""
+"Αν επιλέξετε πολλαπλούς υποκαταλόγους (Για παράδειγμα, σελιδοδείκτες Firefox "
+"και σελιδοδείκτες Epiphany) και χρησιμοποιήσετε την Αναζήτηση "
+"Περιεχομένων..., μπορείτε να πάρετε μια αναζήτηση υποκαταλόγων που "
+"περιορίζεται στα αντικείμενα των δύο αυτών καταλόγων! Μπορείτε ακόμα και να "
+"συνδέσετε ένα έναυσμα για αυτήν την εντολή(!)"
+
+#: C/moreusage.page:71(p)
+msgid ""
+"The comma trick is <link href=\"http://www.43folders.com/2005/06/13/"
+"quicksilver-the-comma-trick\"> directly taken from Quicksilver</link> (the "
+"example given in the external article should work identically in Kupfer)."
+msgstr ""
+"Το τέχνασμα κόμμα <link href=\"http://www.43folders.com/2005/06/13/"
+"quicksilver-the-comma-trick\"> λαμβάνεται απευθείας από το Quicksilver </"
+"link> (το παράδειγμα που δίνεται στο εξωτερικό άρθρο θα πρέπει να δουλεύει "
+"με τον ίδιο τρόπο στο Kupfer)."
+
+#: C/moreusage.page:80(title)
+msgid "Grab Current Selection"
+msgstr "Πιάσιμο τρέχουσας επιλογής"
+
+#: C/moreusage.page:81(p)
+msgid ""
+"To use the current selected text, from any application, with <app>Kupfer</"
+"app>, you can configure a global keyboard shortcut for the action <em>Show "
+"with Selection</em> in <app>Kupfer Preferences</app>."
+msgstr ""
+"Για να χρησιμοποιήσετε το τρέχον επιλεγμένο κείμενο, από οποιαδήποτε "
+"εφαρμογή, με το <app>Kupfer</app>, μπορείτε να διαμορφώσετε μια γενική "
+"συντόμευση πληκτρολογίου για την ενέργεια <em>Εμφάνιση με επιλογή</em> στις "
+"<app>Προτιμήσεις Kupfer</app>."
+
+#: C/moreusage.page:85(p)
+msgid ""
+"If configured, pressing the global keyboard shortcut will summon "
+"<app>Kupfer</app> with the current selection as the focused object."
+msgstr ""
+"Εάν έχει ρυθμιστεί, πιέζοντας την γενική συντόμευση πληκτρολογίου θα καλέσει "
+"το <app>Kupfer</app> με την τρέχουσα επιλογή ως εστιασμένο αντικείμενο."
+
+#: C/moreusage.page:90(p)
+msgid "See <link xref=\"keyboard\"/>"
+msgstr "Βλέπε <link xref=\"keyboard\"/>"
+
+#: C/moreusage.page:94(title)
+msgid "Command-line Connection"
+msgstr "Σύνδεση γραμμής εντολών"
+
+#: C/moreusage.page:95(p)
+msgid ""
+"The command <cmd>kupfer</cmd> on the command-line will focus <app>Kupfer</"
+"app> if it's already running, otherwise it will start it."
+msgstr ""
+"Η εντολή <cmd>kupfer</cmd> στην γραμμή εντολών θα εστιάσει στο <app>Kupfer</"
+"app> αν είναι ήδη σε λειτουργία, διαφορετικά θα το ξεκινήσει."
+
+#: C/moreusage.page:99(p)
+msgid ""
+"The command <cmd>kupfer</cmd> can be used to send files or text from the "
+"command-line to <app>Kupfer</app>. For example, if you are using the shell "
+"in a directory where you have a file called \"report.pdf\", you can focus "
+"this file in <app>Kupfer</app> by running <cmd>kupfer report.pdf</cmd>."
+msgstr ""
+"Η εντολή <cmd>kupfer</cmd> μπορεί να χρησιμοποιηθεί για την αποστολή αρχείων "
+"ή κειμένου από τη γραμμή εντολών στο <app>Kupfer</app>. Για παράδειγμα, εάν "
+"χρησιμοποιείτε το κέλυφος σε έναν κατάλογο όπου έχετε ένα αρχείο που "
+"ονομάζεται \"αναφορά.pdf\", μπορείτε να εστιάσετε σε αυτό το αρχείο στο "
+"<app>Kupfer</app> εκτελώντας την εντολή <cmd>kupfer αναφορά.pdf</cmd>."
+
+#: C/moreusage.page:107(p)
+msgid ""
+"You can also send text if you pipe the output of a command into <cmd>kupfer</"
+"cmd>."
+msgstr ""
+"Μπορείτε επίσης να στείλετε το κείμενο, αν διοχετεύσετε την έξοδο μιας "
+"εντολής στο <cmd>kupfer</cmd>."
+
+#: C/moreusage.page:114(title)
+msgid "Managing Context and Current Selection"
+msgstr "Διαχείριση πλαισίου και τρέχουσας επιλογής"
+
+#: C/moreusage.page:115(p)
+msgid ""
+"If you find the object you want to use, then invoke an action, <app>Kupfer</"
+"app> goes away to perform the action (for example start a program or play a "
+"song). When you come back to <app>Kupfer</app>, it will still keep the same "
+"object and action selected. Some actions make sense to be repeated (like "
+"skipping to the next song) and it can be useful to perform different actions "
+"on the same object."
+msgstr ""
+"Εάν βρείτε το αντικείμενο που θέλετε να χρησιμοποιήσετε και στη συνέχεια να "
+"επικαλεστείτε μια ενέργεια, το <app>Kupfer</app> υποχωρεί για να εκτελέσει "
+"την ενέργεια (για παράδειγμα ξεκινάτε ένα πρόγραμμα ή μια αναπαραγωγή "
+"τραγουδιού). Όταν επιστρέψετε στο <app>Kupfer</app>, αυτό θα εξακολουθεί να "
+"διατηρεί το ίδιο αντικείμενο και την επιλεγμένη ενέργεια. Ορισμένες "
+"ενέργειες έχουν νόημα να επαναλαμβάνονται (όπως πηδώντας στο επόμενο "
+"τραγούδι), και μπορεί να είναι χρήσιμο να εκτελούνται διαφορετικές ενέργειες "
+"για το ίδιο αντικείμενο."
+
+#: C/moreusage.page:123(p)
+msgid ""
+"However, you always have the top level catalog reachable when you \"come back"
+"\" to <app>Kupfer</app> -- say you went into the subcatalog \"Albums\" to "
+"browse your albums only; you select an album to play, and play it. You come "
+"back with the album selected -- but your next search will still go over the "
+"top level catalog, not just albums."
+msgstr ""
+"Ωστόσο, έχετε πάντα τον κατάλογο του κορυφαίου επιπέδου προσβάσιμο όταν "
+"κάνετε \"επιστροφή\" στο <app>Kupfer</app> -- ας υποθέσουμε ότι πάτε στον "
+"υποκατάλογο \"Άλμπουμ\" για να περιηγηθείτε μόνο στα άλμπουμ σας: μπορείτε "
+"να επιλέξετε ένα άλμπουμ για να παίξει, και να το παίξετε. Επιστρέφετε με το "
+"άλμπουμ που επιλέξατε -- αλλά η επόμενη αναζήτηση σας θα εξακολουθήσει να "
+"γίνεται στον κατάλογο κορυφαίου επιπέδου και όχι μόνο στα άλμπουμ."
+
+#: C/moreusage.page:130(p)
+msgid ""
+"How to come back into the subcatalog you were in? You do that by simply "
+"browsing, not searching the first thing you do when you focus <app>Kupfer</"
+"app> again. A quick way is to press down-arrow or space to open the browse "
+"window; think of it as saying \"I want to stay in this subfolder\". With the "
+"browse window open, your next query will search the current subcatalog."
+msgstr ""
+"Πώς να επιστρέψετε στον υποκατάλογο που ήσασταν; Θα το κάνετε αυτό απλά "
+"κάνοντας περιήγηση και όχι αναζήτηση της πρώτης ενέργειας που κάνετε όταν "
+"εστιάσετε και πάλι στο <app>Kupfer</app>. Ένας γρήγορος τρόπος είναι να "
+"πατήσετε το κάτω βέλος ή το διάστημα για να ανοίξετε το παράθυρο αναζήτησης: "
+"είναι σαν λέμε \"Θέλω να μείνω σε αυτόν τον υποφάκελο\". Με ανοιχτό το "
+"παράθυρο αναζήτησης, το επόμενο ερώτημα σας θα ψάξει τον τρέχοντα "
+"υποκατάλογο."
+
+#: C/moreusage.page:137(p)
+msgid ""
+"This way you can work both ways -- you can quickly drill down into folders "
+"to find a file, and when you come back for the next action with <app>Kupfer</"
+"app> you can either summon any normal toplevel object (just start typing), "
+"or stay around where you were, deep in that folder (press space, then type a "
+"query)."
+msgstr ""
+"Απο εδώ μπορείτε να εργαστείτε με δύο τρόπους -- μπορείτε γρήγορα να "
+"εστιάσετε σε φακέλους για να βρείτε ένα αρχείο, και όταν επιστρέψετε για την "
+"επόμενη ενέργεια με το <app>Kupfer</app> μπορείτε είτε να καλέσετε "
+"οποιοδήποτε κανονικό αντικείμενο κορυφαίου επιπέδου (απλά πληκτρολογήστε), ή "
+"να μείνετε γύρω απο το σημείο που ήσασταν, βαθιά σε αυτόν το φάκελο (πιέστε "
+"διάστημα, στη συνέχεια, πληκτρολογήστε ένα ερώτημα)."
+
+#: C/moreusage.page:146(title)
+msgid "Saving Commands as Files"
+msgstr "Αποθήκευση εντολών ως αρχεία"
+
+#: C/moreusage.page:147(p)
+msgid ""
+"You can use keyboard shortcut for <em>Compose Command</em> (by default it is "
+"<keyseq><key>Ctrl</key><key>Return</key></keyseq>) to create a command "
+"object out of the currently focused command in Kupfer. This object can be "
+"saved as a runnable file if you use the <em>Save As...</em> action. The "
+"resulting file will can be executed when opened from the file manager (it "
+"requires that Kupfer is already running)."
+msgstr ""
+"Μπορείτε να χρησιμοποιήσετε την συντόμευση πληκτρολογίου για την <em>Εντολή "
+"σύνθεσης</em> (εξ ορισμού είναι <keyseq><key>Ctrl</key><key>Επιστροφή</key></"
+"keyseq>) για να δημιουργήσετε ένα αντικείμενο εντολής από την τρέχουσα "
+"εστιασμένη εντολή στο Kupfer. Αυτό το αντικείμενο μπορεί να αποθηκευτεί ως "
+"εκτελέσιμο αρχείο αν χρησιμοποιείσετε την ενέργεια <em>Αποθήκευση ως ...</"
+"em>. Το αρχείο που προκύπτει θα μπορεί να εκτελεστεί όταν ανοίξει από τον "
+"διαχειριστή αρχείων (αυτό προϋποθέτει ότι το Kupfer εκτελείται ήδη)."
+
+#: C/managing-plugins.page:7(desc)
+msgid "Using plugins with <app>Kupfer</app>."
+msgstr "Χρησιμοποιώντας πρόσθετα με το <app>Kupfer</app>."
+
+#: C/managing-plugins.page:10(title)
+msgid "How to Configure Plugins"
+msgstr "Πως να ρυθμίσετε τα πρόσθετα"
+
+#: C/managing-plugins.page:12(p)
+msgid ""
+"Functionality in Kupfer is organized by extentsion modules called \"plugins"
+"\". Each plugin provides additional functionality, for example integration "
+"with an external application."
+msgstr ""
+"Η λειτουργικότητα στο Kupfer είναι οργανωμένη με ενότητες επεκτάσεων που "
+"ονομάζονται \"πρόσθετα\". Κάθε πρόσθετο παρέχει επιπλέον λειτουργίες, όπως "
+"για παράδειγμα την ενσωμάτωση με μια εξωτερική εφαρμογή."
+
+#: C/managing-plugins.page:19(title)
+msgid "Configuring Plugins"
+msgstr "Διαμόρφωση προσθέτων"
+
+#: C/managing-plugins.page:21(title)
+msgid "Open <app>Kupfer Preferences</app> to the Plugins tab"
+msgstr "Άνοιγμα του <app>Προτιμήσεις Kupfer</app> στην καρτέλα Πρόσθετα"
+
+#: C/managing-plugins.page:23(p)
+msgid "Use one of the following methods:"
+msgstr "Χρησιμοποιήστε μία από τις ακόλουθες μεθόδους:"
+
+#: C/managing-plugins.page:25(p)
+msgid ""
+"Click the Kupfer icon in the notification area and select the item "
+"<em>Preferences</em>"
+msgstr ""
+"Κάντε κλικ στο εικονίδιο Kupfer στην περιοχή ειδοποιήσεων και επιλέξτε το "
+"στοιχείο <em>Προτιμήσεις</em>"
+
+#: C/managing-plugins.page:25(item)
+msgid "<placeholder-1/>."
+msgstr "<placeholder-1/>."
+
+#: C/managing-plugins.page:29(p)
+msgid ""
+"Search for the object <app>Kupfer Preferences</app> in Kupfer itself. Press "
+"<key>Return</key> to open it."
+msgstr ""
+"Αναζητήστε το αντικείμενο <app>Προτιμήσεις Kupfer</app> στο ίδιο το Kupfer. "
+"Πατήστε <key>Επιστροφή</key> για να το ανοίξετε."
+
+#: C/managing-plugins.page:33(p)
+msgid "Use the keyboard shortcut <keyseq><key>Ctrl</key><key>;</key></keyseq>"
+msgstr ""
+"Χρησιμοποιήστε τη συντόμευση πληκτρολογίου <keyseq><key>Ctrl</key><key>;</"
+"key></keyseq>"
+
+#: C/managing-plugins.page:39(p)
+msgid "Select the tab <em>Plugins</em>"
+msgstr "Επιλέξτε την καρτέλα <em>Πρόσθετα</em>"
+
+#: C/managing-plugins.page:45(p)
+msgid ""
+"Select plugins in the list to read about them, and tick the box next to its "
+"name to activate the plugin, or untick to deactivate."
+msgstr ""
+"Επιλέξτε πρόσθετα στη λίστα για να διαβάσετε για αυτά, και τσεκάρετε το "
+"κουτάκι δίπλα στο όνομά του για να ενεργοποιήσετε το πρόσθετο, ή ξετσεκάρετε "
+"για την απενεργοποίησή του."
+
+#: C/managing-plugins.page:49(p)
+msgid ""
+"If the plugin has any configurable parameters, they will be visible below "
+"the plugin information."
+msgstr ""
+"Αν το πρόσθετο έχει κάποιες δυνατότητες ρύθμισης παραμέτρων, θα είναι ορατές "
+"κάτω από τις πληροφορίες του."
+
+#: C/managing-plugins.page:53(p)
+msgid ""
+"The plugin <app>Kupfer Plugins</app> allows fast access to each plugin's "
+"information page as well as the action \"Show Source Code\" which reveals "
+"the implementation."
+msgstr ""
+"Το πρόσθετο <app>Πρόσθετα Kupfer</app> επιτρέπει τη γρήγορη πρόσβαση στην "
+"σελίδα πληροφοριών κάθε πρόσθετου, καθώς και η ενέργεια \"Προβολή πηγαίου "
+"κώδικα\", η οποία αποκαλύπτει την εφαρμογή."
+
+#: C/managing-plugins.page:59(title)
+msgid "If a Plugin can not be Activated"
+msgstr "Εάν ένα Πρόσθετο δεν μπορεί να ενεργοποιηθεί"
+
+#: C/managing-plugins.page:60(p)
+msgid ""
+"If a plugin fails to activate because it requires a software module that is "
+"not available, its plugin information will display a message like this:"
+msgstr ""
+"Εάν ένα πρόσθετο αποτυγχάνει να ενεργοποιηθεί επειδή απαιτεί μια μονάδα "
+"λογισμικού που δεν είναι διαθέσιμη, οι πληροφορίες του θα εμφανίσουν ένα "
+"μήνυμα σαν αυτό:"
+
+#: C/managing-plugins.page:65(em)
+msgid "Plugin could not be read due to an error:"
+msgstr "Δεν ειναι δυνατή η ανάγνωση του πρόσθετου εξαιτίας κάποιου σφάλματος:"
+
+#: C/managing-plugins.page:66(em)
+msgid "Python module 'gdata' is needed"
+msgstr "Χρειάζεται η ενότητα Python 'gdata'"
+
+#: C/managing-plugins.page:67(p)
+msgid ""
+"This means that you need to install a needed python module from your "
+"distribution—and possibly the plugin documentation can tell you how."
+msgstr ""
+"Αυτό σημαίνει ότι θα πρέπει να εγκαταστήσετε μια αναγκαία ενότητα python από "
+"τη διανομή σας, και, ενδεχομένως, τα έγγραφα του πρόσθετου μπορούν να σας "
+"πουν πώς."
+
+#: C/managing-plugins.page:72(p)
+msgid ""
+"The plugin may also unexpectedly fail to load, and display a different error "
+"message. It may then be a program error in either the plugin or <app>Kupfer</"
+"app>."
+msgstr ""
+"Το πρόσθετο μπορεί επίσης απροσδόκητα να αποτύχει να φορτώσει, και να "
+"εμφανίσει ένα διαφορετικό μήνυμα λάθους. Τότε μπορεί να είναι ένα σφάλμα "
+"προγράμματος είτε του πρόσθετου ή του <app>Kupfer</app>."
+
+#: C/managing-plugins.page:79(title)
+msgid "Installing more Plugins"
+msgstr "Εγκατάσταση περισσότερων Πρόσθετων"
+
+#: C/managing-plugins.page:80(p)
+msgid ""
+"You can install custom plugins into the folder <code>~/.local/share/kupfer/"
+"plugins</code>. Each plugin is either a single <code>.py</code> file or a "
+"python package (a folder directly containing a file called <code>__init__."
+"py</code>). Plugins in the package format can include icon files. Python "
+"packages can even be installed as <code>.zip</code> files."
+msgstr ""
+"Μπορείτε να εγκαταστήσετε προσαρμοσμένα πρόσθετα στο φάκελο <code>~/.local/"
+"share/kupfer/plugins</code>. Κάθε πρόσθετο είναι είτε ένα μεμονωμένο αρχείο "
+"<code>.py</code> ή ένα πακέτο python (ένας φάκελος που περιέχει άμεσα ένα "
+"αρχείο που ονομάζεται <code>__init__.py</code>). Πρόσθετα σε μορφή πακέτου "
+"μπορεί να περιλαμβάνουν αρχεία εικονιδίων. Πακέτα Python μπορεί ακόμη να "
+"εγκατασταθούν και ως το αρχεία <code>.zip</code>."
+
+#: C/managing-plugins.page:88(p)
+msgid ""
+"<em>Caution:</em> Treat a plugin as a computer program. Do not install "
+"untrusted plugins."
+msgstr ""
+"<em>Προσοχή:</em> Αντιμετωπίστε ένα πρόσθετο όπως ένα πρόγραμμα υπολογιστή. "
+"Μην τοποθετείτε μη αξιόπιστα πρόσθετα."
+
+#: C/managing-plugins.page:95(title)
+msgid "Creating Plugins"
+msgstr "Δημιουργία Πρόσθετων"
+
+#: C/managing-plugins.page:96(p)
+msgid ""
+"Documentation for plugin creators is available in the file "
+"<code>Documentation/Manual.rst</code> in the source distribution on the "
+"webpage at <link href=\"http://kaizer.se/wiki/kupfer/Manual/\">Kupfer "
+"Manual</link>. An easy way to start is to copy an existing plugin and "
+"experimenting with it."
+msgstr ""
+"Τεκμηρίωση για τους δημιουργούς των πρόσθετων είναι διαθέσιμη στο αρχείο "
+"<code>Documentation/Manual.rst</code> στη πηγαία διανομή της ιστοσελίδας στο "
+"<link href=\"http://kaizer.se/wiki/kupfer/Manual/\">Εγχειρίδιο Kupfer</"
+"link>. Ένας εύκολος τρόπος για να ξεκινήσετε είναι να αντιγράψετε ένα "
+"υπάρχον πρόσθετο και να πειραματιστείτε με αυτό."
+
+#: C/managing-plugins.page:107(title)
+msgid "The <em>Catalog</em> Tab in Preferences"
+msgstr "Η καρτέλα <em>Κατάλογος</em> στις Προτιμήσεις"
+
+#: C/managing-plugins.page:108(p)
+msgid ""
+"Each plugin can export a number of sources which contain objects. Normally, "
+"all these objects are directly accessible from a top-level search. Some "
+"plugins export so specialized or so many objects that their catalogs should "
+"better not have their objects exported to the top level. To reach those "
+"objects, you have to first find the catalog by name, then enter the catalog "
+"using the action <em>Search Contents</em>."
+msgstr ""
+"Κάθε πρόσθετο μπορεί να εξάγει μια σειρά από πηγές που περιέχουν "
+"αντικείμενα. Κανονικά, όλα αυτά τα αντικείμενα είναι άμεσα προσβάσιμα από "
+"μια αναζήτηση κορυφαίου επιπέδου. Μερικά πρόσθετα εξάγουν τόσο εξειδικευμένα "
+"ή τόσα πολλά αντικείμενα που οι κατάλογοί τους θα πρέπει καλύτερα να μην "
+"έχουν τα αντικείμενα τους να εξάγονται στο κορυφαίο επίπεδο. Για να φτάσετε "
+"σε αυτά τα αντικείμενα, θα πρέπει να βρειτε πρώτα τον κατάλογο με βάση το "
+"όνομα, στη συνέχεια, πληκτρολογήστε τον κατάλογο με τη χρήση της ενέργειας "
+"<em>Αναζήτηση περιεχομένων</em>."
+
+#: C/managing-plugins.page:118(p)
+msgid ""
+"In the tab <em>Catalog</em> in <app>Kupfer Preferences</app>, a ticked box "
+"next to each source means that its objects are exported. An unticked box "
+"means that its contents are hidden from the top level."
+msgstr ""
+"Στην καρτέλα <em>Κατάλογος</em> στις <app>Προτιμήσεις Kupfer</app>, ένα "
+"τσεκαρισμένο πλαίσιο δίπλα σε κάθε πηγή σημαίνει ότι τα αντικείμενα της "
+"εξάγονται. Ένα ατσεκάριστο κουτί σημαίνει ότι το περιεχόμενό της είναι κρυφό "
+"από το κορυφαίο επίπεδο."
+
+#: C/managing-plugins.page:123(p)
+msgid ""
+"<em>Note:</em> Kupfer may become slow if large enough subcatalogs are "
+"exported to the top level."
+msgstr ""
+"<em>Σημείωση:</em> το Kupfer μπορεί να γίνει αργό, εάν αρκετά μεγάλοι "
+"υποκατάλογοι εξάγονται στο κορυφαίο επίπεδο."
+
+#: C/license.page:7(desc)
+msgid "You can copy, modify and share Kupfer."
+msgstr ""
+"Μπορείτε να αντιγράψετε, να τροποποιήσετε και να μοιραστείτε το Kupfer."
+
+#: C/license.page:10(title)
+msgid "License"
+msgstr "Άδεια"
+
+#: C/license.page:12(p)
+msgid ""
+"This program is free software: you can redistribute it and/or modify it "
+"under the terms of the <em>GNU General Public License</em> as published by "
+"the Free Software Foundation, either version 3 of the License, or (at your "
+"option) any later version."
+msgstr ""
+"Αυτό το πρόγραμμα είναι ελεύθερο λογισμικό: επιτρέπεται η αναδιανομή ή/και "
+"τροποποίησή του υπό τους όρους της <em>Γενικής Άδειας Δημόσιας Χρήσης GNU "
+"(GPL)</em>, όπως αυτή έχει δημοσιευτεί από το Ίδρυμα Ελεύθερου Λογισμικού "
+"(FSF), είτε της έκδοσης 3 της Άδειας, είτε (κατ' επιλογήν σας) οποιασδήποτε "
+"μεταγενέστερης έκδοσης."
+
+#: C/license.page:18(p)
+msgid ""
+"This program is distributed in the hope that it will be useful, but WITHOUT "
+"ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or "
+"FITNESS FOR A PARTICULAR PURPOSE. See the <em>GNU General Public License</"
+"em> for more details."
+msgstr ""
+"Το πρόγραμμα αυτό διανέμεται με την ελπίδα ότι θα αποδειχθεί χρήσιμο, παρόλα "
+"αυτά ΧΩΡΙΣ ΚΑΜΙΑ ΕΓΓΥΗΣΗ — χωρίς ούτε και την σιωπηρή εγγύηση "
+"ΕΜΠΟΡΕΥΣΙΜΟΤΗΤΑΣ ή ΚΑΤΑΛΛΗΛΟΤΗΤΑΣ ΓΙΑ ΕΙΔΙΚΟ ΣΚΟΠΟ. Για περισσότερες "
+"λεπτομέρειες ανατρέξτε στη <em>Γενική Άδεια Δημόσιας Χρήσης GNU (GPL)</em>."
+
+#: C/license.page:24(p)
+msgid ""
+"You should have received a copy of the GNU General Public License along with "
+"this program. If not, see <link href=\"http://www.gnu.org/licenses/\">gnu."
+"org/licenses</link>."
+msgstr ""
+"Θα πρέπει να έχετε λάβει ένα αντίγραφο της Γενικής Άδειας Δημόσιας Χρήσης "
+"GNU μαζί με αυτό το πρόγραμμα. Αν όχι, δείτε στο <link href=\"http://www.gnu."
+"org/licenses/\">gnu.org/licenses</link>."
+
+#: C/license.page:30(p)
+msgid ""
+"This documentation is licensed under a <link href=\"http://creativecommons."
+"org/licenses/by-sa/3.0/\">Creative Commons Attribution-Share Alike 3.0 "
+"Unported License</link>."
+msgstr ""
+"Αυτή η τεκμηρίωση είναι υπό την άδεια της <link href=\"http://"
+"creativecommons.org/licenses/by-sa/3.0/\">Creative Commons Attribution-Share "
+"Alike 3.0 Unported License</link>."
+
+#: C/license.page:36(p)
+msgid ""
+"As a special exception, the copyright holders give you permission to copy, "
+"modify, and distribute the example code contained in this document under the "
+"terms of your choosing, without restriction."
+msgstr ""
+"Ως ειδική εξαίρεση, οι κάτοχοι πνευματικών δικαιωμάτων σας δίνουν την άδεια "
+"να αντιγράψετε, να τροποποιήσετε και να διανείμετε το παράδειγμα του κώδικα "
+"που περιέχεται σε αυτό το έγγραφο σύμφωνα με τους όρους της επιλογής σας, "
+"χωρίς κανένα περιορισμό."
+
+#: C/keyboard.page:7(desc)
+msgid "Complete keyboard shortcuts reference."
+msgstr "Πλήρης αναφορά συντομεύσεων πληκτρολογίου."
+
+#: C/keyboard.page:10(title)
+msgid "Command Keys and Accelerator Keys"
+msgstr "Πλήκτρα εντολών και πλήκτρα επιτάχυνσης"
+
+#: C/keyboard.page:13(title) C/generalusage.page:12(title)
+msgid "Keyboard Interface"
+msgstr "Διεπαφή πληκτρολογίου"
+
+#: C/keyboard.page:14(p)
+msgid "In command mode, the following keystrokes have special meanings:"
+msgstr ""
+"Σε κατάσταση εντολών, οι ακόλουθες πληκτρολογήσεις έχουν ιδιαίτερη σημασία:"
+
+#: C/keyboard.page:19(p) C/generalusage.page:34(p)
+msgid "<key>↓</key> or <key>Space</key>"
+msgstr "<key>↓</key> ή <key>Διάστημα</key>"
+
+#: C/keyboard.page:20(p) C/generalusage.page:35(p)
+msgid "Go to the next match"
+msgstr "Μετάβαση στο επόμενο ταίριασμα"
+
+#: C/keyboard.page:23(p) C/generalusage.page:38(p)
+msgid "<key>↑</key> or <keyseq><key>Shift</key><key>Space</key></keyseq>"
+msgstr "<key>↑</key> ή <keyseq><key>Shift</key><key>Διάστημα</key></keyseq>"
+
+#: C/keyboard.page:26(p) C/generalusage.page:41(p)
+msgid "Go to the previous match"
+msgstr "Μετάβαση στο προηγούμενο ταίριασμα"
+
+#: C/keyboard.page:29(p) C/generalusage.page:44(p)
+msgid "<key>→</key> or <key>/</key>"
+msgstr "<key>→</key> ή <key>/</key>"
+
+#: C/keyboard.page:30(p) C/generalusage.page:45(p)
+msgid "Descend into an object with content"
+msgstr "Κατεβαίνει σε ένα αντικείμενο με περιεχόμενο"
+
+#: C/keyboard.page:33(key) C/generalusage.page:48(key)
+msgid "Backspace"
+msgstr "Πλήκτρο backspace"
+
+#: C/keyboard.page:34(p) C/generalusage.page:49(p)
+msgid "Erase a character from the query. If the query is empty, go up a level"
+msgstr ""
+"Διαγραφή ενός χαρακτήρα από το ερώτημα. Εάν το ερώτημα είναι άδειο, "
+"ανεβαίνει ένα επίπεδο προς τα πάνω"
+
+#: C/keyboard.page:39(key) C/keyboard.page:93(key) C/generalusage.page:54(key)
+msgid "."
+msgstr "."
+
+#: C/keyboard.page:40(p) C/generalusage.page:55(p)
+msgid "Activate free-text mode"
+msgstr "Ενεργοποίηση λειτουργίας ελεύθερου κειμένου"
+
+#: C/keyboard.page:43(key) C/keyboard.page:97(key) C/generalusage.page:58(key)
+msgid ","
+msgstr ","
+
+#: C/keyboard.page:44(p) C/generalusage.page:59(p)
+msgid "Put selected object on the stack (\"Comma Trick\")"
+msgstr "Τοποθετεί το επιλεγμένο αντικείμενο στη στοίβα (\"Τέχνασμα κόμμα\")"
+
+#: C/keyboard.page:47(p)
+msgid "Quick access keys:"
+msgstr "Πλήκτρα γρήγορης πρόσβασης:"
+
+#: C/keyboard.page:53(key)
+msgid "="
+msgstr "="
+
+#: C/keyboard.page:55(p)
+msgid ""
+"Activate free-text mode with = prefix (for <link xref=\"plugin-calculator\"/"
+">)"
+msgstr ""
+"Ενεργοποίηση λειτουργίας ελεύθερου κειμένου με πρόθεμα = (για το <link xref="
+"\"plugin-calculator\"/>)"
+
+#: C/keyboard.page:61(key)
+msgid "/"
+msgstr "/"
+
+#: C/keyboard.page:63(p)
+msgid ""
+"Activate free-text mode (when nothing is selected) with <code>/</code> "
+"prefix (to input a rooted path)"
+msgstr ""
+"Ενεργοποίηση λειτουργίας ελεύθερου κειμένου (όταν δεν έχει επιλεγεί τίποτα) "
+"με πρόθεμα <code>/</code> (για την είσοδο μιας ριζωμένης διαδρομής)"
+
+#: C/keyboard.page:68(p) C/generalusage.page:62(p)
+msgid "Additionally:"
+msgstr "Επιπλέον:"
+
+#: C/keyboard.page:72(p) C/generalusage.page:66(p)
+msgid ""
+"<key>Return</key> activates the current selection: the command is executed."
+msgstr ""
+"Το πλήκτρο <key>Επιστροφή</key> ενεργοποιεί την τρέχουσα επιλογή: η εντολή "
+"εκτελείται."
+
+#: C/keyboard.page:74(p) C/generalusage.page:68(p)
+msgid "<key>Escape</key> clears the current selection."
+msgstr "Το πλήκτρο <key>Escape</key> καθαρίζει την τρέχουσα επιλογή."
+
+#: C/keyboard.page:75(p) C/generalusage.page:69(p)
+msgid "<key>Tab</key> switches between the object and the action pane."
+msgstr ""
+"Το πλήκτρο <key>Tab</key> πραγματοποιεί εναλλαγή μεταξύ του αντικειμένου και "
+"του παραθύρου ενεργειών."
+
+#: C/keyboard.page:77(p)
+msgid ""
+"The meaning of the keys <key>Space</key>, <key>.</key>, <key>,</key>, <key>/"
+"</key> and <key>=</key> can not be changed, but you can deactivate their "
+"special meaning with the checkbox <app>Use single keystroke commands</app> "
+"in <app>Kupfer Preferences</app>."
+msgstr ""
+"Η έννοια των πλήκτρων <key>Space</key>, <key>.</key>, <key>,</key>, <key>/</"
+"key> και <key>=</key> δεν μπορεί να αλλάξει, αλλά μπορείτε να "
+"απενεργοποιήσετε την ειδική σημασία τους με το πλαίσιο ελέγχου <app>Χρήση "
+"μονών εντολών πληκτρολόγησης</app> στις <app>Προτιμήσεις Kupfer</app>."
+
+#: C/keyboard.page:86(title)
+msgid "Kupfer's Keyboard Shortcuts"
+msgstr "Συντομεύσεις πληκτρολογίου του Kupfer"
+
+#: C/keyboard.page:87(p)
+msgid ""
+"These keyboard shortcuts are used in <app>Kupfer</app>'s interface. They "
+"have the following meanings and default shortcuts:"
+msgstr ""
+"Αυτές οι συντομεύσεις πληκτρολογίου χρησιμοποιούνται στη διεπαφή του "
+"<app>Kupfer</app>. Έχουν τις ακόλουθες σημασίες και προκαθορισμένες "
+"συντομεύσεις:"
+
+#: C/keyboard.page:93(key) C/keyboard.page:97(key) C/keyboard.page:101(key)
+#: C/keyboard.page:105(key) C/keyboard.page:113(key) C/keyboard.page:117(key)
+#: C/keyboard.page:121(key) C/keyboard.page:125(key) C/keyboard.page:129(key)
+#: C/keyboard.page:174(key)
+msgid "Ctrl"
+msgstr "Ctrl"
+
+#: C/keyboard.page:94(p)
+msgid "Toggle text mode"
+msgstr "Εναλλαγή μορφής κειμένου"
+
+#: C/keyboard.page:98(p)
+msgid "The comma trick"
+msgstr "Το τέχνασμα κόμμα"
+
+#: C/keyboard.page:101(key)
+msgid ";"
+msgstr ";"
+
+#: C/keyboard.page:102(p)
+msgid "Show preferences window"
+msgstr "Εμφάνιση παραθύρου προτιμήσεων"
+
+#: C/keyboard.page:105(key)
+msgid "R"
+msgstr "R"
+
+#: C/keyboard.page:106(p)
+msgid "Reset all"
+msgstr "Επαναφορά όλων"
+
+#: C/keyboard.page:109(key)
+msgid "Alt"
+msgstr "Alt"
+
+#: C/keyboard.page:109(key)
+msgid "A"
+msgstr "A"
+
+#: C/keyboard.page:110(p)
+msgid "Alternate activate"
+msgstr "Εναλλακτική ενεργοποίηση"
+
+#: C/keyboard.page:113(key)
+msgid "Return"
+msgstr "Επιστροφή"
+
+#: C/keyboard.page:114(p)
+msgid "Compose command"
+msgstr "Εντολή σύνθεσης"
+
+#: C/keyboard.page:117(key)
+msgid "S"
+msgstr "S"
+
+#: C/keyboard.page:118(p)
+msgid "Switch to first pane"
+msgstr "Μετάβαση σε πρώτο παράθυρο"
+
+#: C/keyboard.page:121(key)
+msgid "Q"
+msgstr "Q"
+
+#: C/keyboard.page:122(p)
+msgid "Select 'Quit'"
+msgstr "Επιλογή 'Κείσιμο'"
+
+#: C/keyboard.page:125(key)
+msgid "G"
+msgstr "G"
+
+#: C/keyboard.page:126(p)
+msgid "Select 'Selected File'"
+msgstr "Επιλογή 'επιλεγμένο αρχείο'"
+
+#: C/keyboard.page:129(key)
+msgid "T"
+msgstr "T"
+
+#: C/keyboard.page:130(p)
+msgid "Select 'Selected Text'"
+msgstr "Επιλογή 'επιλεγμένο κείμενο'"
+
+#: C/keyboard.page:133(key)
+msgid "F1"
+msgstr "F1"
+
+#: C/keyboard.page:134(p)
+msgid "Show Help"
+msgstr "Εμφάνιση βοήθειας"
+
+#: C/keyboard.page:139(title)
+msgid "How to configure a keyboard shortcut"
+msgstr "Πως να ρυθμίσετε μια συντόμευση πληκτρολογίου"
+
+#: C/keyboard.page:141(p) C/keyboard.page:185(p)
+msgid "Open <app>Kupfer Preferences</app> and go to the <em>Keyboard</em> tab."
+msgstr ""
+"Ανοίξτε τις <app>Προτιμήσεις Kupfer</app> και πηγαίνετε στην καρτέλα "
+"<em>Πληκτρολόγιο</em>."
+
+#: C/keyboard.page:147(p)
+msgid ""
+"Double-click the shorcut's row under <em>Browser Keyboard Shortcuts</em>."
+msgstr ""
+"Κάντε διπλό κλικ στη γραμμή της συντόμευσης <em>Συντομεύσεις πληκτρολογίου "
+"περιηγητή</em>."
+
+#: C/keyboard.page:153(p)
+msgid ""
+"Using the window that appears, press modifier keys and a letter or number "
+"key to set a shortcut. An example is pressing and holding <key>Ctrl</key> "
+"and then pressing and releasing <key>T</key> to bind <keyseq><key>Ctrl</"
+"key><key>T</key></keyseq>."
+msgstr ""
+"Χρησιμοποιώντας το παράθυρο που εμφανίζεται, πατήστε τα πλήκτρα τροποποίησης "
+"και ένα γράμμα ή αριθμό για να ορίσετε μια συντόμευση. Ένα παράδειγμα είναι "
+"πατώντας και κρατώντας πατημένο το <key>Ctrl</key> και, στη συνέχεια, "
+"πιέζοντας και αφήνοντας το <key>T</key> για να δεσμεύσετε τα "
+"<keyseq><key>Ctrl</key><key>T</key></keyseq>."
+
+#: C/keyboard.page:164(title)
+msgid "Global Keyboard Shortcuts"
+msgstr "Γενικές συντομεύσεις πληκτρολογίου"
+
+#: C/keyboard.page:165(p)
+msgid ""
+"<app>Kupfer</app> always listens to global shortcuts, even if it is not "
+"currently in the foreground."
+msgstr ""
+"Το <app>Kupfer</app> ακούει πάντα στις γενικές συντομεύσεις, ακόμη και αν "
+"δεν είναι στο προσκήνιο."
+
+#: C/keyboard.page:169(p)
+msgid "They have the following meanings and default shortcuts:"
+msgstr "Έχουν τις ακόλουθες σημασίες και προεπιλεγμένες συντομεύσεις:"
+
+#: C/keyboard.page:174(key)
+msgid "Space"
+msgstr "Διάστημα"
+
+#: C/keyboard.page:175(p)
+msgid "Show/hide <app>Kupfer</app>"
+msgstr "Εμφάνιση/απόκρυψη του <app>Kupfer</app>"
+
+#: C/keyboard.page:178(p)
+msgid "(not configured by default)"
+msgstr "(δεν έχει ρυθμιστεί από προεπιλογή)"
+
+#: C/keyboard.page:179(p)
+msgid "Show <app>Kupfer</app> with 'Selection' object focused"
+msgstr "Εμφάνιση του <app>Kupfer</app> με 'Επιλογή' εστιασμένο αντικείμενο"
+
+#: C/keyboard.page:183(title)
+msgid "How to configure a global keyboard shortcut"
+msgstr "Πως να ρυθμίσετε μια γενική συντόμευση πληκτρολογίου"
+
+#: C/keyboard.page:191(p)
+msgid ""
+"Double-click the shorcut's row under <em>Global Keyboard Shortcuts</em>."
+msgstr ""
+"Κάντε διπλό κλικ στη γραμμή της συντόμευσης <em>Γενικές συντομεύσεις "
+"πληκτρολογίου</em>."
+
+#: C/keyboard.page:197(p)
+msgid ""
+"Using the window that appears, press modifier keys and a letter or number "
+"key to set a global shortcut. An example is pressing and holding <key>Super</"
+"key> and then pressing and releasing <key>Space</key> to bind "
+"<keyseq><key>Super</key><key>Space</key></keyseq>."
+msgstr ""
+"Χρησιμοποιώντας το παράθυρο που εμφανίζεται, πατήστε τα πλήκτρα τροποποίησης "
+"και ένα γράμμα ή αριθμό για να ορίσετε μια γενική συντόμευση. Ένα παράδειγμα "
+"είναι πατώντας και κρατώντας πατημένο το <key>Super</key> και, στη συνέχεια, "
+"πιέζοντας και αφήνοντας το <key>Space</key> για να δεσμεύσετε τα "
+"<keyseq><key>Super</key><key>Space</key></keyseq>."
+
+#: C/keyboard.page:206(p)
+msgid ""
+"Since these keyboard shortcuts are global, they can be used from any "
+"application. Select shortcuts with care so that they do not conflict with "
+"other functions."
+msgstr ""
+"Δεδομένου ότι αυτές οι συντομεύσεις πληκτρολογίου είναι γενικές, μπορούν να "
+"χρησιμοποιηθούν από οποιαδήποτε εφαρμογή. Επιλέξτε συντομεύσεις με προσοχή "
+"έτσι ώστε να μην έρχονται σε αντίθεση με άλλες λειτουργίες."
+
+#: C/keyboard.page:214(p)
+msgid ""
+"The plugin <em>Triggers</em> allows to activate actions with global keyboard "
+"shortcuts. Trigger shortcuts do not appear in <app>Kupfer Preferences</app>."
+msgstr ""
+"Το πρόσθετο <em>Εναύσματα</em> σας επιτρέπει να ενεργοποιήσετε τις ενέργειες "
+"με τις γενικές συντομεύσεις πληκτρολογίου. Συντομεύσεις του Εναύσματα δεν "
+"εμφανίζονται στις <app>Προτιμήσεις Kupfer</app>."
+
+#: C/keyboard.page:220(p)
+msgid "See <link xref=\"plugin-triggers\"/> for more information."
+msgstr ""
+"Δείτε στο <link xref=\"plugin-triggers\"/> για περισσότερες πληροφορίες."
+
+#: C/introduction.page:7(desc)
+msgid "Introduction to <app>Kupfer</app>."
+msgstr "Εισαγωγή στο <app>Kupfer</app>."
+
+#: C/introduction.page:10(title)
+msgid "Introduction"
+msgstr "Εισαγωγή"
+
+#: C/introduction.page:12(p)
+msgid ""
+"<app>Kupfer</app> is an interface for quick and convenient access to "
+"applications and their documents."
+msgstr ""
+"Το <app>Kupfer</app> είναι μια διεπαφή για γρήγορη και εύκολη πρόσβαση σε "
+"εφαρμογές και τα έγγραφά τους."
+
+#: C/introduction.page:16(p)
+msgid ""
+"The most typical use is to find a specific application and launch it. We "
+"have tried to make <app>Kupfer</app> easy to extend with plugins so that "
+"this quick-access paradigm can be extended to many more objects than just "
+"applications."
+msgstr ""
+"Η πιο τυπική χρήση είναι να βρείτε μια συγκεκριμένη εφαρμογή και να την "
+"τρέξετε. Έχουμε προσπαθήσει να κάνουμε το <app>Kupfer</app> εύκολο να "
+"επεκταθεί με πρόσθετα, έτσι ώστε αυτό το παράδειγμα γρήγορης πρόσβασης να "
+"μπορεί να επεκταθεί και σε πολλά άλλα αντικείμενα εκτός των εφαρμογών."
+
+#: C/introduction.page:22(p)
+msgid ""
+"We hope that using <app>Kupfer</app> feels both <em>very fun</em> and "
+"<em>different</em>."
+msgstr ""
+"Ελπίζουμε ότι η χρήση του <app>Kupfer</app> σας δίνει την αίσθηση ότι είναι "
+"τόσο <em>πολύ διασκεδαστική</em> όσο και <em>διαφορετική</em>."
+
+#: C/introduction.page:26(p)
+msgid ""
+"For up-to-date information about <app>Kupfer</app>, visit its <link href="
+"\"http://kaizer.se/wiki/kupfer/\">homepage</link>."
+msgstr ""
+"Για ενημερωμένες πληροφορίες σχετικά με το <app>Kupfer</app>, επισκεφθείτε "
+"την <link href=\"http://kaizer.se/wiki/kupfer/\">αρχική σελίδα</link> του."
+
+#: C/index.page:9(name)
+msgid "Ulrik Sverdrup"
+msgstr "Ulrik Sverdrup"
+
+#: C/index.page:10(email)
+msgid "ulrik.sverdrup@gmail.com"
+msgstr "ulrik.sverdrup@gmail.com"
+
+#: C/index.page:13(year)
+msgid "2009"
+msgstr "2009"
+
+#: C/index.page:14(name)
+msgid "Kupfer Development Team"
+msgstr "Ομάδα Ανάπτυξης Kupfer"
+
+#: C/index.page:17(license)
+msgid "Creative Commons Share Alike 3.0"
+msgstr "Creative Commons Share Alike 3.0"
+
+#: C/index.page:21(title)
+msgid "Kupfer Manual"
+msgstr "Εγχειρίδιο Kupfer"
+
+#: C/index.page:24(title)
+msgid "Using Kupfer"
+msgstr "Χρήση του Kupfer"
+
+#: C/index.page:27(title)
+msgid "About Specific Plugins"
+msgstr "Σχετικά με Ειδικά Πρόσθετα"
+
+#: C/generalusage.page:7(desc)
+msgid "How to start using <app>Kupfer</app>."
+msgstr "Πώς να αρχίσετε να χρησιμοποιείτε το <app>Kupfer</app>."
+
+#: C/generalusage.page:14(p)
+msgid ""
+"<app>Kupfer</app> is to the largest part a keyboard-managed interface to "
+"applications and documents."
+msgstr ""
+"Το <app>Kupfer</app> είναι στο μεγαλύτερο μέρος του μια διεπαφή "
+"διαχειριζόμενη απο το πληκτρολόγιο σε εφαρμογές και έγγραφα."
+
+#: C/generalusage.page:18(p)
+msgid ""
+"Kupfer's default mode is the command mode: If you type a query, kupfer will "
+"search for a match in its catalog."
+msgstr ""
+"Προεπιλεγμένη λειτουργία του Kupfer είναι η κατάσταση εντολών: Εάν "
+"πληκτρολογήσετε ένα ερώτημα, το kupfer θα ψάξει για ένα ταίριασμα στον "
+"κατάλογό του."
+
+#: C/generalusage.page:23(p)
+msgid ""
+"The arrow keys allow you to browse query matches quite naturally, going to "
+"the previous or next match, and going up and down in the subcatalogs."
+msgstr ""
+"Τα πλήκτρα βέλους σας επιτρέπουν να περιηγηθείτε σε συμφωνίες ερωτημάτων "
+"αρκετά φυσικά, πηγαίνοντας στο προηγούμενο ή το επόμενο ταίριασμα, και "
+"πηγαίνοντας πάνω-κάτω στους υποκαταλόγους."
+
+#: C/generalusage.page:29(p)
+msgid "In command mode, some keystrokes have special meanings:"
+msgstr "Σε κατάσταση εντολών, μερικές πληκτρολογήσεις έχουν ιδιαίτερη σημασία:"
+
+#: C/generalusage.page:71(p)
+msgid ""
+"By default you show <app>Kupfer</app> using the global keyboard shortcut "
+"<keyseq><key>Ctrl</key><key>Space</key></keyseq>."
+msgstr ""
+"Από προεπιλογή θα επιδείξετε το <app>Kupfer</app>, χρησιμοποιώντας την "
+"γενική συντόμευση πληκτρολογίου <keyseq><key>Ctrl</key><key>Space</key></"
+"keyseq>."
+
+#: C/generalusage.page:74(p)
+msgid "See <link xref=\"keyboard\"/> for more information."
+msgstr "Δείτε στο <link xref=\"keyboard\"/> για περισσότερες πληροφορίες."
+
+#: C/generalusage.page:78(title)
+msgid "Learning Habits"
+msgstr "Μαθαίνοντας συνήθειες"
+
+#: C/generalusage.page:79(p)
+msgid ""
+"<app>Kupfer</app> remembers which objects and actions are used the most. "
+"When beginning to use it, you have to use the arrow keys at times to make it "
+"precise which object you want to find. After a few uses of that object, "
+"Kupfer will rank it higher. Objects marked as <link xref=\"plugin-favorites"
+"\">favorites</link> are also ranked higher."
+msgstr ""
+"Το <app>Kupfer</app> θυμάται ποια αντικείμενα και ενέργειες χρησιμοποίηθηκαν "
+"πιο πολύ. Όταν ξεκινήσετε τη χρήση του, θα πρέπει να χρησιμοποιείτε τα "
+"πλήκτρα βέλους κατά καιρούς για να καταστεί σαφές, ποιό αντικείμενο θέλετε "
+"να βρείτε. Μετά από μερικές χρήσεις ενός αντικειμένου, το Kupfer θα το "
+"κατατάξει σε υψηλότερη θέση. Αντικείμενα που χαρακτηρίζονται ως <link xref="
+"\"plugin-favorites\">αγαπημένα</link>, επίσης, κατατάσσεται ψηλότερα."
+
+#: C/generalusage.page:90(title)
+msgid "The Catalog"
+msgstr "Ο Κατάλογος"
+
+#: C/generalusage.page:91(p)
+msgid ""
+"The Catalog is the collection of objects you can access in Kupfer, such as "
+"documents and programs."
+msgstr ""
+"Ο Κατάλογος είναι η συλλογή των αντικειμένων στα οποία μπορείτε να έχετε "
+"πρόσβαση στο Kupfer, όπως έγγραφα και προγράμματα."
+
+#: C/generalusage.page:96(p)
+msgid ""
+"Objects in the catalog that have content, like folders, are marked with an "
+"arrow. Pressing <key>→</key> will enter these objects. Much of the catalog "
+"is composed of subcatalogs; plugin subcatalogs do in general list objects "
+"that are also available directly from the top level. Subcatalogs can be used "
+"for a narrower view or search scope, when using Kupfer."
+msgstr ""
+"Αντικείμενα στον κατάλογο που έχουν περιεχόμενο, όπως φάκελοι, "
+"επισημαίνονται με ένα βέλος. Πατώντας το <key>→</key> θα μπείτε σε αυτά τα "
+"αντικείμενα. Μεγάλο μέρος του καταλόγου αποτελείται από υποκαταλόγους: "
+"υποκατάλογοι πρόσθετων κάνουν γενικά οι λίστες αντικειμένων που είναι επίσης "
+"διαθέσιμες απευθείας από το κορυφαίο επίπεδο. Οι υποκατάλογοι μπορεί να "
+"χρησιμοποιηθούν για μια περιορισμένη προβολή ή μια ευρεία αναζήτηση, κατά τη "
+"χρήση του Kupfer."
+
+#: C/generalusage.page:105(p)
+msgid ""
+"Most subcatalogs update their content automatically. For example, the "
+"Desktop folder source is always up-to-date."
+msgstr ""
+"Οι περισσότεροι υποκατάλογοι ενημερώνουν το περιεχόμενό τους αυτόματα. Για "
+"παράδειγμα, η πηγή του φακέλου Επιφάνεια εργασίας είναι πάντα ενημερωμένη."
+
+#. Put one translator per line, in the form of NAME <EMAIL>, YEAR1, YEAR2
+#: C/generalusage.page:0(None)
+msgid "translator-credits"
+msgstr "Maria Mavridou <mavridou@gmail.com>, 2014"

--- a/help/es/es.po
+++ b/help/es/es.po
@@ -3,19 +3,20 @@
 # Copyright (C) 2010 kupfer's COPYRIGHT HOLDER
 # This file is distributed under the same license as the kupfer package.
 # Jorge González <jorgegonz@svn.gnome.org>, 2010, 2011.
-# Daniel Mustieles <daniel.mustieles@gmail.com>, 2011.
+# Daniel Mustieles <daniel.mustieles@gmail.com>, 2011, 2013.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: kupfer.help.master\n"
-"POT-Creation-Date: 2011-04-04 17:52+0000\n"
-"PO-Revision-Date: 2011-04-06 19:44+0200\n"
+"POT-Creation-Date: 2013-01-22 20:43+0000\n"
+"PO-Revision-Date: 2013-02-05 17:12+0100\n"
 "Last-Translator: Daniel Mustieles <daniel.mustieles@gmail.com>\n"
 "Language-Team: Español <gnome-es-list@gnome.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
 "X-Generator: KBabel 1.11.4\n"
 
 #: C/plugin-websearch.page:7(desc)
@@ -535,9 +536,9 @@ msgid ""
 msgstr ""
 "Cuando escala imágenes con la acción <em>Escalar...</em> del complemento "
 "<app>Herramientas de imagen</app>. Esta acción necesita una descripción como "
-"tercer objeto, similar a «1024» o «1200x800». Si habitualmente escala al "
-"mismo tamaño, indique «1200x800», añádalo a favoritos, y aparecerá siempre "
-"como una sugerencia para la acción."
+"tercer objeto, similar a «1024» o «1200x800». Si habitualmente escala al mismo "
+"tamaño, indique «1200x800», añádalo a favoritos, y aparecerá siempre como una "
+"sugerencia para la acción."
 
 #: C/plugin-favorites.page:54(p)
 msgid ""
@@ -594,8 +595,8 @@ msgid ""
 "<cmd>log</cmd>; the command <cmd>=help</cmd> will show a list of all defined "
 "functions and constants."
 msgstr ""
-"El complemento «Calculadora» usa módulos matemáticos de python y complejos, "
-"y analiza expresiones como expresiones de Python. Puede usar funciones "
+"El complemento «Calculadora» usa módulos matemáticos de python y complejos, y "
+"analiza expresiones como expresiones de Python. Puede usar funciones "
 "matemáticas comunes, como <cmd>sqrt</cmd>, <cmd>sin</cmd>, <cmd>exp</cmd> y "
 "<cmd>log</cmd>»; el comando <cmd>=help</cmd> mostrará una lista de todas las "
 "funciones y constantes definidas."
@@ -624,8 +625,17 @@ msgid ""
 "The last result is stored as the name _ (an underscore, just like in the "
 "Python console)."
 msgstr ""
-"El último resultado se guarda como el nombre «_» (guión bajo, igual que en "
-"la consola de Python)."
+"El último resultado se guarda como el nombre «_» (guión bajo, igual que en la "
+"consola de Python)."
+
+#: C/plugin-calculator.page:65(p)
+msgid ""
+"The Calculator lets you also calculate expression without \"=\" on the "
+"beginning as long it have inside one of operators: +, -, *, /, ^, |, , ~."
+msgstr ""
+"La calculadora también le permite calcular expresiones sin «=» al principio "
+"siempre y cuando tengan dentro uno de los siguientes operadores: +, -, *, /, "
+"^, |, , ~."
 
 #: C/plugin-applications.page:7(desc)
 msgid "Using the applications plugin."
@@ -836,16 +846,16 @@ msgid ""
 "Some actions are only \"multiplied\" when used with many objects, other are "
 "smarter than that:"
 msgstr ""
-"Algunas acciones sólo se «multiplican» cuando se utilizan con muchos "
-"objetos, otras son más inteligentes que eso:"
+"Algunas acciones sólo se «multiplican» cuando se utilizan con muchos objetos, "
+"otras son más inteligentes que eso:"
 
 #: C/moreusage.page:61(p)
 msgid ""
 "Selecting many files and using the Create Archive action, all files will be "
 "packed into the same archive."
 msgstr ""
-"Al seleccionar varios archivos usando la acción «Crear archivador», todos "
-"los archivos se empaquetarán en el mismo archivo."
+"Al seleccionar varios archivos usando la acción «Crear archivador», todos los "
+"archivos se empaquetarán en el mismo archivo."
 
 #: C/moreusage.page:63(p)
 msgid ""
@@ -863,9 +873,9 @@ msgid ""
 "to this command(!)"
 msgstr ""
 "Si selecciona varios catálogos (por ejemplo, «Marcadores de Firefox» y "
-"«Marcadores de Epiphany») y usa «Buscar contenido...», obtiene una búsqueda "
-"de subcatálogo restringida a los objetos de estos dos catálogos. También "
-"puede asociar un disparador a este comando."
+"«Marcadores de Epiphany») y usa «Buscar contenido...», obtiene una búsqueda de "
+"subcatálogo restringida a los objetos de estos dos catálogos. También puede "
+"asociar un disparador a este comando."
 
 #: C/moreusage.page:71(p)
 msgid ""
@@ -926,8 +936,8 @@ msgid ""
 msgstr ""
 "El comando <cmd>kupfer</cmd> se puede usar para enviar archivos o texto "
 "desde la línea de comandos a <app>Kupfer</app>. Por ejemplo, si está usando "
-"la terminal en una carpeta donde tiene un archivo llamado «informe.pdf» "
-"puede dar el foco a este archivo en <app>Kupfer</app> ejecutando <cmd>kupfer "
+"la terminal en una carpeta donde tiene un archivo llamado «informe.pdf» puede "
+"dar el foco a este archivo en <app>Kupfer</app> ejecutando <cmd>kupfer "
 "report.pdf</cmd>."
 
 #: C/moreusage.page:107(p)

--- a/help/es/es.po
+++ b/help/es/es.po
@@ -3,13 +3,13 @@
 # Copyright (C) 2010 kupfer's COPYRIGHT HOLDER
 # This file is distributed under the same license as the kupfer package.
 # Jorge González <jorgegonz@svn.gnome.org>, 2010, 2011.
-# Daniel Mustieles <daniel.mustieles@gmail.com>, 2011, 2013.
+# Daniel Mustieles <daniel.mustieles@gmail.com>, 2011, 2013, 2014.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: kupfer.help.master\n"
-"POT-Creation-Date: 2013-01-22 20:43+0000\n"
-"PO-Revision-Date: 2013-02-05 17:12+0100\n"
+"POT-Creation-Date: 2014-03-23 21:59+0000\n"
+"PO-Revision-Date: 2014-03-26 17:46+0100\n"
 "Last-Translator: Daniel Mustieles <daniel.mustieles@gmail.com>\n"
 "Language-Team: Español <gnome-es-list@gnome.org>\n"
 "Language: \n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
-"X-Generator: KBabel 1.11.4\n"
+"X-Generator: Gtranslator 2.91.5\n"
 
 #: C/plugin-websearch.page:7(desc)
 msgid "Using the search the web plugin."
@@ -536,9 +536,9 @@ msgid ""
 msgstr ""
 "Cuando escala imágenes con la acción <em>Escalar...</em> del complemento "
 "<app>Herramientas de imagen</app>. Esta acción necesita una descripción como "
-"tercer objeto, similar a «1024» o «1200x800». Si habitualmente escala al mismo "
-"tamaño, indique «1200x800», añádalo a favoritos, y aparecerá siempre como una "
-"sugerencia para la acción."
+"tercer objeto, similar a «1024» o «1200x800». Si habitualmente escala al "
+"mismo tamaño, indique «1200x800», añádalo a favoritos, y aparecerá siempre "
+"como una sugerencia para la acción."
 
 #: C/plugin-favorites.page:54(p)
 msgid ""
@@ -595,8 +595,8 @@ msgid ""
 "<cmd>log</cmd>; the command <cmd>=help</cmd> will show a list of all defined "
 "functions and constants."
 msgstr ""
-"El complemento «Calculadora» usa módulos matemáticos de python y complejos, y "
-"analiza expresiones como expresiones de Python. Puede usar funciones "
+"El complemento «Calculadora» usa módulos matemáticos de python y complejos, "
+"y analiza expresiones como expresiones de Python. Puede usar funciones "
 "matemáticas comunes, como <cmd>sqrt</cmd>, <cmd>sin</cmd>, <cmd>exp</cmd> y "
 "<cmd>log</cmd>»; el comando <cmd>=help</cmd> mostrará una lista de todas las "
 "funciones y constantes definidas."
@@ -625,17 +625,21 @@ msgid ""
 "The last result is stored as the name _ (an underscore, just like in the "
 "Python console)."
 msgstr ""
-"El último resultado se guarda como el nombre «_» (guión bajo, igual que en la "
-"consola de Python)."
+"El último resultado se guarda como el nombre «_» (guión bajo, igual que en "
+"la consola de Python)."
 
 #: C/plugin-calculator.page:65(p)
+#| msgid ""
+#| "The Calculator lets you also calculate expression without \"=\" on the "
+#| "beginning as long it have inside one of operators: +, -, *, /, ^, |, , ~."
 msgid ""
 "The Calculator lets you also calculate expression without \"=\" on the "
-"beginning as long it have inside one of operators: +, -, *, /, ^, |, , ~."
+"beginning as long it have inside one of operators: +, -, *, /, ^, |, &amp;, "
+"~."
 msgstr ""
-"La calculadora también le permite calcular expresiones sin «=» al principio "
+"La Calculadora también le permite calcular expresiones sin «=» al principio "
 "siempre y cuando tengan dentro uno de los siguientes operadores: +, -, *, /, "
-"^, |, , ~."
+"^, |, &amp;, ~."
 
 #: C/plugin-applications.page:7(desc)
 msgid "Using the applications plugin."
@@ -846,16 +850,16 @@ msgid ""
 "Some actions are only \"multiplied\" when used with many objects, other are "
 "smarter than that:"
 msgstr ""
-"Algunas acciones sólo se «multiplican» cuando se utilizan con muchos objetos, "
-"otras son más inteligentes que eso:"
+"Algunas acciones sólo se «multiplican» cuando se utilizan con muchos "
+"objetos, otras son más inteligentes que eso:"
 
 #: C/moreusage.page:61(p)
 msgid ""
 "Selecting many files and using the Create Archive action, all files will be "
 "packed into the same archive."
 msgstr ""
-"Al seleccionar varios archivos usando la acción «Crear archivador», todos los "
-"archivos se empaquetarán en el mismo archivo."
+"Al seleccionar varios archivos usando la acción «Crear archivador», todos "
+"los archivos se empaquetarán en el mismo archivo."
 
 #: C/moreusage.page:63(p)
 msgid ""
@@ -873,9 +877,9 @@ msgid ""
 "to this command(!)"
 msgstr ""
 "Si selecciona varios catálogos (por ejemplo, «Marcadores de Firefox» y "
-"«Marcadores de Epiphany») y usa «Buscar contenido...», obtiene una búsqueda de "
-"subcatálogo restringida a los objetos de estos dos catálogos. También puede "
-"asociar un disparador a este comando."
+"«Marcadores de Epiphany») y usa «Buscar contenido...», obtiene una búsqueda "
+"de subcatálogo restringida a los objetos de estos dos catálogos. También "
+"puede asociar un disparador a este comando."
 
 #: C/moreusage.page:71(p)
 msgid ""
@@ -936,8 +940,8 @@ msgid ""
 msgstr ""
 "El comando <cmd>kupfer</cmd> se puede usar para enviar archivos o texto "
 "desde la línea de comandos a <app>Kupfer</app>. Por ejemplo, si está usando "
-"la terminal en una carpeta donde tiene un archivo llamado «informe.pdf» puede "
-"dar el foco a este archivo en <app>Kupfer</app> ejecutando <cmd>kupfer "
+"la terminal en una carpeta donde tiene un archivo llamado «informe.pdf» "
+"puede dar el foco a este archivo en <app>Kupfer</app> ejecutando <cmd>kupfer "
 "report.pdf</cmd>."
 
 #: C/moreusage.page:107(p)
@@ -1818,7 +1822,7 @@ msgstr ""
 "ejemplo, el catálogo de la carpeta «Escritorio» siempre está actualizado."
 
 #. Put one translator per line, in the form of NAME <EMAIL>, YEAR1, YEAR2
-#: C/index.page:0(None)
+#: C/generalusage.page:0(None)
 msgid "translator-credits"
 msgstr ""
 "Daniel Mustieles <daniel.mustieles@gmail.com>, 2011\n"

--- a/help/pl/pl.po
+++ b/help/pl/pl.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Kupfer\n"
-"POT-Creation-Date: 2011-03-12 21:08+0100\n"
-"PO-Revision-Date: 2011-03-13 21:27+0100\n"
+"POT-Creation-Date: 2013-01-22 20:43+0000\n"
+"PO-Revision-Date: 2013-03-20 19:30+0100\n"
 "Last-Translator: Karol Będkowski <karol.bedkowski@gmail.com>\n"
 "Language-Team: Polish <>\n"
 "Language: pl\n"
@@ -17,26 +17,36 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
+#: C/plugin-websearch.page:7(desc)
 msgid "Using the search the web plugin."
-msgstr "Użycie wtyczki przeszukiwania web"
+msgstr "Użycie wtyczki przeszukiwania web."
 
+#: C/plugin-websearch.page:10(app)
 msgid "Search the Web"
 msgstr "Przeszukiwanie web"
 
+#: C/plugin-websearch.page:13(title) C/plugin-triggers.page:23(title)
+#: C/plugin-notes.page:22(title) C/plugin-nautilusselection.page:13(title)
+#: C/plugin-gwibber.page:25(title) C/plugin-favorites.page:22(title)
+#: C/plugin-calculator.page:21(title) C/plugin-applications.page:19(title)
+#: C/generalusage.page:10(title)
 msgid "Basic Usage"
 msgstr "Podstawy obsługi"
 
+#: C/plugin-websearch.page:15(p)
 msgid "Activate Kupfer and make sure it is in free-text mode (press period)"
 msgstr ""
 "Aktywacja Kupfera i upewnienie się, że znajduje się w trybie tekstowym "
 "(naciśnięcie kropki)"
 
+#: C/plugin-websearch.page:17(p)
 msgid ""
 "Type in a search query and tap <key>Tab</key> to switch to the action pane."
 msgstr ""
 "Wpisanie szukanego zapytania i naciśnięcie klawisza <key>Tab</key> aby "
 "przełączyć się do panelu akcji."
 
+#: C/plugin-websearch.page:19(p)
 msgid ""
 "Type \"Search With\" to find Search the Web's action and tap <key>Tab</key> "
 "again to switch to the third pane (indirect object)."
@@ -45,6 +55,7 @@ msgstr ""
 "naciśnięcie <key>Tab</key> aby przejść do trzeciego panelu (obiekt "
 "pośrednik)."
 
+#: C/plugin-websearch.page:22(p)
 msgid ""
 "Select search engine with the arrow keys and type <key>Return</key> to open "
 "the search in a web browser."
@@ -52,9 +63,11 @@ msgstr ""
 "Wybranie wyszukiwarki za pomocą klawiszy strzałek i naciśnięcie klawisza "
 "<key>Return</key> w celu otwarcia wyników wyszukiwania w przeglądarce WWW."
 
+#: C/plugin-websearch.page:29(title)
 msgid "Search Engines"
 msgstr "Wyszukiwarki"
 
+#: C/plugin-websearch.page:30(p)
 msgid ""
 "The Search the Web plugin uses <app>Firefox'</app> search engines, so you "
 "can add Search Engines directly in <app>Firefox</app> and <app>Kupfer</app> "
@@ -62,9 +75,10 @@ msgid ""
 msgstr ""
 "Wtyczka \"Przeszukaj sieć WWW\" używa wyszukiwarek zdefiniowanych w "
 "programie <app>Firefox</app>. Dodanie nowej wyszukiwarki do programu "
-"<app>Firefox<app> pozwoli na ich późniejsze używanie w programie "
+"<app>Firefox</app> pozwoli na ich późniejsze używanie w programie "
 "<app>Kupfer</app>."
 
+#: C/plugin-websearch.page:35(p)
 msgid ""
 "You can also install custom search plugins directly, only for <app>Kupfer</"
 "app>, in the folder:"
@@ -72,22 +86,28 @@ msgstr ""
 "Dodatkowe wyszukiwarki mogą zostać zainstalowane bezpośrednio, tylko dla "
 "programu <app>Kupfer</app>, w katalogu:"
 
+#: C/plugin-websearch.page:39(code)
 #, no-wrap
 msgid "~/.local/share/kupfer/searchplugins/"
 msgstr "~/.local/share/kupfer/searchplugins/"
 
+#: C/plugin-websearch.page:40(p)
 msgid "The search engine descriptions must written in OpenSearch format."
 msgstr "Definicje wyszukiwarek muszą być zapisane w formacie OpenSearch."
 
+#: C/plugin-triggers.page:7(desc)
 msgid "Using the triggers plugin."
 msgstr "Użycie wtyczki wyzwalaczy."
 
+#: C/plugin-triggers.page:10(app) C/keyboard.page:213(title)
 msgid "Triggers"
 msgstr "Wyzwalacze"
 
+#: C/plugin-triggers.page:13(title)
 msgid "Triggers Plugin"
 msgstr "Wtyczka wyzwalaczy"
 
+#: C/plugin-triggers.page:14(p)
 msgid ""
 "With <app>Triggers</app> you can take a command you would normally perform "
 "in <app>Kupfer</app>, such as launching an application or opening a "
@@ -100,19 +120,23 @@ msgstr ""
 "klawiszowych. Jak długo <app>Kupfer</app> jest uruchomiony, wyzwalacze będą "
 "działać niezależnie od aktualnie aktywnej aplikacji."
 
+#: C/plugin-triggers.page:25(title)
 msgid "Creating a new trigger"
 msgstr "Tworzenie nowego wyzwalacza"
 
+#: C/plugin-triggers.page:27(p)
 msgid "Set up a command in <app>Kupfer</app> that you want to run"
 msgstr "Wskazanie polecenia w <app>Kupferze</app> które ma być uruchamiane"
 
+#: C/plugin-triggers.page:32(p)
 msgid ""
 "Press <keyseq><key>Ctrl</key><key>Return</key></keyseq> to create a "
 "<em>composed command</em>."
 msgstr ""
 "Naciśnięcie <keyseq><key>Ctrl</key><key>Return</key></keyseq> w celu "
-"stworzenia <em>skomponowanego polecenia</em>"
+"stworzenia <em>skomponowanego polecenia</em>."
 
+#: C/plugin-triggers.page:38(p)
 msgid ""
 "Type <key>Tab</key> and select the action <em>Add Trigger...</em> and press "
 "<key>Return</key>"
@@ -120,6 +144,7 @@ msgstr ""
 "Naciśnięcie <key>Tab</key>, wybór akcji <em>Dodaj wyzwalacz...</em> i "
 "naciśnięcie <key>Return</key>"
 
+#: C/plugin-triggers.page:44(p)
 msgid ""
 "Using the window that appears, press modifier keys and a letter or number "
 "key to set a global shortcut. An example is pressing and holding "
@@ -133,9 +158,11 @@ msgstr ""
 "naciśnięcie i puszczenie <key>R</key> w celu przypisania <keyseq><key>Ctrl</"
 "key><key>Alt</key><key>R</key></keyseq>."
 
+#: C/plugin-triggers.page:54(title)
 msgid "Removing a trigger"
 msgstr "Usuwanie wyzwalaczy"
 
+#: C/plugin-triggers.page:56(p)
 msgid ""
 "Find the source <em>Triggers</em> in <app>Kupfer</app> and press <key>→</"
 "key> to see its contents."
@@ -143,25 +170,30 @@ msgstr ""
 "Znalezienie źródła <em>Wyzwalacze</em> w programie <app>Kupfer</app> i "
 "naciśnięcie klawisza <key>→</key> w celu wyświetlenia zawartości."
 
+#: C/plugin-triggers.page:62(p)
 msgid ""
 "Find the active trigger in the list and use the action <em>Remove Trigger</"
 "em>."
 msgstr ""
 "Znalezienie aktywnego wyzwalacza na liście i użycie akcji <em>Usuń "
-"wyzwalacz</em>"
+"wyzwalacz</em>."
 
+#: C/plugin-triggers.page:68(p)
 msgid ""
 "Since trigger keyboard shortcuts are global, they can be used from any "
 "application. Select shortcuts with care so that they do not conflict with "
 "other functions."
 msgstr ""
-"Skróty klawiszowe wyzwalaczy są globalne - mogą by używane z poziomu innych "
+"Skróty klawiszowe wyzwalaczy są globalne - mogą być używane z poziomu innych "
 "programów. Skróty należy wybierać z rozwagą, tak aby nie powstały konflikty "
 "z innymi funkcjami."
 
+#: C/plugin-triggers.page:74(title) C/plugin-notes.page:60(title)
+#: C/plugin-gwibber.page:68(title) C/plugin-favorites.page:38(title)
 msgid "Power User Tips"
 msgstr "Porady dla zaawansowanych użytkowników"
 
+#: C/plugin-triggers.page:75(p)
 msgid ""
 "<em>Proxy objects</em> such as <em>Selected Text</em>, <em>Selected File</"
 "em>, <em>Frontmost Window</em>, <em>Last Command</em> et cetera allow very "
@@ -171,6 +203,7 @@ msgstr ""
 "<em>wybrany plik</em>, <em>pierwszoplanowe okno</em>, <em>ostatnie "
 "polecenie</em> itp pozwalają na tworzenie bardzo użytecznych wyzwalaczy."
 
+#: C/plugin-triggers.page:79(p)
 msgid ""
 "The application action <em>Launch</em> is special; if you bind a trigger "
 "using <em>Launch</em>, it will start the application if it is not running, "
@@ -178,54 +211,67 @@ msgid ""
 "Again</em> will start the application if it is running or not."
 msgstr ""
 "Akcja programów <em>uruchom</em> jest specjalna. Utworzenie wyzwalacza z "
-"użyciem <em>uruchom</em> spowoduje uruchomienie programu jeżeli nie jest "
-"uruchomiony lub uaktywnienie jego okna gdy jest już uruchomiony. W "
+"użyciem <em>uruchom</em> spowoduje uruchomienie programu, jeżeli nie jest "
+"uruchomiony lub uaktywnienie jego okna, gdy jest już uruchomiony. W "
 "przeciwieństwie <em>uruchom ponownie</em> uruchomi program niezależnie czy "
 "jest uruchomiony czy nie."
 
+#: C/plugin-triggers.page:87(title)
 msgid "Example Triggers"
 msgstr "Przykładowe wyzwalacze"
 
+#: C/plugin-triggers.page:90(em)
 msgid "Text Editor → Launch"
 msgstr "Edytor tekstu → Uruchom"
 
+#: C/plugin-triggers.page:91(p)
 msgid ""
 "Start <em>Text Editor</em> or focus its window if it is already running."
 msgstr ""
-"Uruchamia <em>edytor tekstu</em> lub uaktywnia jego okno gdy jest już "
+"Uruchamia <em>edytor tekstu</em> lub uaktywnia jego okno, gdy jest już "
 "uruchomiony."
 
+#: C/plugin-triggers.page:97(em)
 msgid "Selected Text → Search With → Google"
 msgstr "Zaznaczony tekst → Szukaj za pomocą... → Google"
 
+#: C/plugin-triggers.page:98(p)
 msgid "Search the web using the currently selected text."
 msgstr "Przeszukuje sieć używając aktualnie zaznaczonego tekstu."
 
+#: C/plugin-triggers.page:100(em)
 msgid "Selected File → Move To → (Downloads Folder)"
-msgstr "Wybrany plik → Przenieś do  → (Pobrane)"
+msgstr "Wybrany plik → Przenieś do → (Pobrane)"
 
+#: C/plugin-triggers.page:101(p)
 msgid "Move the currently selected file to a specific folder"
 msgstr "Przeniesienie zaznaczonego pliku do wskazanego katalogu"
 
+#: C/plugin-triggers.page:105(em)
 msgid "Songs → Search Contents"
 msgstr "Utwory → Przeszukaj zawartość"
 
+#: C/plugin-triggers.page:106(p)
 msgid ""
 "You may even add a trigger to open a specific subcatalog in Kupfer, for "
 "example Rhythmbox's songs."
 msgstr ""
 "Możliwe jest dodanie wyzwalacza w celu otwierania określonego podkatalogu w "
-"Kupferze, na przykład utworów w Rhythmboxie."
+"Kupferze, na przykład utworów w Rhythmboksie."
 
+#: C/plugin-notes.page:7(desc)
 msgid "Using the notes plugin."
 msgstr "Użycie wtyczki notatek"
 
+#: C/plugin-notes.page:10(app) C/plugin-calculator.page:37(title)
 msgid "Notes"
 msgstr "Notatki"
 
+#: C/plugin-notes.page:13(title)
 msgid "Notes Plugin"
 msgstr "Wtyczka notatek"
 
+#: C/plugin-notes.page:14(p)
 msgid ""
 "With <app>Notes</app> you can access or create new notes in either the "
 "program <app>Gnote</app> or <app>Tomboy</app>. <app>Notes</app> will work "
@@ -235,12 +281,14 @@ msgstr ""
 "Wtyczka <em>Notatki</em> umożliwia dostęp i tworzenie nowych notatek w "
 "programie <app>Gnote</app> lub <app>Tomboy</app>. <app>Notatki</app> "
 "działają identycznie w obu programach - wskazanie programu który ma być "
-"użyty możliwe jest na panelu informacyjnym wtyczki, w <app>Ustawieniach "
+"użyty możliwe jest na panelu informacyjnym wtyczki, w <app>Preferencjach "
 "Kupfera</app>"
 
+#: C/plugin-notes.page:24(title)
 msgid "Creating a new note"
 msgstr "Tworzenie nowej notatki"
 
+#: C/plugin-notes.page:26(p)
 msgid ""
 "Activate Kupfer and type <key>.</key> to enter text mode, then type in a "
 "note title"
@@ -248,6 +296,7 @@ msgstr ""
 "Aktywacja Kupfera i naciśnięcie <key>.</key> w celu przejścia do trybu "
 "tekstowego. Następnie wpisanie tytułu notatki."
 
+#: C/plugin-notes.page:32(p)
 msgid ""
 "Type <key>Tab</key> and select the action <em>Create Note</em> and press "
 "<key>Return</key>."
@@ -255,17 +304,21 @@ msgstr ""
 "Naciśnięcie <key>Tab</key>, wybranie akcji <em>Utwórz notatkę</em> i "
 "naciśnięcie <key>Return</key>."
 
+#: C/plugin-notes.page:39(title)
 msgid "Finding a note by title"
 msgstr "Szukanie notatek według tytułu"
 
+#: C/plugin-notes.page:41(p)
 msgid "Simply search for the note title in <app>Kupfer</app>"
 msgstr ""
 "Wyszukanie odbywa się przez proste wyszukanie tytułu notatki w "
 "<app>Kupferze</app>"
 
+#: C/plugin-notes.page:45(title)
 msgid "Finding a note by content"
 msgstr "Szukanie notatek według zawartości"
 
+#: C/plugin-notes.page:47(p)
 msgid ""
 "Activate Kupfer and type <key>.</key> to enter text mode, then type in a "
 "search query"
@@ -273,6 +326,7 @@ msgstr ""
 "Aktywacje <app>Kupfera</app>, naciśnięcie <key>.</key> w celu przejścia do "
 "trybu tekstowego a następnie wpisanie szukanego tekstu."
 
+#: C/plugin-notes.page:53(p)
 msgid ""
 "Type <key>Tab</key> and select the action <em>Get Note Search Results...</"
 "em> and press <key>Return</key>."
@@ -280,28 +334,33 @@ msgstr ""
 "Naciśnięcie <key>Tab</key>, wybranie akcji <em>Wyszukaj wśród notatek ..</"
 "em> i naciśnięcie <key>Return</key>."
 
+#: C/plugin-notes.page:63(p)
 msgid ""
 "You can use the <em>Selected Text</em> object and create a new note with the "
 "content of the selection."
 msgstr ""
-"Istnieje możliwość użycia obiektu <em>Zaznaczony tekst</em> i stworzenie nowej "
-"notatki z zaznaczeniem jako zawartością."
+"Istnieje możliwość użycia obiektu <em>Zaznaczony tekst</em> i stworzenie "
+"nowej notatki z zaznaczeniem jako zawartością."
 
+#: C/plugin-nautilusselection.page:7(desc)
 msgid "Using the selected file plugin."
 msgstr "Użycie wtyczki \"wybrany plik\""
 
+#: C/plugin-nautilusselection.page:10(app)
 msgid "Selected File"
 msgstr "Wybrany plik"
 
+#: C/plugin-nautilusselection.page:14(p)
 msgid ""
 "Select a file in the file manager. Open <app>Kupfer</app> and search for the "
 "object <app>Selected File</app>, which represents the file or files that are "
 "selected."
 msgstr ""
-"Zaznaczenie pliku w menadżerze plików, a następnie otwarcie <app>Kupfera</app> "
-"i wybranie obiektu <app>Wybrany plik</app> reprezentującego zaznaczony wcześniej "
-"plik lub pliki."
+"Zaznaczenie pliku w menadżerze plików, a następnie otwarcie <app>Kupfera</"
+"app> i wybranie obiektu <app>Wybrany plik</app> reprezentującego zaznaczony "
+"wcześniej plik lub pliki."
 
+#: C/plugin-nautilusselection.page:19(p)
 msgid ""
 "Instead of searching, you can press <keyseq><key>Ctrl</key><key>G</key></"
 "keyseq> to directly focus the selected file. See <link xref=\"keyboard\"/> "
@@ -311,9 +370,11 @@ msgstr ""
 "naciśnięcie <keyseq><key>Ctrl</key><key>G</key></keyseq>. Więcej informacji "
 "można znaleźć w <link xref=\"keyboard\"/>."
 
+#: C/plugin-nautilusselection.page:26(title)
 msgid "<app>Selected File</app> requires <app>Nautilus</app>"
 msgstr "Wtyczka <app>Wybrany plik</app> wymaga programu <app>Nautilus</app>"
 
+#: C/plugin-nautilusselection.page:27(p)
 msgid ""
 "The selected file plugin works with the <app>Nautilus</app> file browser and "
 "requires that the extension <cmd>kupfer_provider.py</cmd> is installed (it "
@@ -322,18 +383,22 @@ msgid ""
 msgstr ""
 "Wtyczka <app>Wybrany plik</app> działa z menadżerem plików <app>Nautilius</"
 "app> i wymaga rozszerzenia <cmd>kupfer_provider.py</cmd>, które jest "
-"standardowo instalowane z <app>Kupferem</app>. Po pierwszej instalacji  "
+"standardowo instalowane z <app>Kupferem</app>. Po pierwszej instalacji "
 "<app>Nautilus</app> musi zostać zrestartowany w celu włączenia rozszerzenia."
 
+#: C/plugin-gwibber.page:7(desc)
 msgid "Using the Gwibber plugin."
-msgstr "Użycie wtyczki Gwibber"
+msgstr "Użycie wtyczki Gwibber."
 
+#: C/plugin-gwibber.page:10(app)
 msgid "Gwibber"
 msgstr "Gwibber"
 
+#: C/plugin-gwibber.page:13(title)
 msgid "Gwibber Plugin"
 msgstr "Wtyczka Gwibber"
 
+#: C/plugin-gwibber.page:14(p)
 msgid ""
 "With the <app>Gwibber</app> plugin you can send messages to social networks "
 "such as Twitter or Identi.ca."
@@ -341,6 +406,7 @@ msgstr ""
 "Wtyczka <app>Gwibber</app> umożliwia wysyłanie wiadomości do sieci "
 "społecznościowych takich jak Twitter czy Identi.ca."
 
+#: C/plugin-gwibber.page:18(p)
 msgid ""
 "The plugin requires that the application <app>Gwibber</app> is installed and "
 "configured for your user. <app>Kupfer</app> will start and use Gwibber's "
@@ -350,9 +416,11 @@ msgstr ""
 "app>. <app>Kupfer</app> podczas pracy uruchamia i używa w tle serwisu "
 "Gwibbera."
 
+#: C/plugin-gwibber.page:27(title)
 msgid "Sending a message to all services"
 msgstr "Wysyłanie wiadomości do wszystkich serwisów"
 
+#: C/plugin-gwibber.page:29(p)
 msgid ""
 "Activate Kupfer and type <key>.</key> to enter text mode, then type in a "
 "message."
@@ -360,6 +428,7 @@ msgstr ""
 "Aktywacja Kupfera i naciśnięcie <key>.</key> w celu przejścia do trybu "
 "tekstowego. Następnie wpisanie wiadomości."
 
+#: C/plugin-gwibber.page:35(p)
 msgid ""
 "Type <key>Tab</key> and select the action <em>Send Message</em> and press "
 "<key>Return</key>."
@@ -367,9 +436,11 @@ msgstr ""
 "Naciśnięcie <key>Tab</key>, wybór akcji <em>Wyślij wiadomość</em> i "
 "naciśnięcie <key>Return</key>"
 
+#: C/plugin-gwibber.page:42(title)
 msgid "Sending a message to a specific service"
 msgstr "Wysyłanie wiadomości do określonego serwisu"
 
+#: C/plugin-gwibber.page:44(p)
 msgid ""
 "Activate Kupfer and search for the service object, for example <em>Identi."
 "ca</em>"
@@ -377,16 +448,19 @@ msgstr ""
 "Aktywacja Kupfera i wyszukanie obiektu serwisu - na przykład <em>Identi.ca</"
 "em>"
 
+#: C/plugin-gwibber.page:50(p)
 msgid "Type <key>Tab</key> and select the action <em>Send Message</em>."
 msgstr "Naciśnięcie <key>Tab</key>, wybór akcji <em>Wyślij wiadomość</em>."
 
+#: C/plugin-gwibber.page:55(p)
 msgid ""
 "Type <key>Tab</key> to select the last pane, and type in a message. Press "
 "<key>Return</key> to send."
 msgstr ""
 "Naciśnięcie <key>Tab</key> w celu wybrania ostatniego panelu a następnie "
-"wpisanie wiadomości. Naciśnięcie  <key>Return</key> wysyła wiadomość."
+"wpisanie wiadomości. Naciśnięcie <key>Return</key> wysyła wiadomość."
 
+#: C/plugin-gwibber.page:61(p)
 msgid ""
 "The plugin also provides a source for incoming messages, <em>Gwibber "
 "Messages</em> and more actions on messages such as <em>Reply</em>, <em>Send "
@@ -396,6 +470,7 @@ msgstr ""
 "em>) oraz więcej akcji dla wiadomości, takich jak <em>Odpowiedz</em>, "
 "<em>Wyślij prywatną wiadomość</em> itd."
 
+#: C/plugin-gwibber.page:71(p)
 msgid ""
 "You can use the <em>comma trick</em> if you want to send a message to more "
 "than one service, but not all, at the same time."
@@ -403,30 +478,36 @@ msgstr ""
 "Jest możliwe użycie <em>triku z przecinkiem</em> w celu wysłania wiadomości "
 "od razu do więcej niż jednego serwisu."
 
+#: C/plugin-favorites.page:7(desc)
 msgid "Using the favorites plugin."
-msgstr "Użycie wtyczki \"ulubione\""
+msgstr "Użycie wtyczki \"ulubione\"."
 
+#: C/plugin-favorites.page:10(app)
 msgid "Favorites"
 msgstr "Ulubione"
 
+#: C/plugin-favorites.page:13(title)
 msgid "Favorites Plugin"
 msgstr "Wtyczka ulubione"
 
+#: C/plugin-favorites.page:14(p)
 msgid ""
 "With <app>Favorites</app> you mark objects, for example files, for quicker "
 "access. It is a sort of shelf on which you can store objects in Kupfer. "
 "Objects marked as favorites will also be ranked higher and are adorned with "
 "a star symbol."
 msgstr ""
-"Wtyczka  <app>Ulubione</app> umożliwia zaznaczenie obiektów, na przykład "
+"Wtyczka <app>Ulubione</app> umożliwia zaznaczenie obiektów, na przykład "
 "plików, w celu szybszego do nich dostępu. Jest to swego rodzaju półki na "
 "której można umieścić obiekty w Kupferze. Dodatkowo obiekty oznaczone jako "
 "ulubione umieszczane są wyżej w rankingu wyszukanych obiektów oraz oznaczane "
 "symbolem gwiazdki."
 
+#: C/plugin-favorites.page:25(p)
 msgid "Find an object in <app>Kupfer</app>"
 msgstr "Znalezienie obiektu w <app>Kupferze</app>"
 
+#: C/plugin-favorites.page:30(p)
 msgid ""
 "Type <key>Tab</key> and select either the action <em>Add to Favorites</em> "
 "or <em>Remove from Favorites</em>."
@@ -434,6 +515,7 @@ msgstr ""
 "Naciśnięcie <key>Tab</key> i wybranie akcie <em>Dodaj do ulubionych</em> lub "
 "<em>Usuń z ulubionych</em>."
 
+#: C/plugin-favorites.page:39(p)
 msgid ""
 "If you favorite an object, you can access it in more places. Not only in the "
 "\"Favorites\" subcatalog, but also as the indirect (secondary) object for "
@@ -443,9 +525,11 @@ msgstr ""
 "podkatalogu \"Ulubione\", ale także jako obiekty pośrednika (drugie) dla "
 "niektórych akcji. Na przykład:"
 
+#: C/plugin-favorites.page:45(p)
 msgid "Command-lines from favorites are quick to access."
-msgstr "Dostęp do ulubionych poleceń linii komend jest szybszy."
+msgstr "Dostęp do ulubionych poleceń jest szybszy."
 
+#: C/plugin-favorites.page:46(p)
 msgid ""
 "When scaling images with the <em>Scale...</em> action from the <app>Image "
 "Tools</app> plugin. This action needs a size description as the third "
@@ -459,22 +543,27 @@ msgstr ""
 "często do tego samego rozmiaru, na przykład \"1200x800\", dodanie go do "
 "ulubionych spowoduje, że będzie pojawiać się jako sugerowany dla tej akcji."
 
+#: C/plugin-favorites.page:54(p)
 msgid ""
 "Actions needing an email address as the indirect object will pick up email "
 "addresses from favorites as well as well."
 msgstr ""
-"Akcje wymagające adresu email jako dodatkowego obiektu będą także pobierać "
+"Akcje wymagające adresu e-mail jako dodatkowego obiektu będą także pobierać "
 "adresy z ulubionych."
 
+#: C/plugin-calculator.page:7(desc)
 msgid "Using the calculator plugin."
 msgstr "Użycie wtyczki kalkulator"
 
+#: C/plugin-calculator.page:10(app)
 msgid "Calculator"
 msgstr "Kalkulator"
 
+#: C/plugin-calculator.page:13(title)
 msgid "Calculator Plugin"
 msgstr "Wtyczka kalkulator"
 
+#: C/plugin-calculator.page:14(p)
 msgid ""
 "The calculator plugin lets you calculate expressions quickly. It can "
 "evaluate expressions entered as text starting with \"=\". Entering = from "
@@ -482,22 +571,26 @@ msgid ""
 msgstr ""
 "Wtyczka \"Kalkulator\" umożliwia szybkie wykonywanie obliczeń, poprzez "
 "obliczanie wartości wyrażeń wpisanych jako ciągi rozpoczynające się od znaki "
-"\"=\". Dla szybszego dostępu wprowadzenie znaku \"=\" w trybie komend "
+"\"=\". Dla szybszego dostępu wprowadzenie znaku \"=\" w trybie poleceń "
 "rozpoczyna od razu tryb tekstowy."
 
+#: C/plugin-calculator.page:23(p)
 msgid "Activate Kupfer and type <key>=</key>"
 msgstr "Aktywacja Kupfera i naciśnięcie <key>=</key>"
 
+#: C/plugin-calculator.page:26(p)
 msgid ""
 "Type in a mathematical expression using <key>+</key>,<key>-</key>,<key>/</"
 "key>,<key>*</key> (and <key>**</key> for exponentiation)"
 msgstr ""
-"Wpisanie wyrażenie matematycznego  używającego <key>+</key>,<key>-</key>,"
+"Wpisanie wyrażenie matematycznego używającego <key>+</key>,<key>-</key>,"
 "<key>/</key>,<key>*</key> (dla <key>**</key> dla potęgowania)"
 
+#: C/plugin-calculator.page:30(p)
 msgid "Press <key>Return</key> to get the result."
 msgstr "Naciśnięcie <key>Return</key> w celu obliczenia rezultatu."
 
+#: C/plugin-calculator.page:38(p)
 msgid ""
 "The Calculator uses python's math and complex math modules, and parses "
 "expressions as Python expressions. You may use common mathematical "
@@ -506,11 +599,12 @@ msgid ""
 "functions and constants."
 msgstr ""
 "Kalkulator używa modułów pythonowych \"math\" i \"complex math\" oraz "
-"interpretuje wyrażenia Pythona. Wtyczka umożliwia  stosowanie standardowych "
-"funkcji matematycznych, takich jak <cmd>sqrt</cmd>, <cmd>sin</cmd>, </"
-"cmd>exp</cmd> oraz <cmd>log</cmd>. Komenda <cmd>=help</cmd> wyświetla listę "
-"wszystkich dostępnych funkcji i stałych."
+"interpretuje wyrażenia Pythona. Wtyczka umożliwia stosowanie standardowych "
+"funkcji matematycznych, takich jak <cmd>sqrt</cmd>, <cmd>sin</cmd>, "
+"<cmd>exp</cmd> oraz <cmd>log</cmd>. Polecenie <cmd>=help</cmd> wyświetla "
+"listę wszystkich dostępnych funkcji i stałych."
 
+#: C/plugin-calculator.page:47(p)
 msgid ""
 "Notice that the power operator in Python is double stars, for example "
 "<code>=3**3</code> will evaluate to 27."
@@ -518,15 +612,18 @@ msgstr ""
 "Proszę zauważyć, że operatorem potęgowania w Pytonie jest podwójna gwiazdka, "
 "na przykład wyrażenie <code>=3**3</code> zostanie obliczone jako 27."
 
+#: C/plugin-calculator.page:53(p)
 msgid "To calculate trig functions for angles, convert to radians first:"
 msgstr ""
 "Aby obliczyć wartości funkcji trygonometrycznych dla kątów, muszą one zostać "
 "najpierw zamienione na radiany:"
 
+#: C/plugin-calculator.page:56(code)
 #, no-wrap
 msgid "sin(radians(30)) -&gt; 0.5"
 msgstr "sin(radians(30)) -&gt; 0.5"
 
+#: C/plugin-calculator.page:59(p)
 msgid ""
 "The last result is stored as the name _ (an underscore, just like in the "
 "Python console)."
@@ -534,48 +631,114 @@ msgstr ""
 "Ostatni wynik jest zapisywany pod nazwą _ (podkreślenie, tak ja w konsoli "
 "pythonowej)"
 
+#: C/plugin-calculator.page:65(p)
+msgid ""
+"The Calculator lets you also calculate expression without \"=\" on the "
+"beginning as long it have inside one of operators: +, -, *, /, ^, |, , ~."
+msgstr ""
+
+#: C/plugin-applications.page:7(desc)
 msgid "Using the applications plugin."
 msgstr "Użycie wtyczki programów"
 
+#: C/plugin-applications.page:10(app)
 msgid "Applications"
 msgstr "Programy"
 
+#: C/plugin-applications.page:13(title)
 msgid "Applications Plugin"
 msgstr "Wtyczka programy"
 
+#: C/plugin-applications.page:14(p)
 msgid "<app>Applications</app> provides all installed programs."
 msgstr ""
 "Wtyczka <app>Programy</app> dostarcza listę wszystkich zainstalowanych "
 "programów."
 
+#: C/plugin-applications.page:21(title)
 msgid "Launching an application"
 msgstr "Uruchamianie programu"
 
+#: C/plugin-applications.page:23(p)
 msgid "Activate Kupfer and type an abbreviation of the application name"
 msgstr "Aktywacja Kupfera i wpisanie skrótu nazwy programu."
 
+#: C/plugin-applications.page:28(p)
 msgid "Press <key>Return</key> to launch the application."
 msgstr "Naciśnięcie <key>Return</key> w celu uruchomienia programu."
 
+#: C/plugin-applications.page:34(title)
 msgid "Opening a file with a specific application"
 msgstr "Otwieranie pliku z użyciem określonej aplikacji."
 
+#: C/plugin-applications.page:36(p)
 msgid "Select a file in <app>Kupfer</app>"
 msgstr "Wybranie pliku w <app>Kupferze</app>"
 
+#: C/plugin-applications.page:41(p)
 msgid "Type <key>Tab</key> and select the action <em>Open With...</em>"
 msgstr "Naciśnięcie <key>Tab</key>, wybór akcji <em>Otwórz za pomocą</em>."
 
+#: C/plugin-applications.page:46(p)
+#, fuzzy
+#| msgid ""
+#| "Type <key>Tab</key> to select the third (indirect object) pane and in it, "
+#| "select the application the file with."
 msgid ""
 "Type <key>Tab</key> to select the third (indirect object) pane and in it, "
-"select the application the file with."
+"select the application to open the file with."
 msgstr ""
-"Naciśnięcie <key>Tab</key> w celu przejścia do  trzeciego panelu (obiekt "
+"Naciśnięcie <key>Tab</key> w celu przejścia do trzeciego panelu (obiekt "
 "pośrednik), a następnie wybranie programy dla pliku."
 
+#: C/plugin-applications.page:53(p)
+msgid ""
+"The action <em>Open</em> opens files and folders with the registered default "
+"application for that specific file type. This can be configured using the "
+"action <em>Set Default Application...</em>."
+msgstr ""
+
+#: C/plugin-applications.page:58(p)
+msgid ""
+"The file type associations are provided by the desktop environment, and "
+"modifying them here will modify them on the desktop as well. This may not be "
+"true when not using GNOME or XFCE."
+msgstr ""
+
+#: C/plugin-applications.page:64(title)
+msgid "Selecting default application for a file type or folders"
+msgstr ""
+
+#: C/plugin-applications.page:66(p)
+#, fuzzy
+#| msgid "Select a file in <app>Kupfer</app>"
+msgid "Select a file or folder in <app>Kupfer</app>"
+msgstr "Wybranie pliku w <app>Kupferze</app>"
+
+#: C/plugin-applications.page:71(p)
+#, fuzzy
+#| msgid "Type <key>Tab</key> and select the action <em>Open With...</em>"
+msgid ""
+"Type <key>Tab</key> and select the action <em>Set Default Application...</em>"
+msgstr "Naciśnięcie <key>Tab</key>, wybór akcji <em>Otwórz za pomocą</em>."
+
+#: C/plugin-applications.page:77(p)
+#, fuzzy
+#| msgid ""
+#| "Type <key>Tab</key> to select the third (indirect object) pane and in it, "
+#| "select the application the file with."
+msgid ""
+"Type <key>Tab</key> to select the third (indirect object) pane and in it, "
+"select the application to always open the file type with."
+msgstr ""
+"Naciśnięcie <key>Tab</key> w celu przejścia do trzeciego panelu (obiekt "
+"pośrednik), a następnie wybranie programy dla pliku."
+
+#: C/plugin-applications.page:85(title)
 msgid "Configuration"
 msgstr "Konfiguracja"
 
+#: C/plugin-applications.page:86(p)
 msgid ""
 "The configuration option <em>Applications for Desktop Environment</em> in "
 "the plugin's information pane in <app>Kupfer Preferences</app> determines "
@@ -584,21 +747,25 @@ msgid ""
 "which desktop environment is used. By default, it behaves like GNOME."
 msgstr ""
 "Parametr konfiguracyjny <em>Programy środowiska graficznego</em> w panelu "
-"informacyjnym wtyczki w <app>Ustawieniach Kupfera</app> określa jak "
+"informacyjnym wtyczki w <app>Preferencjach Kupfera</app> określa jak "
 "<app>Kupfer</app> powinien zachowywać się przy pobieraniu konfiguracji "
 "środowiska graficznego - wiele aplikacji nie powinno być pokazywanych w "
 "zależności od aktualnie używanego środowiska graficznego. Domyślnym "
 "ustawieniem jest środowisko GNOME."
 
+#: C/moreusage.page:7(desc)
 msgid "More advanced usage information."
 msgstr "Informacje o zaawansowanym użyciu"
 
+#: C/moreusage.page:10(title)
 msgid "Using <app>Kupfer</app> in Depth"
-msgstr "Zaawansowane używanie <app>Kupfera></app>"
+msgstr "Zaawansowane używanie <app>Kupfera</app>"
 
+#: C/moreusage.page:13(title)
 msgid "Adding Applications and Scripts"
 msgstr "Dodawanie programów i skryptów"
 
+#: C/moreusage.page:14(p)
 msgid ""
 "<app>Kupfer</app> will show all applications that are configured visible in "
 "your menu editor."
@@ -606,6 +773,7 @@ msgstr ""
 "<app>Kupfera</app> będzie pokazywał wszystkie programy, które są oznaczone "
 "jako widoczne w edytorze menu."
 
+#: C/moreusage.page:18(p)
 msgid ""
 "If you want to add an application manually, you can create a new <code>."
 "desktop</code> file and place it in one of the standard directories for "
@@ -616,6 +784,7 @@ msgstr ""
 "plik <code>.desktop</code> i umieścić go w jednym ze standardowych miejsc "
 "dla programów, np w <file>~/.local/share/applications</file>. "
 
+#: C/moreusage.page:24(p)
 msgid ""
 "If you have a collection of scripts that you want to call from <app>Kupfer</"
 "app>, you can add the scripts folder as a catalog directory to <app>Kupfer</"
@@ -625,20 +794,34 @@ msgid ""
 msgstr ""
 "Jeżeli użytkownik posiada kolekcję skryptów, które mają być uruchamiane "
 "poprzez <app>Kupfera</app>, katalog ze skryptami może zostać dodany "
-"bezpośrednio do <app>Kupfera</app> w oknie ustawień. Skrypty dodane w ten "
+"bezpośrednio do <app>Kupfera</app> w oknie preferencji. Skrypty dodane w ten "
 "sposób do <app>Kupfera</app> mogą być uruchamiana bezpośrednio lub w "
 "terminalu pod warunkiem, że są one wykonywalne."
 
+#: C/moreusage.page:31(p)
 msgid ""
 "You can also save command-lines by using the action <em>Add to Favorites</"
 "em>."
 msgstr ""
-"Istnieje także możliwość zapisania poleceń linii komend używając akcji "
+"Istnieje także możliwość zapisania poleceń wiersza poleceń używając akcji "
 "<em>Dodaj do ulubionych</em>."
 
+#: C/moreusage.page:38(title)
+msgid "Opening Files and Folders"
+msgstr ""
+
+#: C/moreusage.page:39(p)
+msgid ""
+"Using the action <em>Open</em>, files and folders are opened in their "
+"preferred application. The application associations can be changed, see "
+"<link xref=\"plugin-applications\"/>."
+msgstr ""
+
+#: C/moreusage.page:47(title)
 msgid "The <em>Comma Trick</em>"
 msgstr "<em>Trik z przecinkiem</em>"
 
+#: C/moreusage.page:48(p)
 msgid ""
 "The comma trick allows the user to use actions on many objects at the same "
 "time."
@@ -646,24 +829,27 @@ msgstr ""
 "Trik z przecinkiem umożliwia użytkownikowi użycie akcji od razu dla wielu "
 "obiektów."
 
+#: C/moreusage.page:52(p)
 msgid ""
 "Simply press comma <key>,</key> when an object is selected. The object is "
 "put on a \"stack\", and you can find yet another file or object, press comma "
 "to put it on the stack. When you subsequently invoke an action, the action "
 "is carried out on all of the objects at the same time."
 msgstr ""
-"Naciśnięcie przecinka <key>,</key> spowoduje umieszczenie zaznaczonego obiektu "
-"na \"stosie\". Kupfer umożliwia znalezienie kolejnego "
-"obiektu i dodanie go na stos przez ponowne naciśnięcie przecinka. Późniejsze "
-"wywołanie akcji uwzględni wszystkie obiekty umieszczone na stosie."
+"Naciśnięcie przecinka <key>,</key> spowoduje umieszczenie zaznaczonego "
+"obiektu na \"stosie\". Kupfer umożliwia znalezienie kolejnego obiektu i "
+"dodanie go na stos przez ponowne naciśnięcie przecinka. Późniejsze wywołanie "
+"akcji uwzględni wszystkie obiekty umieszczone na stosie."
 
+#: C/moreusage.page:58(p)
 msgid ""
 "Some actions are only \"multiplied\" when used with many objects, other are "
 "smarter than that:"
 msgstr ""
-"Niektóre akcje są jedynie wywoływane wielokrotnie gdy są uruchomione dla wielu "
-"obiektów. Inne są sprytniejsze:"
+"Niektóre akcje są jedynie wywoływane wielokrotnie, gdy są uruchomione dla "
+"wielu obiektów. Inne są sprytniejsze:"
 
+#: C/moreusage.page:61(p)
 msgid ""
 "Selecting many files and using the Create Archive action, all files will be "
 "packed into the same archive."
@@ -671,37 +857,42 @@ msgstr ""
 "Zaznaczenie wielu plików i użycie akcji \"Utwórz archiwum\" spowoduje "
 "dodanie wszystkich plików do jednego archiwum."
 
+#: C/moreusage.page:63(p)
 msgid ""
 "If you select multiple contacts and use a Send Email action, it creates one "
 "email directed at all the contacts."
 msgstr ""
-"Zaznaczenie wielu kontaktów i użycie akcji \"Wyślij Email\" utworzy jeden "
-"email do wszystkich wybranych kontaktów."
+"Zaznaczenie wielu kontaktów i użycie akcji \"Wyślij e-mail\" utworzy jeden "
+"e-mail do wszystkich wybranych kontaktów."
 
+#: C/moreusage.page:65(p)
 msgid ""
 "If you select multiple subcatalogs (For example Firefox Bookmarks and "
 "Epiphany Bookmarks) and use Search Contents.., you get a subcatalog search "
 "restricted to the objects of those two catalogs! You can even bind a trigger "
 "to this command(!)"
 msgstr ""
-"Zaznaczenie wielu podkatalogów (np. Zakładki Firefox i Zakładki Epiphany) i "
-"użycie akcji \"Przeszukaj zawartość\" spowoduje umożliwi przeszukanie "
-"podkatalogu zbudowanego z obiektów pochodzących z tych dwóch katalogów. Kupfer "
-"umożliwia także przypisanie wyzwalacza do takiej komendy."
+"Zaznaczenie wielu podkatalogów (np. Zakładki Firefoksa i Zakładki Epiphany) "
+"i użycie akcji \"Przeszukaj zawartość\" spowoduje umożliwi przeszukanie "
+"podkatalogu zbudowanego z obiektów pochodzących z tych dwóch katalogów. "
+"Kupfer umożliwia także przypisanie wyzwalacza do takiego polecenia."
 
+#: C/moreusage.page:71(p)
 msgid ""
 "The comma trick is <link href=\"http://www.43folders.com/2005/06/13/"
 "quicksilver-the-comma-trick\"> directly taken from Quicksilver</link> (the "
 "example given in the external article should work identically in Kupfer)."
 msgstr ""
-"Trik z kropką jest wzorowany bezpośrednio na  <link href=\"http://"
+"Trik z kropką jest wzorowany bezpośrednio na <link href=\"http://"
 "www.43folders.com/2005/06/13/quicksilver-the-comma-trick\">programie "
 "Quicksilver</link> (przykłady podane w zewnętrznym artykule powinny działać "
 "identycznie w Kupferze)."
 
+#: C/moreusage.page:80(title)
 msgid "Grab Current Selection"
 msgstr "Przechwyć aktualne zaznaczenie"
 
+#: C/moreusage.page:81(p)
 msgid ""
 "To use the current selected text, from any application, with <app>Kupfer</"
 "app>, you can configure a global keyboard shortcut for the action <em>Show "
@@ -709,9 +900,10 @@ msgid ""
 msgstr ""
 "W celu użycia aktualnie zaznaczonego tekstu z dowolnego programu "
 "<app>Kupfer</app> umożliwia skonfigurowanie globalnego skrótu klawiszowego "
-"dla akcji <em>Wyświetlenie zaznaczenia</em> w <app>ustawieniach Kupfera</"
+"dla akcji <em>Wyświetlenie zaznaczenia</em> w <app>Preferencjach Kupfera</"
 "app>."
 
+#: C/moreusage.page:85(p)
 msgid ""
 "If configured, pressing the global keyboard shortcut will summon "
 "<app>Kupfer</app> with the current selection as the focused object."
@@ -719,48 +911,37 @@ msgstr ""
 "Po skonfigurowaniu, naciśnięcie globalnego skrótu klawiszowego wywoła "
 "<app>Kupfera</app> z zaznaczeniem jako wybranym obiektem."
 
+#: C/moreusage.page:90(p)
 msgid "See <link xref=\"keyboard\"/>"
 msgstr "Więcej informacji: <link xref=\"keyboard\"/>"
 
-msgid "Open Terminal Here"
-msgstr "Uruchom terminal w tym miejscu"
-
-msgid ""
-"Open terminal first calls <cmd>xdg-terminal</cmd>, then <cmd>gnome-terminal</"
-"cmd>. xdg-terminal is a script to find the user's configured terminal "
-"program for their Desktop Environment. Install <cmd>xdg-terminal</cmd> if "
-"you need this (or install a symlink <em>called</em> xdg-terminal)."
-msgstr ""
-"\"Uruchom terminal\" w pierwszej kolejności próbuje uruchomić <cmd>xdg-"
-"terminal</cmd>, potem <cmd>gnome-terminal</cmd>. xdg-terminal jest skryptem, "
-"który uruchamia skonfigurowany przez użytkownika program terminala dla "
-"środowiska graficznego. Jeżeli istnieje taka potrzeba należy zainstalować "
-"<cmd>xdg-terminal</cmd> (lub utworzyć łącze symboliczne o <em>nazwie</em> "
-"xdg-teminal)."
-
+#: C/moreusage.page:94(title)
 msgid "Command-line Connection"
-msgstr "Powiązania z linią komend"
+msgstr "Powiązania z wierszem poleceń"
 
+#: C/moreusage.page:95(p)
 msgid ""
 "The command <cmd>kupfer</cmd> on the command-line will focus <app>Kupfer</"
 "app> if it's already running, otherwise it will start it."
 msgstr ""
-"Komenda <cmd>kupfer</cmd> wykonana w linii poleceń wyświetli <app>Kupfera</"
-"app> jeżeli jest już uruchomi. W przeciwnym wypadku - <app>Kupfer</app> "
-"zostanie uruchomiony."
+"Polecenie <cmd>kupfer</cmd> wykonana w wierszu poleceń wyświetli "
+"<app>Kupfera</app>, jeżeli jest już uruchomiony. W przeciwnym wypadku - "
+"<app>Kupfer</app> zostanie uruchomiony."
 
+#: C/moreusage.page:99(p)
 msgid ""
 "The command <cmd>kupfer</cmd> can be used to send files or text from the "
 "command-line to <app>Kupfer</app>. For example, if you are using the shell "
 "in a directory where you have a file called \"report.pdf\", you can focus "
 "this file in <app>Kupfer</app> by running <cmd>kupfer report.pdf</cmd>."
 msgstr ""
-"Komenda <cmd>kupfer</cmd> może być użyta do przesyłania plików lub tekstu z "
-"programów uruchamianych z linii komend do <app>Kupfera</app>. Dla przykładu, "
-"jeżeli podczas pracy w powłoce w katalogu znajduje się plik \"raport.pdf\", "
-"możliwe jest wybranie tego pliku w <app>Kupferze</app> przez uruchomienie "
-"<cmd>kupfer raport.pdf</cmd>."
+"Polecenie <cmd>kupfer</cmd> może być użyta do przesyłania plików lub tekstu "
+"z programów uruchamianych z wiersza poleceń do <app>Kupfera</app>. Dla "
+"przykładu, jeżeli podczas pracy w powłoce w katalogu znajduje się plik "
+"\"raport.pdf\", możliwe jest wybranie tego pliku w <app>Kupferze</app> przez "
+"uruchomienie <cmd>kupfer raport.pdf</cmd>."
 
+#: C/moreusage.page:107(p)
 msgid ""
 "You can also send text if you pipe the output of a command into <cmd>kupfer</"
 "cmd>."
@@ -768,9 +949,11 @@ msgstr ""
 "Istnieje możliwość przesłania wyniku wywołania programu do polecenia "
 "<cmd>kupfer</cmd>."
 
+#: C/moreusage.page:114(title)
 msgid "Managing Context and Current Selection"
 msgstr "Zarządzanie kontekstem i aktualnym zaznaczeniem"
 
+#: C/moreusage.page:115(p)
 msgid ""
 "If you find the object you want to use, then invoke an action, <app>Kupfer</"
 "app> goes away to perform the action (for example start a program or play a "
@@ -787,6 +970,7 @@ msgstr ""
 "utworu muzycznego) a także może być użyteczne przy przeprowadzaniu innej "
 "akcji na tym samym obiekcie."
 
+#: C/moreusage.page:123(p)
 msgid ""
 "However, you always have the top level catalog reachable when you \"come back"
 "\" to <app>Kupfer</app> -- say you went into the subcatalog \"Albums\" to "
@@ -801,6 +985,7 @@ msgstr ""
 "ale wyszukiwanie będzie odbywało się na najwyższym poziomie katalogu a nie "
 "albumu."
 
+#: C/moreusage.page:130(p)
 msgid ""
 "How to come back into the subcatalog you were in? You do that by simply "
 "browsing, not searching the first thing you do when you focus <app>Kupfer</"
@@ -814,6 +999,7 @@ msgstr ""
 "celu otwarcia okna przeglądarki. Gdy okno przeglądarki zostanie otwarte, "
 "kolejne wyszukiwanie będzie odbywało się w aktualnym podkatalogu."
 
+#: C/moreusage.page:137(p)
 msgid ""
 "This way you can work both ways -- you can quickly drill down into folders "
 "to find a file, and when you come back for the next action with <app>Kupfer</"
@@ -827,9 +1013,11 @@ msgstr ""
 "rozpoczęcie pisania) lub pozostać w miejscu gdzie się było poprzednio, w "
 "zagnieżdżonym katalogu (przez naciśnięcie spacji, a później pisanie)."
 
+#: C/moreusage.page:146(title)
 msgid "Saving Commands as Files"
 msgstr "Zapisywanie poleceń jako pliki"
 
+#: C/moreusage.page:147(p)
 msgid ""
 "You can use keyboard shortcut for <em>Compose Command</em> (by default it is "
 "<keyseq><key>Ctrl</key><key>Return</key></keyseq>) to create a command "
@@ -838,20 +1026,23 @@ msgid ""
 "resulting file will can be executed when opened from the file manager (it "
 "requires that Kupfer is already running)."
 msgstr ""
-"<app>Kupfer</app> umożliwia użycie skrótu klawiszowego dla komendy "
+"<app>Kupfer</app> umożliwia użycie skrótu klawiszowego dla polecenia "
 "<em>komponuj</em> (domyślnie <keyseq><key>Ctrl</key><key>Return</key></"
-"keyseq>) w celu utworzenia obiektu komendy na podstawie aktualnie "
+"keyseq>) w celu utworzenia obiektu polecenia na podstawie aktualnie "
 "podświetlonego polecenia w Kupferze. Obiekt taki może być zapisany jako "
 "uruchamialny plik przez użycie akcji <em>Zapisz jako...</em>. Plik, który w "
 "rezultacie zostanie utworzony, może zostać otwarty przez menadżer plików "
 "(wymaga uruchomionego Kupfera)."
 
+#: C/managing-plugins.page:7(desc)
 msgid "Using plugins with <app>Kupfer</app>."
 msgstr "Używanie wtyczek w <app>Kupfera</app>"
 
+#: C/managing-plugins.page:10(title)
 msgid "How to Configure Plugins"
 msgstr "Konfiguracja wtyczek"
 
+#: C/managing-plugins.page:12(p)
 msgid ""
 "Functionality in Kupfer is organized by extentsion modules called \"plugins"
 "\". Each plugin provides additional functionality, for example integration "
@@ -861,36 +1052,48 @@ msgstr ""
 "\"wtyczkami\". Każda wtyczka dostarcza dodatkowe funkcje, na przykład - "
 "integrację z zewnętrznymi programami."
 
+#: C/managing-plugins.page:19(title)
 msgid "Configuring Plugins"
 msgstr "Konfiguracja wtyczek"
 
+#: C/managing-plugins.page:21(title)
 msgid "Open <app>Kupfer Preferences</app> to the Plugins tab"
-msgstr "Otwarcie <app>Ustawienia Kupfera</app> i zakładki \"Wtyczki\"."
+msgstr "Otwarcie <app>Preferencji Kupfera</app> i karty \"Wtyczki\""
 
+#: C/managing-plugins.page:23(p)
 msgid "Use one of the following methods:"
-msgstr "Otwarcie okna ustawień jest możliwe poprzez:"
+msgstr "Otwarcie okna preferencji jest możliwe poprzez:"
 
+#: C/managing-plugins.page:25(p)
 msgid ""
 "Click the Kupfer icon in the notification area and select the item "
 "<em>Preferences</em>"
 msgstr ""
-"Kliknięcie ikony Kupfera w obszarze powiadamiania i wybranie <em>Ustawienia</"
-"em>"
+"Kliknięcie ikony Kupfera w obszarze powiadamiania i wybranie "
+"<em>Preferencje</em>"
 
+#: C/managing-plugins.page:25(item)
+msgid "<placeholder-1/>."
+msgstr "<placeholder-1/>."
+
+#: C/managing-plugins.page:29(p)
 msgid ""
 "Search for the object <app>Kupfer Preferences</app> in Kupfer itself. Press "
 "<key>Return</key> to open it."
 msgstr ""
-"Znalezienie obiektu <app>Ustawienia Kupfera</app> w Kupferze. Naciśnięcie "
-"klawisza <key>Return</key> otwiera okno ustawień."
+"Znalezienie obiektu <app>Preferencje Kupfera</app> w Kupferze. Naciśnięcie "
+"klawisza <key>Return</key> otwiera okno preferencji."
 
+#: C/managing-plugins.page:33(p)
 msgid "Use the keyboard shortcut <keyseq><key>Ctrl</key><key>;</key></keyseq>"
 msgstr ""
 "Użycie skrótu klawiszowego <keyseq><key>Ctrl</key><key>;</key></keyseq>"
 
+#: C/managing-plugins.page:39(p)
 msgid "Select the tab <em>Plugins</em>"
-msgstr "Wybranie zakładki <em>Wtyczki</em>"
+msgstr "Wybranie karty <em>Wtyczki</em>"
 
+#: C/managing-plugins.page:45(p)
 msgid ""
 "Select plugins in the list to read about them, and tick the box next to its "
 "name to activate the plugin, or untick to deactivate."
@@ -898,6 +1101,7 @@ msgstr ""
 "Zaznaczenie wtyczki na liście wyświetli informacje o niej. Zaznaczenie pola "
 "obok nazwy wtyczki aktywuje ją, odznaczenie - wyłącza ją."
 
+#: C/managing-plugins.page:49(p)
 msgid ""
 "If the plugin has any configurable parameters, they will be visible below "
 "the plugin information."
@@ -905,6 +1109,7 @@ msgstr ""
 "Jeżeli wtyczka posiada konfigurowalne parametry, zostaną one wyświetlone "
 "poniżej informacji o wtyczce."
 
+#: C/managing-plugins.page:53(p)
 msgid ""
 "The plugin <app>Kupfer Plugins</app> allows fast access to each plugin's "
 "information page as well as the action \"Show Source Code\" which reveals "
@@ -914,9 +1119,11 @@ msgstr ""
 "temat poszczególnych wtyczek, a także udostępnia akcję \"Wyświetl kod "
 "źródłowy\" umożliwiającą podgląd implementacji."
 
+#: C/managing-plugins.page:59(title)
 msgid "If a Plugin can not be Activated"
 msgstr "Problemy z aktywacją wtyczki"
 
+#: C/managing-plugins.page:60(p)
 msgid ""
 "If a plugin fails to activate because it requires a software module that is "
 "not available, its plugin information will display a message like this:"
@@ -925,20 +1132,24 @@ msgstr ""
 "zewnętrznego modułu na panelu informacyjnym pokazuje się odpowiednia "
 "informacja, na przykład:"
 
+#: C/managing-plugins.page:65(em)
 msgid "Plugin could not be read due to an error:"
 msgstr "Wtyczka nie może być wczytana ze względu na błąd:"
 
+#: C/managing-plugins.page:66(em)
 msgid "Python module 'gdata' is needed"
 msgstr "Wymagany jest moduł Pythona 'gdata'."
 
+#: C/managing-plugins.page:67(p)
 msgid ""
 "This means that you need to install a needed python module from your "
 "distribution—and possibly the plugin documentation can tell you how."
 msgstr ""
-"Komunikat taki oznacza, że należy zainstalować wymagany moduł Pythona  - "
+"Komunikat taki oznacza, że należy zainstalować wymagany moduł Pythona - "
 "prawdopodobnie dokumentacja wtyczki dostarcza więcej informacji jak to "
 "zrobić."
 
+#: C/managing-plugins.page:72(p)
 msgid ""
 "The plugin may also unexpectedly fail to load, and display a different error "
 "message. It may then be a program error in either the plugin or <app>Kupfer</"
@@ -948,9 +1159,11 @@ msgstr ""
 "się inny komunikat błędu. Może to oznaczać błąd programistyczny we wtyczce "
 "lub w <app>Kupferze</app>."
 
+#: C/managing-plugins.page:79(title)
 msgid "Installing more Plugins"
 msgstr "Instalacja kolejnych wtyczek"
 
+#: C/managing-plugins.page:80(p)
 msgid ""
 "You can install custom plugins into the folder <code>~/.local/share/kupfer/"
 "plugins</code>. Each plugin is either a single <code>.py</code> file or a "
@@ -960,11 +1173,12 @@ msgid ""
 msgstr ""
 "Użytkownik ma możliwość instalacji dodatkowych wtyczek w katalogu <code>~/."
 "local/share/kupfer/plugins</code>. Każda wtyczka jest w postaci pojedynczego "
-"pliku <code>.py</code> lub w postaci pakietu pythona (katalog zawierający "
+"pliku <code>.py</code> lub w postaci pakietu Pythona (katalog zawierający "
 "przynajmniej plik <code>__init__.py</code>). Wtyczki w postaci pakietów mogą "
-"zawierać pliki ikon. Pakiety pythona mogą być instalowane jako pliki <code>."
+"zawierać pliki ikon. Pakiety Pythona mogą być instalowane jako pliki <code>."
 "zip</code>."
 
+#: C/managing-plugins.page:88(p)
 msgid ""
 "<em>Caution:</em> Treat a plugin as a computer program. Do not install "
 "untrusted plugins."
@@ -972,9 +1186,11 @@ msgstr ""
 "<em>Uwaga:</em> Wtyczki są programami komputerowymi. Nie należy instalować "
 "wtyczek z niezaufanych źródeł."
 
+#: C/managing-plugins.page:95(title)
 msgid "Creating Plugins"
 msgstr "Tworzenie wtyczek"
 
+#: C/managing-plugins.page:96(p)
 msgid ""
 "Documentation for plugin creators is available in the file "
 "<code>Documentation/Manual.rst</code> in the source distribution on the "
@@ -988,9 +1204,11 @@ msgstr ""
 "na rozpoczęcie pracy jest skopiowanie istniejącej wtyczki i "
 "eksperymentowanie z nią."
 
+#: C/managing-plugins.page:107(title)
 msgid "The <em>Catalog</em> Tab in Preferences"
-msgstr "Zakładka <em>Katalog</em> w oknie ustawień"
+msgstr "Karta <em>Katalog</em> w oknie preferencji"
 
+#: C/managing-plugins.page:108(p)
 msgid ""
 "Each plugin can export a number of sources which contain objects. Normally, "
 "all these objects are directly accessible from a top-level search. Some "
@@ -1008,29 +1226,34 @@ msgstr ""
 "jego nazwy, a następnie wejść do niego używając akcji <em>Przeszukaj "
 "zawartość</em>."
 
+#: C/managing-plugins.page:118(p)
 msgid ""
 "In the tab <em>Catalog</em> in <app>Kupfer Preferences</app>, a ticked box "
 "next to each source means that its objects are exported. An unticked box "
 "means that its contents are hidden from the top level."
 msgstr ""
-"W zakładce <em>Katalog</em> w <app>ustawieniach Kupfera</app> zaznaczenie "
+"W karcie <em>Katalog</em> w <app>Preferencjach Kupfera</app> zaznaczenie "
 "pola przy poszczególnych źródłach oznacza, że jego obiekt będą eksportowane. "
 "Odznaczenie pola oznacza, że obiekty danego źródła są ukryte na najwyższym "
 "poziomie listy."
 
+#: C/managing-plugins.page:123(p)
 msgid ""
 "<em>Note:</em> Kupfer may become slow if large enough subcatalogs are "
 "exported to the top level."
 msgstr ""
-"<em>Uwaga:</em> Kupfer może zachowywać się wolno jeżeli znacząca ilość "
+"<em>Uwaga:</em> Kupfer może zachowywać się wolno, jeżeli znacząca ilość "
 "podkatalogów jest eksportowana na najwyższy poziom listy."
 
+#: C/license.page:7(desc)
 msgid "You can copy, modify and share Kupfer."
 msgstr "Użytkownik może kopiować, modyfikować i dzielić się Kupferem."
 
+#: C/license.page:10(title)
 msgid "License"
 msgstr "Licencja"
 
+#: C/license.page:12(p)
 msgid ""
 "This program is free software: you can redistribute it and/or modify it "
 "under the terms of the <em>GNU General Public License</em> as published by "
@@ -1038,10 +1261,11 @@ msgid ""
 "option) any later version."
 msgstr ""
 "Niniejszy program jest wolnym oprogramowaniem; możesz go rozprowadzać dalej "
-"i/lub modyfikować na warunkach Powszechnej <em>Licencji Publicznej GNU<.em>, "
+"i/lub modyfikować na warunkach Powszechnej <em>Licencji Publicznej GNU</em>, "
 "wydanej przez Fundację Wolnego Oprogramowania - według wersji 3 tej Licencji "
 "lub (według twojego wyboru) którejś z późniejszych wersji."
 
+#: C/license.page:18(p)
 msgid ""
 "This program is distributed in the hope that it will be useful, but WITHOUT "
 "ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or "
@@ -1053,6 +1277,7 @@ msgstr ""
 "HANDLOWEJ albo PRZYDATNOŚCI DO OKREŚLONYCH ZASTOSOWAŃ. W celu uzyskania "
 "bliższych informacji sięgnij do Powszechnej Licencji Publicznej GNU."
 
+#: C/license.page:24(p)
 msgid ""
 "You should have received a copy of the GNU General Public License along with "
 "this program. If not, see <link href=\"http://www.gnu.org/licenses/\">gnu."
@@ -1060,8 +1285,10 @@ msgid ""
 msgstr ""
 "Z pewnością wraz z niniejszym programem otrzymałeś też egzemplarz "
 "Powszechnej Licencji Publicznej GNU (GNU General Public License); jeśli nie "
-"- wejdź na <http://www.gnu.org/licenses/>."
+"- wejdź na <link href=\"http://www.gnu.org/licenses/\">gnu.org/licenses</"
+"link>."
 
+#: C/license.page:30(p)
 msgid ""
 "This documentation is licensed under a <link href=\"http://creativecommons."
 "org/licenses/by-sa/3.0/\">Creative Commons Attribution-Share Alike 3.0 "
@@ -1071,6 +1298,7 @@ msgstr ""
 "creativecommons.org/licenses/by-sa/3.0/\">Creative Commons Attribution-Share "
 "Alike 3.0 Unported License</link>."
 
+#: C/license.page:36(p)
 msgid ""
 "As a special exception, the copyright holders give you permission to copy, "
 "modify, and distribute the example code contained in this document under the "
@@ -1080,72 +1308,93 @@ msgstr ""
 "modyfikację i dystrybucję przykładowych kodów źródłowych zawartych w "
 "niniejszej dokumentacji pod dowolnie wybranymi warunkami, bez ograniczeń,"
 
+#: C/keyboard.page:7(desc)
 msgid "Complete keyboard shortcuts reference."
 msgstr "Kompletna lista skrótów klawiszowych."
 
+#: C/keyboard.page:10(title)
 msgid "Command Keys and Accelerator Keys"
 msgstr "Klawisze poleceń oraz klawisze akceleratorów"
 
+#: C/keyboard.page:13(title) C/generalusage.page:12(title)
 msgid "Keyboard Interface"
 msgstr "Klawiatura"
 
+#: C/keyboard.page:14(p)
 msgid "In command mode, the following keystrokes have special meanings:"
-msgstr "W trybie komend następujące klawisze posiadają specjalne znaczenie:"
+msgstr "W trybie poleceń następujące klawisze posiadają specjalne znaczenie:"
 
+#: C/keyboard.page:19(p) C/generalusage.page:34(p)
 msgid "<key>↓</key> or <key>Space</key>"
 msgstr "<key>↓</key> lub <key>Spacja</key>"
 
+#: C/keyboard.page:20(p) C/generalusage.page:35(p)
 msgid "Go to the next match"
 msgstr "Przejście do następnego znalezionego obiektu"
 
+#: C/keyboard.page:23(p) C/generalusage.page:38(p)
 msgid "<key>↑</key> or <keyseq><key>Shift</key><key>Space</key></keyseq>"
 msgstr "<key>↑</key> lub <keyseq><key>Shift</key><key>Spacja</key></keyseq>"
 
+#: C/keyboard.page:26(p) C/generalusage.page:41(p)
 msgid "Go to the previous match"
 msgstr "Przejście do poprzedniego znalezionego elementu"
 
+#: C/keyboard.page:29(p) C/generalusage.page:44(p)
 msgid "<key>→</key> or <key>/</key>"
 msgstr "<key>→</key> lub <key>/</key>"
 
+#: C/keyboard.page:30(p) C/generalusage.page:45(p)
 msgid "Descend into an object with content"
 msgstr "Wejście do obiektu posiadającego zawartość"
 
+#: C/keyboard.page:33(key) C/generalusage.page:48(key)
 msgid "Backspace"
 msgstr "Backspace"
 
+#: C/keyboard.page:34(p) C/generalusage.page:49(p)
 msgid "Erase a character from the query. If the query is empty, go up a level"
 msgstr ""
 "Usunięcie znaku z zapytania. Jeżeli zapytanie jest puste - przejście na "
 "wyższy poziom."
 
+#: C/keyboard.page:39(key) C/keyboard.page:93(key) C/generalusage.page:54(key)
 msgid "."
 msgstr "."
 
+#: C/keyboard.page:40(p) C/generalusage.page:55(p)
 msgid "Activate free-text mode"
 msgstr "Aktywacja trybu \"tekstowego\""
 
+#: C/keyboard.page:43(key) C/keyboard.page:97(key) C/generalusage.page:58(key)
 msgid ","
 msgstr ","
 
+#: C/keyboard.page:44(p) C/generalusage.page:59(p)
 msgid "Put selected object on the stack (\"Comma Trick\")"
 msgstr "Odłożenie zaznaczonego obiektu na stosie (\"trik z przecinkiem\")"
 
+#: C/keyboard.page:47(p)
 msgid "Quick access keys:"
 msgstr "Klawisze szybkiego dostępu:"
 
+#: C/keyboard.page:53(key)
 msgid "="
 msgstr "="
 
+#: C/keyboard.page:55(p)
 msgid ""
 "Activate free-text mode with = prefix (for <link xref=\"plugin-calculator\"/"
 ">)"
 msgstr ""
-"Aktywacja trybu tekstowego z prefiksem = (dla <link xref=\"plugin-calculator"
-"\"/>)"
+"Aktywacja trybu tekstowego z przedrostkiem = (dla <link xref=\"plugin-"
+"calculator\"/>)"
 
+#: C/keyboard.page:61(key)
 msgid "/"
 msgstr "/"
 
+#: C/keyboard.page:63(p)
 msgid ""
 "Activate free-text mode (when nothing is selected) with <code>/</code> "
 "prefix (to input a rooted path)"
@@ -1153,20 +1402,25 @@ msgstr ""
 "Aktywacja trybu tekstowego (gdy nic nie jest zaznaczone) z prefiksem <code>/"
 "</code> (dla wprowadzania ścieżki względem korzenia /)."
 
+#: C/keyboard.page:68(p) C/generalusage.page:62(p)
 msgid "Additionally:"
 msgstr "Dodatkowo:"
 
+#: C/keyboard.page:72(p) C/generalusage.page:66(p)
 msgid ""
 "<key>Return</key> activates the current selection: the command is executed."
 msgstr ""
 "<key>Return</key> aktywuje zaznaczony obiekt - polecenie jest wykonywane."
 
+#: C/keyboard.page:74(p) C/generalusage.page:68(p)
 msgid "<key>Escape</key> clears the current selection."
 msgstr "<key>Escape</key> usuwa aktualne zaznaczenie."
 
+#: C/keyboard.page:75(p) C/generalusage.page:69(p)
 msgid "<key>Tab</key> switches between the object and the action pane."
 msgstr "<key>Tab</key> przełącza między obiektem i panelem akcji."
 
+#: C/keyboard.page:77(p)
 msgid ""
 "The meaning of the keys <key>Space</key>, <key>.</key>, <key>,</key>, <key>/"
 "</key> and <key>=</key> can not be changed, but you can deactivate their "
@@ -1176,102 +1430,133 @@ msgstr ""
 "Znaczenie klawiszy <key>Spacja</key>, <key>.</key>, <key>,</key>, <key>/</"
 "key> oraz <key>=</key> może być zmienione, ale w tym celu należy najpierw "
 "wyłączyć ich specjalne działanie przez odznaczenie pola <app>Włączenie jedno-"
-"klawiszowych poleceń</app> w <app>ustawieniach Kupfera</app>."
+"klawiszowych poleceń</app> w <app>Preferencjach Kupfera</app>."
 
+#: C/keyboard.page:86(title)
 msgid "Kupfer's Keyboard Shortcuts"
 msgstr "Skróty klawiszowe Kupfera"
 
+#: C/keyboard.page:87(p)
 msgid ""
 "These keyboard shortcuts are used in <app>Kupfer</app>'s interface. They "
 "have the following meanings and default shortcuts:"
 msgstr ""
-"Poniższe skróty klawiszowe są użyte w interfejsie <app>Kupfera<app> i "
+"Poniższe skróty klawiszowe są użyte w interfejsie <app>Kupfera</app> i "
 "posiadają one domyślnie następujące znaczenie:"
 
+#: C/keyboard.page:93(key) C/keyboard.page:97(key) C/keyboard.page:101(key)
+#: C/keyboard.page:105(key) C/keyboard.page:113(key) C/keyboard.page:117(key)
+#: C/keyboard.page:121(key) C/keyboard.page:125(key) C/keyboard.page:129(key)
+#: C/keyboard.page:174(key)
 msgid "Ctrl"
 msgstr "Ctrl"
 
+#: C/keyboard.page:94(p)
 msgid "Toggle text mode"
 msgstr "Przełączenie trybu tekstowego"
 
+#: C/keyboard.page:98(p)
 msgid "The comma trick"
 msgstr "Trik z przecinkiem"
 
+#: C/keyboard.page:101(key)
 msgid ";"
 msgstr ";"
 
+#: C/keyboard.page:102(p)
 msgid "Show preferences window"
-msgstr "Wyświetlenie okna ustawień"
+msgstr "Wyświetlenie okna preferencji"
 
+#: C/keyboard.page:105(key)
 msgid "R"
 msgstr "R"
 
+#: C/keyboard.page:106(p)
 msgid "Reset all"
 msgstr "Resetuj wszystko"
 
+#: C/keyboard.page:109(key)
 msgid "Alt"
 msgstr "Alt"
 
+#: C/keyboard.page:109(key)
 msgid "A"
 msgstr "A"
 
+#: C/keyboard.page:110(p)
 msgid "Alternate activate"
 msgstr "Alternatywna aktywacja"
 
+#: C/keyboard.page:113(key)
 msgid "Return"
 msgstr "Return"
 
+#: C/keyboard.page:114(p)
 msgid "Compose command"
 msgstr "Polecenie \"komponuj\""
 
+#: C/keyboard.page:117(key)
 msgid "S"
 msgstr "S"
 
+#: C/keyboard.page:118(p)
 msgid "Switch to first pane"
 msgstr "Przełączenie do pierwszego panelu"
 
+#: C/keyboard.page:121(key)
 msgid "Q"
 msgstr "Q"
 
+#: C/keyboard.page:122(p)
 msgid "Select 'Quit'"
 msgstr "Wybranie \"Zakończ\""
 
+#: C/keyboard.page:125(key)
 msgid "G"
 msgstr "G"
 
+#: C/keyboard.page:126(p)
 msgid "Select 'Selected File'"
 msgstr "Wybranie \"Wybrany plik\""
 
+#: C/keyboard.page:129(key)
 msgid "T"
 msgstr "T"
 
+#: C/keyboard.page:130(p)
 msgid "Select 'Selected Text'"
 msgstr "Wybranie \"Zaznaczony tekst\""
 
+#: C/keyboard.page:133(key)
 msgid "F1"
 msgstr "F1"
 
+#: C/keyboard.page:134(p)
 msgid "Show Help"
 msgstr "Wyświetlenie pomocy"
 
+#: C/keyboard.page:139(title)
 msgid "How to configure a keyboard shortcut"
 msgstr "Konfiguracja skrótów klawiszowych"
 
+#: C/keyboard.page:141(p) C/keyboard.page:185(p)
 msgid "Open <app>Kupfer Preferences</app> and go to the <em>Keyboard</em> tab."
 msgstr ""
-"Otwarcie <app>ustawień Kupfera</app> i przejście do zakładki <em>Klawiatura</"
+"Otwarcie <app>Preferencji Kupfera</app> i przejście do karty <em>Klawiatura</"
 "em>."
 
+#: C/keyboard.page:147(p)
 msgid ""
 "Double-click the shorcut's row under <em>Browser Keyboard Shortcuts</em>."
 msgstr ""
 "Dwukrotne kliknięcie wiersza ze skrótem pod <em>Skróty klawiszowe listy "
 "elementów</em>."
 
+#: C/keyboard.page:153(p)
 msgid ""
 "Using the window that appears, press modifier keys and a letter or number "
-"key to set a global shortcut. An example is pressing and holding <key>Ctrl</"
-"key> and then pressing and releasing <key>T</key> to bind <keyseq><key>Ctrl</"
+"key to set a shortcut. An example is pressing and holding <key>Ctrl</key> "
+"and then pressing and releasing <key>T</key> to bind <keyseq><key>Ctrl</"
 "key><key>T</key></keyseq>."
 msgstr ""
 "Za pomocą okna, które zostanie wyświetlone, nacisnąć klawisz modyfikatora i "
@@ -1280,9 +1565,11 @@ msgstr ""
 "<key>T</key> zostanie przypisany skrót <keyseq><key>Ctrl</key><key>T</key></"
 "keyseq>."
 
+#: C/keyboard.page:164(title)
 msgid "Global Keyboard Shortcuts"
 msgstr "Globalne skróty klawiszowe"
 
+#: C/keyboard.page:165(p)
 msgid ""
 "<app>Kupfer</app> always listens to global shortcuts, even if it is not "
 "currently in the foreground."
@@ -1290,31 +1577,39 @@ msgstr ""
 "<app>Kupfer</app> zawsze reaguje na globalne skróty klawiszowe, nawet gdy "
 "nie jest w danej chwili aktywny."
 
+#: C/keyboard.page:169(p)
 msgid "They have the following meanings and default shortcuts:"
 msgstr ""
 "Globalne skróty klawiszowe obejmują następujące akcje i posiadają domyślne "
 "przypisania:"
 
+#: C/keyboard.page:174(key)
 msgid "Space"
 msgstr "Spacja"
 
+#: C/keyboard.page:175(p)
 msgid "Show/hide <app>Kupfer</app>"
 msgstr "Pokaż / ukryj <app>Kupfera</app>"
 
+#: C/keyboard.page:178(p)
 msgid "(not configured by default)"
 msgstr "(domyślnie nieskonfigurowane)"
 
+#: C/keyboard.page:179(p)
 msgid "Show <app>Kupfer</app> with 'Selection' object focused"
 msgstr "Pokazanie <app>Kupfera</app> z wybranym obiektem \"Zaznaczenie\"."
 
+#: C/keyboard.page:183(title)
 msgid "How to configure a global keyboard shortcut"
 msgstr "Konfiguracja globalnych skrótów klawiszowych"
 
+#: C/keyboard.page:191(p)
 msgid ""
 "Double-click the shorcut's row under <em>Global Keyboard Shortcuts</em>."
 msgstr ""
 "Dwukrotne kliknięcie wiersza skrótu pod <em>Globalne skróty klawiszowe</em>."
 
+#: C/keyboard.page:197(p)
 msgid ""
 "Using the window that appears, press modifier keys and a letter or number "
 "key to set a global shortcut. An example is pressing and holding <key>Super</"
@@ -1327,6 +1622,7 @@ msgstr ""
 "<key>Spacja</key> zostanie przypisany skrót <keyseq><key>Super</"
 "key><key>Spacja</key></keyseq>."
 
+#: C/keyboard.page:206(p)
 msgid ""
 "Since these keyboard shortcuts are global, they can be used from any "
 "application. Select shortcuts with care so that they do not conflict with "
@@ -1336,23 +1632,28 @@ msgstr ""
 "programu. Należy uważnie wybierać skróty klawiszowe, tak aby nie spowodowały "
 "one problemów z innymi funkcjami."
 
+#: C/keyboard.page:214(p)
 msgid ""
 "The plugin <em>Triggers</em> allows to activate actions with global keyboard "
 "shortcuts. Trigger shortcuts do not appear in <app>Kupfer Preferences</app>."
 msgstr ""
 "Wtyczka <em>Wyzwalacze</em> pozwala na aktywację akcji za pomocą globalnych "
 "skrótów klawiszowych. Skróty klawiszowe wtyczki wyzwalaczy nie są "
-"wyświetlane w oknie <app>Ustawienia Kupfera</app>."
+"wyświetlane w oknie <app>Preferencji Kupfera</app>."
 
+#: C/keyboard.page:220(p)
 msgid "See <link xref=\"plugin-triggers\"/> for more information."
 msgstr "Więcej informacji można znaleźć w <link xref=\"plugin-triggers\"/>."
 
+#: C/introduction.page:7(desc)
 msgid "Introduction to <app>Kupfer</app>."
-msgstr "Wprowadzenie do <app>Kupfera</app>"
+msgstr "Wprowadzenie do <app>Kupfera</app>."
 
+#: C/introduction.page:10(title)
 msgid "Introduction"
 msgstr "Wprowadzenie"
 
+#: C/introduction.page:12(p)
 msgid ""
 "<app>Kupfer</app> is an interface for quick and convenient access to "
 "applications and their documents."
@@ -1360,6 +1661,7 @@ msgstr ""
 "<app>Kupfer</app> jest interfejsem umożliwiającym szybki i wygodny dostęp "
 "dla programów i dokumentów."
 
+#: C/introduction.page:16(p)
 msgid ""
 "The most typical use is to find a specific application and launch it. We "
 "have tried to make <app>Kupfer</app> easy to extend with plugins so that "
@@ -1371,6 +1673,7 @@ msgstr ""
 "umożliwiający łatwe rozszerzanie go przez wtyczki, więc szybki dostęp może "
 "dotyczyć wielu różnych obiektów - nie tylko programów."
 
+#: C/introduction.page:22(p)
 msgid ""
 "We hope that using <app>Kupfer</app> feels both <em>very fun</em> and "
 "<em>different</em>."
@@ -1378,40 +1681,51 @@ msgstr ""
 "Autorzy mają nadzieję, że używanie <app>Kupfera</app> sprawi dużo "
 "przyjemności i ułatwi życie użytkownikowi."
 
+#: C/introduction.page:26(p)
 msgid ""
 "For up-to-date information about <app>Kupfer</app>, visit its <link href="
 "\"http://kaizer.se/wiki/kupfer/\">homepage</link>."
 msgstr ""
-"Najświeższe informacje na temat <app>Kupfera</app> można znaleźć na jego  "
+"Najświeższe informacje na temat <app>Kupfera</app> można znaleźć na jego "
 "<link href=\"http://kaizer.se/wiki/kupfer/\">stronie domowej</link>."
 
+#: C/index.page:9(name)
 msgid "Ulrik Sverdrup"
 msgstr "Ulrik Sverdrup"
 
+#: C/index.page:10(email)
 msgid "ulrik.sverdrup@gmail.com"
 msgstr "ulrik.sverdrup@gmail.com"
 
+#: C/index.page:13(year)
 msgid "2009"
 msgstr "2009"
 
+#: C/index.page:14(name)
 msgid "Kupfer Development Team"
 msgstr "Kupfer Development Team"
 
+#: C/index.page:17(license)
 msgid "Creative Commons Share Alike 3.0"
 msgstr "Creative Commons Share Alike 3.0"
 
+#: C/index.page:21(title)
 msgid "Kupfer Manual"
 msgstr "Podręcznik Kupfera"
 
+#: C/index.page:24(title)
 msgid "Using Kupfer"
 msgstr "Używanie Kupfera"
 
+#: C/index.page:27(title)
 msgid "About Specific Plugins"
 msgstr "Informacje o niektórych wtyczkach"
 
+#: C/generalusage.page:7(desc)
 msgid "How to start using <app>Kupfer</app>."
 msgstr "Rozpoczęcie pracy z <app>Kupferem</app>"
 
+#: C/generalusage.page:14(p)
 msgid ""
 "<app>Kupfer</app> is to the largest part a keyboard-managed interface to "
 "applications and documents."
@@ -1419,13 +1733,15 @@ msgstr ""
 "<app>Kupfer</app> jest głównie \"klawiaturowym interfejsem\" dla programów i "
 "dokumentów."
 
+#: C/generalusage.page:18(p)
 msgid ""
 "Kupfer's default mode is the command mode: If you type a query, kupfer will "
 "search for a match in its catalog."
 msgstr ""
-"Domyślnym trybem pracy Kupfera jest tryb komend - wpisanie ciągu znaków "
+"Domyślnym trybem pracy Kupfera jest tryb poleceń - wpisanie ciągu znaków "
 "spowoduje, że Kufer wyszuka pasujące obiekty w jego katalogu."
 
+#: C/generalusage.page:23(p)
 msgid ""
 "The arrow keys allow you to browse query matches quite naturally, going to "
 "the previous or next match, and going up and down in the subcatalogs."
@@ -1434,9 +1750,11 @@ msgstr ""
 "przechodząc do poprzedniego lub następnego znalezionego obiektu oraz "
 "poruszając się w górę i w dół podkatalogu."
 
+#: C/generalusage.page:29(p)
 msgid "In command mode, some keystrokes have special meanings:"
-msgstr "W trybie komend pewne klawisze posiadają specjalne znaczenie:"
+msgstr "W trybie poleceń pewne klawisze posiadają specjalne znaczenie:"
 
+#: C/generalusage.page:71(p)
 msgid ""
 "By default you show <app>Kupfer</app> using the global keyboard shortcut "
 "<keyseq><key>Ctrl</key><key>Space</key></keyseq>."
@@ -1444,12 +1762,15 @@ msgstr ""
 "Domyślnie wyświetlenie okna <app>Kupfera</app> następuje po naciśnięciu "
 "klawiszy <keyseq><key>Ctrl</key><key>Spacja</key></keyseq>."
 
+#: C/generalusage.page:74(p)
 msgid "See <link xref=\"keyboard\"/> for more information."
 msgstr "Więcej informacji można znaleźć w <link xref=\"keyboard\"/>."
 
+#: C/generalusage.page:78(title)
 msgid "Learning Habits"
 msgstr "Nauka przyzwyczajeń"
 
+#: C/generalusage.page:79(p)
 msgid ""
 "<app>Kupfer</app> remembers which objects and actions are used the most. "
 "When beginning to use it, you have to use the arrow keys at times to make it "
@@ -1463,9 +1784,11 @@ msgstr ""
 "Kupfer umieści go wyżej na swojej liście. Obiekty zaznaczone jako <link xref="
 "\"plugin-favorites\">ulubione</link> również są umieszczane wyżej."
 
+#: C/generalusage.page:90(title)
 msgid "The Catalog"
 msgstr "Katalog"
 
+#: C/generalusage.page:91(p)
 msgid ""
 "The Catalog is the collection of objects you can access in Kupfer, such as "
 "documents and programs."
@@ -1473,6 +1796,7 @@ msgstr ""
 "Katalog jest kolekcją obiektów, do których Kupfer umożliwia dostęp, takich "
 "jak dokumenty i programy."
 
+#: C/generalusage.page:96(p)
 msgid ""
 "Objects in the catalog that have content, like folders, are marked with an "
 "arrow. Pressing <key>→</key> will enter these objects. Much of the catalog "
@@ -1487,6 +1811,7 @@ msgstr ""
 "najwyższym poziomie. Podkatalogi mogą być użyte do zawężenia wyświetlania "
 "lub wyszukiwania elementów podczas używania Kupfera."
 
+#: C/generalusage.page:105(p)
 msgid ""
 "Most subcatalogs update their content automatically. For example, the "
 "Desktop folder source is always up-to-date."
@@ -1495,194 +1820,6 @@ msgstr ""
 "przykład katalog \"Pulpit\" jest zawsze aktualny."
 
 #. Put one translator per line, in the form of NAME <EMAIL>, YEAR1, YEAR2
+#: C/index.page:0(None)
 msgid "translator-credits"
 msgstr "Karol Będkowski <karol.bedkowski@gmail.com>, 2010"
-
-#~ msgid "Using <app>Kupfer</app> more conveniently."
-#~ msgstr "Wygodniejsze używani\te <app>Kupfera</app>"
-
-#~ msgid ""
-#~ "Kupfer listens to global shortcuts, even if Kupfer is not currently in "
-#~ "the foreground. The most important global shortcut is the shortcut to "
-#~ "show and hide Kupfer's command window which by default is "
-#~ "<keyseq><key>Ctrl</key><key>Space</key></keyseq>."
-#~ msgstr ""
-#~ "Kupfer reaguje na globalne skróty klawiszowe nawet, gdy jego okno jest "
-#~ "aktualnie ukryte. Najważniejszym skrótem klawiszowym jest polecenie "
-#~ "pokazania i ukrycia okna Kupfera - domyślnie jest to <keyseq><key>Ctrl</"
-#~ "key><key>Spacja</key></keyseq>."
-
-#~ msgid "Global Keyboard Shortcuts are configured in Kupfer's preferences."
-#~ msgstr ""
-#~ "Globalne skróty klawiszowe są konfigurowane w oknie ustawień Kupfera."
-
-#~ msgid ""
-#~ "The Triggers plugin allows to configure actions to be activated by global "
-#~ "shortcuts, but triggers can only be configured in that plugin."
-#~ msgstr ""
-#~ "Wtyczka \"Wyzwalacze\" pozawala na konfigurację akcji, które mogą być "
-#~ "uruchamiane przez globalne skróty klawiszowe. Wyzwalacze mogę być "
-#~ "konfigurowane jedynie poprzez tę wtyczkę."
-
-#~ msgid ""
-#~ "Additional keyboard shortcuts that work with Kupfer when it is in the "
-#~ "foreground can be configured in Kupfer's preferences."
-#~ msgstr ""
-#~ "Dodatkowe skróty klawiszowe, które działają gdy okno Kupfera jest na "
-#~ "pierwszym planie, mogą być konfigurowane w oknie ustawień Kupfera."
-
-#~ msgid ""
-#~ "Install custom plugins in the folder <file>~/.local/share/kupfer/plugins/"
-#~ "</file>"
-#~ msgstr ""
-#~ "Dodatkowe wtyczki mogą zostać umieszczone w <file>~/.local/share/kupfer/"
-#~ "plugins/</file>"
-
-#~ msgid ""
-#~ "Kupfer cache, config and data are located in the directories <file>~/."
-#~ "cache/kupfer</file>, <file>~/.config/kupfer</file> and <file>~/.local/"
-#~ "share/kupfer</file>."
-#~ msgstr ""
-#~ "Pamięć podręczna, konfiguracja i pliki danych są umieszczane w katalogach "
-#~ "<file>~/.cache/kupfer</file>, <file>~/.config/kupfer</file> i <file>~/."
-#~ "local/share/kupfer</file>."
-
-#~ msgid ""
-#~ "You can install custom plugins into ~/.local/share/kupfer/plugins; adding "
-#~ "to <app>Kupfer</app>'s object knowledge can be surprisingly easy, just "
-#~ "look at the default plugins if you want to create new."
-#~ msgstr ""
-#~ "Użytkownik może zainstalować dodatkowe wtyczki w katalogu ~/.local/share/"
-#~ "kupfer/plugins. Dodawanie do <app>Kupfera</app> dodatkowych źródeł "
-#~ "obiektów jest zaskakująco proste - podstawę do ich stworzenia mogą "
-#~ "stanowić domyślne wtyczki."
-
-#~ msgid ""
-#~ "To use <app>Kupfer</app> like a pro, you can configure a \"Magic "
-#~ "Keybinding\" for <app>Kupfer</app>. GUI configuration is not yet "
-#~ "supported, but edit the configuration file <file>~/.config/kupfer/kupfer."
-#~ "cfg</file> to include the following:"
-#~ msgstr ""
-#~ "Aby używać <app>Kupfera</app> jak zawodowiec, użytkownik może "
-#~ "skonfigurować \"magiczne skróty klawiszowe\" dla programu <app>Kupfer</"
-#~ "app>. Konfiguracja ta nie jest wspierana przez interfejs programu, ale "
-#~ "użytkownik może edytować plik konfiguracyjny <file>~/.config/kupfer/"
-#~ "kupfer.cfg</file>, który zawiera:"
-
-#~ msgid ""
-#~ "\n"
-#~ "[Kupfer]\n"
-#~ "keybinding = &lt;Control&gt;space\n"
-#~ "magickeybinding = &lt;Ctrl&gt;&lt;Alt&gt;space\n"
-#~ "  "
-#~ msgstr ""
-#~ "\n"
-#~ "[Kupfer]\n"
-#~ "keybinding = &lt;Control&gt;space\n"
-#~ "magickeybinding = &lt;Ctrl&gt;&lt;Alt&gt;space\n"
-#~ "  "
-
-#~ msgid ""
-#~ "Now, pressing <keyseq><key>Ctrl</key><key>Alt</key><key>Space</key></"
-#~ "keyseq> will summon <app>Kupfer</app> with the current selection in "
-#~ "focus. Make sure you have installed <app>Kupfer</app>'s nautilus plugin, "
-#~ "then both the currently selected file in Nautilus, or the currently "
-#~ "selected text in the front application will be selected."
-#~ msgstr ""
-#~ "Naciśnięcie <keyseq><key>Ctrl</key><key>Alt</key><key>Spacja</key></"
-#~ "keyseq>  wywoła program <app>Kupfer</app> z wybranym aktualnym "
-#~ "zaznaczeniem. W przypadku zainstalowania wtyczki dla Nautilusa "
-#~ "zaznaczenia pliku w Nautilusie spowoduje jego wybranie w Kupferrze."
-
-#~ msgid ""
-#~ "Now you can select a word in, say, a web browser, use <keyseq><key>Ctrl</"
-#~ "key><key>Alt</key><key>Space</key></keyseq>, and select action <gui>Look "
-#~ "Up</gui> to look up the selected word. Or select an image file, use "
-#~ "<keyseq><key>Ctrl</key><key>Alt</key><key>Space</key></keyseq>, select "
-#~ "action <gui>Scale</gui> with object <gui>1000</gui> to scale the image to "
-#~ "1000 pixels wide!"
-#~ msgstr ""
-#~ "Użytkownik ma możliwość zaznaczenia słowa na przykład w przeglądarce "
-#~ "internetowej, a poprzez nazciśnięcie <keyseq><key>Ctrl</key><key>Alt</"
-#~ "key><key>Space</key></keyseq> i wybranie akcji <gui>\"Znajdź\"</gui> "
-#~ "znaleźć wybrane słowo. Inny przykład - po zaznaczeniu pliku obrazu "
-#~ "użytkownik może użyć <keyseq><key>Ctrl</key><key>Alt</key><key>Spacja</"
-#~ "key></keyseq>, wybrać akcję <gui>Skaluj</gui> z obiektem <gui>1000</gui> "
-#~ "aby przeskalować obraz do szerokości 1000 pikseli."
-
-#~ msgid ""
-#~ "An example useful script is <link href=\"http://kaizer.se/wiki/code/"
-#~ "rhrating.py/\"> here</link> which changes the rating of <app>Rhythmbox</"
-#~ "app>'s currently playing song; I have added five scriptlets calling "
-#~ "<file>rhrating.py</file> with numbers from 0 to 5 to my catalog to "
-#~ "quickly rate tracks. (This is something that might be integrated into "
-#~ "<app>Kupfer</app> later)"
-#~ msgstr ""
-#~ "Przykładowy, użyteczny  <link href=\"http://kaizer.se/wiki/code/rhrating."
-#~ "py/\">skryptem</link> pozwala na zmianę oceny aktualnie odtwarzanego "
-#~ "przez <app>Rhytmbox</app> utworu. Po dodaniu pięciu skryptletów zwanych "
-#~ "<file>rhrating.py</file> z numerami od 0 do 5 do katalogu możliwe jest "
-#~ "szybkie ocenianie utworów. (Być może zostanie to zintegrowane z "
-#~ "<app>Kupferem</app> w późniejszym czasie)."
-
-#~ msgid ""
-#~ "<app>Kupfer</app> is its own remote control. When <app>Kupfer</app> is "
-#~ "already running, <app>Kupfer</app> on the command-line will focus its "
-#~ "window, but there is more you can do: If you invoke <cmd><app>kupfer</"
-#~ "app><var>QUERY</var></cmd> where <var>QUERY</var> is a text string or a "
-#~ "filename, <app>Kupfer</app> will focus, and select this item. This way, "
-#~ "you can quickly invoke <app>Kupfer</app> actions even on objects from a "
-#~ "shell-based context."
-#~ msgstr ""
-#~ "<app>Kupfer</app> może zdalnie sterować sam sobą. Kiedy <app>Kupfer</app> "
-#~ "jest już uruchomiony uruchomienie <app>Kupfera</app> z linii komend "
-#~ "przywoła jego okno na pierwszy plan lub - gdy zostanie wywołany jako "
-#~ "<cmd><app>kupfer</app> <var>ZAPYTANIE</var></cmd>, gdzie <var>ZAPYTANIE</"
-#~ "var> jest napisem lub nazwą plików - zostanie wyświetlone okno "
-#~ "<app>Kupfera</app> oraz zaznaczony odpowiedni obiekt. W ten sposób można "
-#~ "szybko wywoływać w <app>Kupferze</app> akcję dla obiektów podczas pracy z "
-#~ "powłoką."
-
-#~ msgid ""
-#~ "You can also pipe the output of a command into <app>Kupfer</app> to send "
-#~ "text to the already running instance of <app>Kupfer</app>."
-#~ msgstr ""
-#~ "Istnieje także możliwość przesłania wyniku komendy do <app>Kupfera</app> "
-#~ "w celu przesłania tekstu do już uruchomionej instancji <app>Kupfera</app>."
-
-#~ msgid "Legal Information."
-#~ msgstr "Informacje prawne."
-
-#~ msgid ""
-#~ "<app>Kupfer</app> is a program to change, speed up and make everything "
-#~ "about files and programs more fun on your computer. <app>Kupfer</app> is "
-#~ "a launcher; you typically use it to summon an application or a document "
-#~ "quickly by typing parts of its name. It can also do more than getting at "
-#~ "something quickly: there are different plugins for accessing more objects "
-#~ "and running custom commands."
-#~ msgstr ""
-#~ "<app>Kupfer</app> jest programem który zmienia, przyśpiesza i robi "
-#~ "wszystko co związane z plikami i programami bardziej przyjemnym.  "
-#~ "<app>Kupfer</app> jest aktywatorem, użytkownicy zwykle używają go aby "
-#~ "wywołać programy lub dokumenty szybko, przez wpisanie części ich nazwy. "
-#~ "Potrafi także zrobić dużo więcej niż wybieranie czegoś szybko - istnieje "
-#~ "wiele różnych wtyczek dostarczających wiele obiektów i uruchamiające "
-#~ "specjalne polecenia."
-
-#~ msgid ""
-#~ "<app>Kupfer</app> is written using Python and has a flexible "
-#~ "architecture; the implementation is simple and makes the easy things work "
-#~ "first. One goal is that new plugins can be written quickly without too "
-#~ "much programming."
-#~ msgstr ""
-#~ "<app>Kupfer</app> jest napisany z życiem Pythona i posiada elastyczną "
-#~ "architekturę - implementacja jest prosta i sprawia, że proste rzeczy "
-#~ "działają od razu. Jednym z celów jest umożliwienie szybkiego tworzenia "
-#~ "nowych wtyczek bez większego programowania."
-
-#~ msgid ""
-#~ "The program is very inspired by <link href=\"http://www.blacktree.com/"
-#~ "\">Quicksilver</link>."
-#~ msgstr ""
-#~ "Inspiracją dla tego programu jest <link href=\"http://www.blacktree.com/"
-#~ "\">Quicksilver</link>."

--- a/help/sl/sl.po
+++ b/help/sl/sl.po
@@ -284,7 +284,7 @@ msgstr "Pošiljanje sporočila vsem storitvam"
 
 #: C/plugin-gwibber.page:29(p)
 msgid "Activate Kupfer and type <key>.</key> to enter text mode, then type in a message."
-msgstr "Omogočite Kupfer in vpišite <key>.</Key> za vstop v besedilni način in nato vpišite sporočilo."
+msgstr "Omogočite Kupfer in vpišite <key>.</key> za vstop v besedilni način in nato vpišite sporočilo."
 
 #: C/plugin-gwibber.page:35(p)
 msgid "Type <key>Tab</key> and select the action <em>Send Message</em> and press <key>Return</key>."
@@ -429,7 +429,7 @@ msgstr "Omogočite Kupfer in vtipkajte okrajšavo imena programa"
 
 #: C/plugin-applications.page:28(p)
 msgid "Press <key>Return</key> to launch the application."
-msgstr "Za zagon programa pritisnite <key>Enter</key."
+msgstr "Za zagon programa pritisnite <key>Enter</key>."
 
 #: C/plugin-applications.page:34(title)
 msgid "Opening a file with a specific application"
@@ -840,7 +840,7 @@ msgstr "="
 
 #: C/keyboard.page:55(p)
 msgid "Activate free-text mode with = prefix (for <link xref=\"plugin-calculator\"/>)"
-msgstr "Omogoči način prostega besedila s predpono <code>=<code> (za <link xref=\"plugin-calculator\"/>)"
+msgstr "Omogoči način prostega besedila s predpono <code>=</code> (za <link xref=\"plugin-calculator\"/>)"
 
 #: C/keyboard.page:61(key)
 msgid "/"
@@ -848,7 +848,7 @@ msgstr "/"
 
 #: C/keyboard.page:63(p)
 msgid "Activate free-text mode (when nothing is selected) with <code>/</code> prefix (to input a rooted path)"
-msgstr "Omogoči način prostega besedila (ko ni nič izbrano) s predpono <code>/<code> (za vnos korenske poti)"
+msgstr "Omogoči način prostega besedila (ko ni nič izbrano) s predpono <code>/</code> (za vnos korenske poti)"
 
 #: C/keyboard.page:68(p)
 #: C/generalusage.page:62(p)

--- a/kupfer.doap
+++ b/kupfer.doap
@@ -6,7 +6,7 @@
          xmlns="http://usefulinc.com/ns/doap#">
   <name xml:lang="en">kupfer</name>
   <shortdesc xml:lang="en">Convenient command and access tool</shortdesc>
-  <homepage rdf:resource="http://kaizer.se/wiki/kupfer/"/>
+  <homepage rdf:resource="https://wiki.gnome.org/Apps/Kupfer"/>
   <mailing-list rdf:resource="http://mail.gnome.org/mailman/listinfo/kupfer-list"/>
   <maintainer>
     <foaf:Person>

--- a/kupfer/plugin/session_xfce.py
+++ b/kupfer/plugin/session_xfce.py
@@ -12,7 +12,7 @@ from kupfer.plugin import session_support as support
 # sequences of argument lists
 LOGOUT_CMD = (["xfce4-session-logout", "--logout"],)
 SHUTDOWN_CMD = (["xfce4-session-logout"],)
-LOCKSCREEN_CMD = (["xdg-screensaver", "lock"], )
+LOCKSCREEN_CMD = (["xflock4"], )
 
 
 class XfceItemsSource (support.CommonSource):

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,3 +1,4 @@
+ca
 cs
 da
 de

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,6 +1,7 @@
 cs
 da
 de
+el
 en
 en_GB
 es

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,0 +1,3087 @@
+# Catalan translation for kupfer.
+# Copyright (C) 2012 gnome-software's COPYRIGHT HOLDER
+# This file is distributed under the same license as the gnome-calendar package.
+#
+# Jordi Mas i Hernandez <jmas@softcatala.org>, 2013.
+#
+#
+msgid ""
+msgstr ""
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-09-03 21:42+0200\n"
+"PO-Revision-Date: 2013-09-02 23:20+0200\n"
+"Last-Translator: Jordi Mas i Hernandez <jmas@softcatala.org>\n"
+"Language-Team: Softcatalà\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Id-Version: gnome-software master\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../auxdata/kupfer.desktop.in.h:1 ../kupfer/version.py:15
+#: ../kupfer/plugin/core/contents.py:91
+msgid "Kupfer"
+msgstr ""
+
+#: ../auxdata/kupfer.desktop.in.h:2
+msgid "Application Launcher"
+msgstr "Llançador d'aplicació"
+
+#: ../auxdata/kupfer.desktop.in.h:3
+msgid "Convenient command and access tool for applications and documents"
+msgstr ""
+
+#: ../auxdata/kupfer-exec.desktop.in.h:1
+msgid "Execute in Kupfer"
+msgstr ""
+
+#: ../auxdata/kupfer-mimetypes.xml.in.h:1
+msgid "Saved Kupfer Command"
+msgstr ""
+
+#: ../data/credentials_dialog.ui.h:1
+msgid "User credentials"
+msgstr ""
+
+#: ../data/credentials_dialog.ui.h:2
+msgid "_User:"
+msgstr "_Usuari:"
+
+#: ../data/credentials_dialog.ui.h:3
+msgid "_Password:"
+msgstr "_Contrasenya:"
+
+#: ../data/credentials_dialog.ui.h:4
+msgid "_Change"
+msgstr "_Canvia"
+
+#: ../data/getkey_dialog.ui.h:1
+msgid "Set Keyboard Shortcut"
+msgstr "Defineix la drecera de teclat"
+
+#: ../data/getkey_dialog.ui.h:2
+msgid "Please press desired key combination"
+msgstr "Premeu si us plau la combinació de tecles desitjada"
+
+#: ../data/getkey_dialog.ui.h:3
+msgid "Keybinding could not be bound"
+msgstr ""
+
+#: ../data/preferences.ui.h:1 ../kupfer/plugin/core/contents.py:78
+msgid "Kupfer Preferences"
+msgstr "Preferències del Kupfer"
+
+#: ../data/preferences.ui.h:2
+msgid "Start automatically on login"
+msgstr ""
+
+#: ../data/preferences.ui.h:3
+msgid "<b>Start</b>"
+msgstr "<b>Inici</b>"
+
+#: ../data/preferences.ui.h:4
+msgid "Show icon in notification area"
+msgstr "Mostra la icona a l'àrea de notificació"
+
+#: ../data/preferences.ui.h:5
+msgid "Icon set:"
+msgstr "Conjunt d'icones:"
+
+#: ../data/preferences.ui.h:6
+msgid "Terminal emulator:"
+msgstr ""
+
+#: ../data/preferences.ui.h:7
+msgid "Desktop Environment"
+msgstr "Entorn d'escriptori"
+
+#: ../data/preferences.ui.h:8 ../kupfer/plugin/gmail/__init__.py:60
+msgid "General"
+msgstr "General"
+
+#: ../data/preferences.ui.h:9
+msgid "<b>Global Keyboard Shortcuts</b>"
+msgstr "<b>Dreceres de teclat globals</b>"
+
+#: ../data/preferences.ui.h:10 ../kupfer/ui/preferences.py:863
+msgid "Reset"
+msgstr "Reinicia"
+
+#: ../data/preferences.ui.h:11
+msgid "<b>Browser Keyboard Shortcuts</b>"
+msgstr "<b>Navegador de dreceres de teclat</b>"
+
+#: ../data/preferences.ui.h:12
+msgid "Use single keystroke commands (Space, /, period, comma etc.)"
+msgstr ""
+
+#: ../data/preferences.ui.h:13
+msgid "Keyboard"
+msgstr "Teclat"
+
+#: ../data/preferences.ui.h:14
+msgid "Plugins"
+msgstr "Connectors"
+
+#: ../data/preferences.ui.h:15
+msgid "Inclusion in Top Level Searches"
+msgstr ""
+
+#: ../data/preferences.ui.h:16
+msgid ""
+"Marked sources have their objects included in top level searches.\n"
+"An unmarked source's contents are only available by locating its subcatalog."
+msgstr ""
+
+#: ../data/preferences.ui.h:18
+msgid "Indexed Folders"
+msgstr ""
+
+#: ../data/preferences.ui.h:19
+msgid "Folders whose files are always available in the catalog."
+msgstr ""
+
+#: ../data/preferences.ui.h:20 ../kupfer/obj/sources.py:157
+msgid "Catalog"
+msgstr "Catàleg"
+
+#: ../kupfer/core/commandexec.py:239
+#, python-format
+msgid "Could not to carry out '%s'"
+msgstr ""
+
+#: ../kupfer/core/commandexec.py:268
+#, python-format
+msgid "\"%s\" produced a result"
+msgstr ""
+
+#: ../kupfer/core/execfile.py:30
+#, python-format
+msgid "No permission to run \"%s\" (not executable)"
+msgstr ""
+
+#: ../kupfer/core/execfile.py:47
+#, python-format
+msgid "Command in \"%s\" is not available"
+msgstr ""
+
+#: ../kupfer/keyrelay.py:62
+#, python-format
+msgid "Keyboard relay is active for display %s"
+msgstr ""
+
+#: ../kupfer/main.py:43
+msgid "do not present main interface on launch"
+msgstr ""
+
+#: ../kupfer/main.py:44
+msgid "list available plugins"
+msgstr ""
+
+#: ../kupfer/main.py:45
+msgid "enable debug info"
+msgstr "activa la informació de depuració"
+
+#. TRANS: --exec-helper=HELPER is an internal command
+#. TRANS: that executes a helper program that is part of kupfer
+#: ../kupfer/main.py:49
+msgid "run plugin helper"
+msgstr ""
+
+#: ../kupfer/main.py:52
+msgid "show usage help"
+msgstr ""
+
+#: ../kupfer/main.py:53
+msgid "show version information"
+msgstr "mostra la informació de la versió"
+
+#: ../kupfer/main.py:59
+msgid "Usage: kupfer [ OPTIONS | FILE ... ]"
+msgstr ""
+
+#: ../kupfer/main.py:70
+msgid "Available plugins:"
+msgstr "Connectors disponibles:"
+
+#: ../kupfer/main.py:121
+#, python-format
+msgid ""
+"%(PROGRAM_NAME)s: %(SHORT_DESCRIPTION)s\n"
+"\t%(COPYRIGHT)s\n"
+"\t%(WEBSITE)s\n"
+msgstr ""
+
+#. TRANS: Names of accelerators in the interface
+#: ../kupfer/ui/accelerators.py:4
+msgid "Alternate Activate"
+msgstr ""
+
+#. TRANS: The "Comma Trick"/"Put Selection on Stack" allows the
+#. TRANS: user to select many objects to be used for one action
+#: ../kupfer/ui/accelerators.py:7
+msgid "Comma Trick"
+msgstr ""
+
+#. TRANS: "Compose Command" makes one object out of the selected
+#. TRANS: object + action (+iobject)
+#: ../kupfer/ui/accelerators.py:10
+msgid "Compose Command"
+msgstr ""
+
+#: ../kupfer/ui/accelerators.py:11
+msgid "Mark Default Action"
+msgstr ""
+
+#: ../kupfer/ui/accelerators.py:12
+msgid "Forget Object"
+msgstr "Oblida l'objecte"
+
+#: ../kupfer/ui/accelerators.py:13
+msgid "Reset All"
+msgstr "Restableix-ho tot"
+
+#: ../kupfer/ui/accelerators.py:14
+msgid "Select Quit"
+msgstr ""
+
+#: ../kupfer/ui/accelerators.py:15
+msgid "Select Selected File"
+msgstr "Seleccioneu el fitxer seleccionat"
+
+#: ../kupfer/ui/accelerators.py:16
+msgid "Select Selected Text"
+msgstr ""
+
+#: ../kupfer/ui/accelerators.py:17
+msgid "Show Help"
+msgstr "Mostra l'ajuda"
+
+#: ../kupfer/ui/accelerators.py:18
+msgid "Show Preferences"
+msgstr "Mostra les preferències"
+
+#: ../kupfer/ui/accelerators.py:19
+msgid "Switch to First Pane"
+msgstr ""
+
+#: ../kupfer/ui/accelerators.py:20
+msgid "Toggle Text Mode"
+msgstr ""
+
+#: ../kupfer/ui/browser.py:888
+#, python-format
+msgid "%s is empty"
+msgstr ""
+
+#: ../kupfer/ui/browser.py:892
+#, python-format
+msgid "No matches in %(src)s for \"%(query)s\""
+msgstr ""
+
+#: ../kupfer/ui/browser.py:898
+msgid "No matches"
+msgstr "No hi ha cap coincidència"
+
+#: ../kupfer/ui/browser.py:903
+msgid "Type to search"
+msgstr "Teclegeu per cercar"
+
+#: ../kupfer/ui/browser.py:909
+#, python-format
+msgid "Type to search %s"
+msgstr "Teclegeu per cercar %s"
+
+#: ../kupfer/ui/browser.py:924
+msgid "No action"
+msgstr "Cap acció"
+
+#: ../kupfer/ui/browser.py:1513
+#, python-format
+msgid "Make \"%(action)s\" Default for \"%(object)s\""
+msgstr ""
+
+#. TRANS: Removing learned and/or configured bonus search score
+#: ../kupfer/ui/browser.py:1523
+#, python-format
+msgid "Forget About \"%s\""
+msgstr ""
+
+#. TRANS: Names of global keyboard shortcuts
+#: ../kupfer/ui/browser.py:1960 ../kupfer/ui/preferences.py:59
+msgid "Show Main Interface"
+msgstr ""
+
+#: ../kupfer/ui/preferences.py:60
+msgid "Show with Selection"
+msgstr ""
+
+#. TRANS: Plugin info fields
+#: ../kupfer/ui/preferences.py:430
+msgid "Description"
+msgstr "Descripció"
+
+#: ../kupfer/ui/preferences.py:430
+msgid "Author"
+msgstr "Autor"
+
+#: ../kupfer/ui/preferences.py:447
+msgid "Version"
+msgstr "Versió"
+
+#. TRANS: Error message when Plugin needs a Python module to load
+#: ../kupfer/ui/preferences.py:457
+#, python-format
+msgid "Python module '%s' is needed"
+msgstr ""
+
+#: ../kupfer/ui/preferences.py:471
+msgid "Plugin could not be read due to an error:"
+msgstr ""
+
+#: ../kupfer/ui/preferences.py:479 ../kupfer/plugin/kupfer_plugins.py:80
+msgid "disabled"
+msgstr "inhabilitat"
+
+#: ../kupfer/ui/preferences.py:553
+msgid "Content of"
+msgstr ""
+
+#. TRANS: Plugin contents header
+#: ../kupfer/ui/preferences.py:562
+msgid "Sources"
+msgstr "Fonts"
+
+#. TRANS: Plugin contents header
+#: ../kupfer/ui/preferences.py:566
+msgid "Actions"
+msgstr "Accions"
+
+#: ../kupfer/ui/preferences.py:589
+#, python-format
+msgid "Using encrypted password storage: %s"
+msgstr ""
+
+#: ../kupfer/ui/preferences.py:591
+#, python-format
+msgid "Using password storage: %s"
+msgstr ""
+
+#. TRANS: Plugin-specific configuration (header)
+#: ../kupfer/ui/preferences.py:608
+msgid "Configuration"
+msgstr "Configuració"
+
+#: ../kupfer/ui/preferences.py:628
+msgid "Set username and password"
+msgstr "Defineix el nom d'usuari i contrasenya"
+
+#. TRANS: File Chooser Title
+#: ../kupfer/ui/preferences.py:682
+msgid "Choose a Directory"
+msgstr "Escolliu un directori"
+
+#: ../kupfer/ui/preferences.py:861
+msgid "Reset all shortcuts to default values?"
+msgstr ""
+
+#: ../kupfer/ui/preferences.py:869 ../kupfer/plugin/custom_terminal.py:12
+msgid "Command"
+msgstr "Ordre"
+
+#: ../kupfer/ui/preferences.py:870
+msgid "Shortcut"
+msgstr "Drecera"
+
+#. TRANS: Don't translate literally!
+#. TRANS: This should be a list of all translators of this language
+#: ../kupfer/version.py:73
+msgid "translator-credits"
+msgstr "Jordi Mas i Hernàndez <jmas@softcatala.org>, 2013"
+
+#: ../kupfer/version.py:78
+msgid "A free software (GPLv3+) launcher"
+msgstr ""
+
+#: ../kupfer/version.py:81
+msgid ""
+"\n"
+"This program is free software: you can redistribute it and/or modify\n"
+"it under the terms of the GNU General Public License as published by\n"
+"the Free Software Foundation, either version 3 of the License, or\n"
+"(at your option) any later version.\n"
+"\n"
+"This program is distributed in the hope that it will be useful,\n"
+"but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
+"GNU General Public License for more details.\n"
+"\n"
+"You should have received a copy of the GNU General Public License\n"
+"along with this program.  If not, see <http://www.gnu.org/licenses/>.\n"
+msgstr ""
+
+#. follows strings used elsewhere
+#: ../kupfer/version.py:98
+msgid "Could not find running Kupfer"
+msgstr ""
+
+#: ../kupfer/obj/base.py:457 ../kupfer/plugin/core/text.py:22
+msgid "Text"
+msgstr "Text"
+
+#: ../kupfer/obj/compose.py:15
+msgid "Run after Delay..."
+msgstr ""
+
+#: ../kupfer/obj/compose.py:36
+msgid "Perform command after a specified time interval"
+msgstr ""
+
+#: ../kupfer/obj/compose.py:95
+msgid "Multiple Objects"
+msgstr ""
+
+#: ../kupfer/obj/compose.py:126
+#, python-format
+msgid "%s object"
+msgid_plural "%s objects"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../kupfer/obj/contacts.py:129 ../kupfer/plugin/pidgin.py:156
+#, python-format
+msgid "[%(status)s] %(userid)s/%(service)s"
+msgstr ""
+
+#: ../kupfer/obj/contacts.py:131
+msgid "unknown"
+msgstr "desconegut"
+
+#: ../kupfer/obj/contacts.py:144
+msgid "Aim"
+msgstr ""
+
+#: ../kupfer/obj/contacts.py:151
+msgid "Google Talk"
+msgstr "Google Talk"
+
+#: ../kupfer/obj/contacts.py:159
+msgid "ICQ"
+msgstr "ICQ"
+
+#: ../kupfer/obj/contacts.py:166
+msgid "MSN"
+msgstr "MSN"
+
+#: ../kupfer/obj/contacts.py:173
+msgid "QQ"
+msgstr "QQ"
+
+#: ../kupfer/obj/contacts.py:180
+msgid "Yahoo"
+msgstr "Yahoo"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/obj/contacts.py:187 ../kupfer/plugin/skype.py:2
+msgid "Skype"
+msgstr "Skype"
+
+#: ../kupfer/obj/exceptions.py:19
+#, python-format
+msgid "%s does not support this operation"
+msgstr ""
+
+#: ../kupfer/obj/exceptions.py:24
+msgid "Can not be used with multiple objects"
+msgstr ""
+
+#: ../kupfer/obj/fileactions.py:30 ../kupfer/plugin/notes.py:89
+#: ../kupfer/plugin/gnome_terminal.py:36 ../kupfer/plugin/gtg.py:137
+#: ../kupfer/plugin/zim.py:176
+msgid "Open"
+msgstr "Obre"
+
+#: ../kupfer/obj/fileactions.py:43
+#, python-format
+msgid "No default application for %(file)s (%(type)s)"
+msgstr ""
+
+#: ../kupfer/obj/fileactions.py:45
+#, python-format
+msgid "Please use \"%s\""
+msgstr ""
+
+#: ../kupfer/obj/fileactions.py:45 ../kupfer/plugin/applications.py:109
+msgid "Set Default Application..."
+msgstr ""
+
+#: ../kupfer/obj/fileactions.py:71
+msgid "Open with default application"
+msgstr ""
+
+#: ../kupfer/obj/fileactions.py:74
+msgid "Reveal"
+msgstr "Mostra"
+
+#: ../kupfer/obj/fileactions.py:83
+msgid "Open parent folder"
+msgstr ""
+
+#: ../kupfer/obj/fileactions.py:89
+msgid "Open Terminal Here"
+msgstr "Obre un terminal aquí"
+
+#: ../kupfer/obj/fileactions.py:102
+msgid "Open this location in a terminal"
+msgstr ""
+
+#: ../kupfer/obj/fileactions.py:110
+msgid "Run in Terminal"
+msgstr "Executa en un terminal"
+
+#: ../kupfer/obj/fileactions.py:110
+msgid "Run (Execute)"
+msgstr ""
+
+#: ../kupfer/obj/fileactions.py:130
+msgid "Run this program in a Terminal"
+msgstr ""
+
+#: ../kupfer/obj/fileactions.py:132
+msgid "Run this program"
+msgstr ""
+
+#: ../kupfer/obj/objects.py:252 ../kupfer/plugin/windows.py:105
+#: ../kupfer/plugin/windows.py:264 ../kupfer/plugin/vim/plugin.py:172
+msgid "Go To"
+msgstr "Vés a"
+
+#: ../kupfer/obj/objects.py:278
+msgid "Open URL"
+msgstr "Obre un URL"
+
+#: ../kupfer/obj/objects.py:289
+msgid "Open URL with default viewer"
+msgstr ""
+
+#: ../kupfer/obj/objects.py:303
+msgid "Launch"
+msgstr "Executa"
+
+#: ../kupfer/obj/objects.py:316
+msgid "Show application window"
+msgstr ""
+
+#: ../kupfer/obj/objects.py:317
+msgid "Launch application"
+msgstr "Executa l'aplicació"
+
+#: ../kupfer/obj/objects.py:328
+msgid "Launch Again"
+msgstr ""
+
+#: ../kupfer/obj/objects.py:335
+msgid "Launch another instance of this application"
+msgstr ""
+
+#: ../kupfer/obj/objects.py:341 ../kupfer/plugin/windows.py:37
+msgid "Close"
+msgstr "Tanca"
+
+#: ../kupfer/obj/objects.py:349
+msgid "Attempt to close all application windows"
+msgstr ""
+
+#. TRANS: 'Run' as in Perform a (saved) command
+#: ../kupfer/obj/objects.py:398
+msgid "Run"
+msgstr ""
+
+#: ../kupfer/obj/objects.py:408
+msgid "Perform command"
+msgstr ""
+
+#: ../kupfer/obj/objects.py:421
+msgid "(Empty Text)"
+msgstr ""
+
+#. TRANS: This is description for a TextLeaf, a free-text search
+#. TRANS: The plural parameter is the number of lines %(num)d
+#: ../kupfer/obj/objects.py:451
+#, python-format
+msgid "\"%(text)s\""
+msgid_plural "(%(num)d lines) \"%(text)s\""
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../kupfer/obj/sources.py:24
+#, python-format
+msgid "%s et. al."
+msgstr ""
+
+#: ../kupfer/obj/sources.py:54
+#, python-format
+msgid "Recursive source of %(dir)s, (%(levels)d levels)"
+msgstr ""
+
+#: ../kupfer/obj/sources.py:108
+#, python-format
+msgid "Directory source %s"
+msgstr ""
+
+#: ../kupfer/obj/sources.py:119
+msgid "Home Folder"
+msgstr "Carpeta personal"
+
+#: ../kupfer/obj/sources.py:130
+msgid "Catalog Index"
+msgstr ""
+
+#: ../kupfer/obj/sources.py:145
+msgid "An index of all available sources"
+msgstr ""
+
+#: ../kupfer/obj/sources.py:177
+msgid "Root catalog"
+msgstr ""
+
+#: ../kupfer/obj/special.py:10
+msgid "Please Configure Plugin"
+msgstr ""
+
+#: ../kupfer/obj/special.py:11
+#, python-format
+msgid "Plugin %s is not configured"
+msgstr ""
+
+#: ../kupfer/obj/special.py:32
+#, python-format
+msgid "Invalid user credentials for %s"
+msgstr ""
+
+#: ../kupfer/plugin/applications.py:2 ../kupfer/plugin/applications.py:38
+msgid "Applications"
+msgstr "Aplicacions"
+
+#: ../kupfer/plugin/applications.py:8 ../kupfer/plugin/applications.py:74
+msgid "All applications and preferences"
+msgstr ""
+
+#: ../kupfer/plugin/applications.py:23
+msgid "Applications for Desktop Environment"
+msgstr ""
+
+#: ../kupfer/plugin/applications.py:83
+msgid "Open With..."
+msgstr "Obre amb..."
+
+#: ../kupfer/plugin/applications.py:105
+msgid "Open with any application"
+msgstr ""
+
+#: ../kupfer/plugin/applications.py:124
+msgid "Set default application to open this file type"
+msgstr ""
+
+#: ../kupfer/plugin/archivemanager.py:1
+msgid "Archive Manager"
+msgstr "Gestor d'arxius"
+
+#: ../kupfer/plugin/archivemanager.py:9
+msgid "Use Archive Manager actions"
+msgstr ""
+
+#: ../kupfer/plugin/archivemanager.py:27
+msgid "Compressed archive type for 'Create Archive In'"
+msgstr ""
+
+#: ../kupfer/plugin/archivemanager.py:44
+msgid "Extract Here"
+msgstr "Extreu aquí"
+
+#: ../kupfer/plugin/archivemanager.py:64
+msgid "Extract compressed archive"
+msgstr ""
+
+#: ../kupfer/plugin/archivemanager.py:70
+msgid "Create Archive"
+msgstr "Crea arxiu"
+
+#: ../kupfer/plugin/archivemanager.py:86
+#: ../kupfer/plugin/archivemanager.py:129
+msgid "Create a compressed archive from folder"
+msgstr ""
+
+#: ../kupfer/plugin/archivemanager.py:92
+msgid "Create Archive In..."
+msgstr "Crea arxiu..."
+
+#. TRANS: Default filename (no extension) for 'Create Archive In...'
+#: ../kupfer/plugin/archivemanager.py:115
+msgid "Archive"
+msgstr "Arxiu"
+
+#: ../kupfer/plugin/calculator.py:2 ../kupfer/plugin/calculator.py:81
+msgid "Calculator"
+msgstr "Calculadora"
+
+#: ../kupfer/plugin/calculator.py:4
+msgid "Calculate mathematical expressions"
+msgstr ""
+
+#: ../kupfer/plugin/calculator.py:119
+msgid "Calculate"
+msgstr "Calcula"
+
+#: ../kupfer/plugin/clipboard.py:1 ../kupfer/plugin/clipboard.py:112
+msgid "Clipboards"
+msgstr "Porta-retalls"
+
+#: ../kupfer/plugin/clipboard.py:4
+msgid "Recent clipboards and clipboard proxy objects"
+msgstr ""
+
+#: ../kupfer/plugin/clipboard.py:24
+msgid "Number of recent clipboards to remember"
+msgstr ""
+
+#: ../kupfer/plugin/clipboard.py:30
+msgid "Include selected text in clipboard history"
+msgstr ""
+
+#: ../kupfer/plugin/clipboard.py:36
+msgid "Copy selected text to primary clipboard"
+msgstr ""
+
+#: ../kupfer/plugin/clipboard.py:47
+#, fuzzy
+msgid "Selected Text"
+msgstr "Seleccioneu el fitxer seleccionat"
+
+#: ../kupfer/plugin/clipboard.py:57
+#, python-format
+msgid "Clipboard \"%(desc)s\""
+msgid_plural "Clipboard with %(num)d lines \"%(desc)s\""
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../kupfer/plugin/clipboard.py:64
+msgid "Clipboard Text"
+msgstr "Text del porta-retalls"
+
+#: ../kupfer/plugin/clipboard.py:74
+#, fuzzy
+msgid "Clipboard File"
+msgstr "Text del porta-retalls"
+
+#: ../kupfer/plugin/clipboard.py:84
+msgid "Clipboard Files"
+msgstr ""
+
+#: ../kupfer/plugin/clipboard.py:92
+msgid "Clear"
+msgstr "Esborra"
+
+#: ../kupfer/plugin/clipboard.py:104
+msgid "Remove all recent clipboards"
+msgstr ""
+
+#: ../kupfer/plugin/commands.py:1 ../kupfer/plugin/commands.py:187
+#, fuzzy
+msgid "Shell Commands"
+msgstr "Ordre"
+
+#: ../kupfer/plugin/commands.py:9
+#, python-format
+msgid ""
+"Run command-line programs. Actions marked with the symbol %s run in a "
+"subshell."
+msgstr ""
+
+#: ../kupfer/plugin/commands.py:41
+msgid "Run (Get Output)"
+msgstr ""
+
+#: ../kupfer/plugin/commands.py:59
+msgid "Run program and return its output"
+msgstr ""
+
+#. TRANS: The user starts a program (command) and the text
+#. TRANS: is an argument to the command
+#: ../kupfer/plugin/commands.py:65
+msgid "Pass to Command..."
+msgstr ""
+
+#: ../kupfer/plugin/commands.py:107
+msgid "Run program with object as an additional parameter"
+msgstr ""
+
+#. TRANS: The user starts a program (command) and
+#. TRANS: the text is written on stdin
+#: ../kupfer/plugin/commands.py:115
+msgid "Write to Command..."
+msgstr ""
+
+#: ../kupfer/plugin/commands.py:149 ../kupfer/plugin/commands.py:161
+msgid "Run program and supply text on the standard input"
+msgstr ""
+
+#. TRANS: The user starts a program (command) and
+#. TRANS: the text is written on stdin, and we
+#. TRANS: present the output (stdout) to the user.
+#: ../kupfer/plugin/commands.py:157
+msgid "Filter through Command..."
+msgstr ""
+
+#: ../kupfer/plugin/commands.py:215
+msgid "Run command-line programs"
+msgstr ""
+
+#: ../kupfer/plugin/core/alternatives.py:7
+msgid "GTK+"
+msgstr "GTK+"
+
+#: ../kupfer/plugin/core/alternatives.py:13
+msgid "GNOME Terminal"
+msgstr "Terminal del GNOME"
+
+#: ../kupfer/plugin/core/alternatives.py:22
+msgid "XFCE Terminal"
+msgstr ""
+
+#: ../kupfer/plugin/core/alternatives.py:31
+#, fuzzy
+msgid "LXTerminal"
+msgstr "Terminal del GNOME"
+
+#: ../kupfer/plugin/core/alternatives.py:40
+#, fuzzy
+msgid "X Terminal"
+msgstr "Terminal del GNOME"
+
+#: ../kupfer/plugin/core/alternatives.py:49
+msgid "Urxvt"
+msgstr ""
+
+#: ../kupfer/plugin/core/alternatives.py:58
+msgid "Konsole"
+msgstr "Konsole"
+
+#: ../kupfer/plugin/core/commands.py:13 ../kupfer/plugin/core/commands.py:32
+msgid "Save As..."
+msgstr "Anomena i desa..."
+
+#: ../kupfer/plugin/core/contents.py:41
+msgid "Quit"
+msgstr "Surt"
+
+#: ../kupfer/plugin/core/contents.py:46
+msgid "Quit Kupfer"
+msgstr ""
+
+#: ../kupfer/plugin/core/contents.py:52
+msgid "About Kupfer"
+msgstr ""
+
+#: ../kupfer/plugin/core/contents.py:59
+msgid "Show information about Kupfer authors and license"
+msgstr ""
+
+#: ../kupfer/plugin/core/contents.py:65
+msgid "Kupfer Help"
+msgstr ""
+
+#: ../kupfer/plugin/core/contents.py:72
+msgid "Get help with Kupfer"
+msgstr ""
+
+#: ../kupfer/plugin/core/contents.py:85
+msgid "Show preferences window for Kupfer"
+msgstr ""
+
+#: ../kupfer/plugin/core/__init__.py:64
+#, fuzzy
+msgid "Search Contents"
+msgstr "Motors de cerca"
+
+#: ../kupfer/plugin/core/__init__.py:82
+msgid "Search inside this catalog"
+msgstr ""
+
+#: ../kupfer/plugin/core/__init__.py:90
+msgid "Copy"
+msgstr "Còpia"
+
+#: ../kupfer/plugin/core/__init__.py:105
+msgid "Copy to clipboard"
+msgstr "Copia-ho al porta-retalls"
+
+#: ../kupfer/plugin/core/__init__.py:127
+msgid "Rescan"
+msgstr ""
+
+#: ../kupfer/plugin/core/__init__.py:142
+msgid "Force reindex of this source"
+msgstr ""
+
+#: ../kupfer/plugin/core/internal.py:13
+#, fuzzy
+msgid "Last Command"
+msgstr "Ordre"
+
+#: ../kupfer/plugin/core/internal.py:24
+msgid "Internal Kupfer Objects"
+msgstr ""
+
+#: ../kupfer/plugin/core/internal.py:46 ../kupfer/plugin/core/internal.py:48
+msgid "Last Result"
+msgstr ""
+
+#: ../kupfer/plugin/core/internal.py:66
+msgid "Command Results"
+msgstr ""
+
+#: ../kupfer/plugin/dictionary.py:1 ../kupfer/plugin/dictionary.py:21
+msgid "Dictionary"
+msgstr "Diccionari"
+
+#: ../kupfer/plugin/dictionary.py:3 ../kupfer/plugin/dictionary.py:47
+msgid "Look up word in dictionary"
+msgstr ""
+
+#: ../kupfer/plugin/dictionary.py:30
+msgid "Look Up"
+msgstr ""
+
+#: ../kupfer/plugin/documents.py:1
+msgid "Documents"
+msgstr "Documents"
+
+#: ../kupfer/plugin/documents.py:4
+msgid "Recently used documents and bookmarked folders"
+msgstr ""
+
+#: ../kupfer/plugin/documents.py:22
+msgid "Max recent document days"
+msgstr ""
+
+#: ../kupfer/plugin/documents.py:32
+msgid "Recent Items"
+msgstr ""
+
+#: ../kupfer/plugin/documents.py:78
+msgid "Recently used documents"
+msgstr ""
+
+#: ../kupfer/plugin/documents.py:88
+#, fuzzy, python-format
+msgid "%s Documents"
+msgstr "Documents"
+
+#: ../kupfer/plugin/documents.py:113
+#, python-format
+msgid "Recently used documents for %s"
+msgstr ""
+
+#: ../kupfer/plugin/documents.py:132
+msgid "Places"
+msgstr "Llocs"
+
+#: ../kupfer/plugin/documents.py:164
+#, fuzzy
+msgid "Bookmarked folders"
+msgstr "Carpeta personal"
+
+#: ../kupfer/plugin/epiphany.py:1 ../kupfer/plugin/epiphany.py:18
+msgid "Epiphany Bookmarks"
+msgstr "Adreces d'interès de l'Epiphany"
+
+#: ../kupfer/plugin/epiphany.py:3 ../kupfer/plugin/epiphany.py:35
+msgid "Index of Epiphany bookmarks"
+msgstr ""
+
+#: ../kupfer/plugin/favorites.py:1 ../kupfer/plugin/favorites.py:21
+msgid "Favorites"
+msgstr "Preferits"
+
+#: ../kupfer/plugin/favorites.py:4
+msgid "Mark commonly used items and store objects for later use"
+msgstr ""
+
+#: ../kupfer/plugin/favorites.py:127
+msgid "Shelf of \"Favorite\" items"
+msgstr ""
+
+#: ../kupfer/plugin/favorites.py:140
+msgid "Add to Favorites"
+msgstr "Afegeix als preferits"
+
+#: ../kupfer/plugin/favorites.py:148
+msgid "Add item to favorites shelf"
+msgstr ""
+
+#: ../kupfer/plugin/favorites.py:155
+msgid "Remove from Favorites"
+msgstr "Suprimeix dels preferits"
+
+#: ../kupfer/plugin/favorites.py:163
+msgid "Remove item from favorites shelf"
+msgstr ""
+
+#: ../kupfer/plugin/fileactions.py:1
+msgid "File Actions"
+msgstr ""
+
+#: ../kupfer/plugin/fileactions.py:9
+msgid "More file actions"
+msgstr ""
+
+#: ../kupfer/plugin/fileactions.py:40 ../kupfer/plugin/windows.py:122
+#: ../kupfer/plugin/thunar.py:211
+msgid "Move To..."
+msgstr ""
+
+#: ../kupfer/plugin/fileactions.py:67 ../kupfer/plugin/thunar.py:253
+msgid "Move file to new location"
+msgstr ""
+
+#: ../kupfer/plugin/fileactions.py:80 ../kupfer/plugin/fileactions.py:103
+#, fuzzy
+msgid "Rename To..."
+msgstr "Envia a..."
+
+#: ../kupfer/plugin/fileactions.py:145 ../kupfer/plugin/thunar.py:166
+msgid "Copy To..."
+msgstr "Copia a..."
+
+#: ../kupfer/plugin/fileactions.py:186 ../kupfer/plugin/thunar.py:207
+msgid "Copy file to a chosen location"
+msgstr ""
+
+#: ../kupfer/plugin/firefox.py:4 ../kupfer/plugin/firefox.py:61
+msgid "Firefox Bookmarks"
+msgstr "Adreces d'interès del Firefox"
+
+#: ../kupfer/plugin/firefox.py:6 ../kupfer/plugin/firefox.py:147
+msgid "Index of Firefox bookmarks"
+msgstr ""
+
+#: ../kupfer/plugin/firefox.py:26
+msgid "Include visited sites"
+msgstr ""
+
+#: ../kupfer/plugin/firefox.py:44
+#, fuzzy
+msgid "Firefox tag"
+msgstr "Adreces d'interès del Firefox"
+
+#. TRANS: Multihead refers to support for multiple computer displays
+#. TRANS: In this case, it only concerns the special configuration
+#. TRANS: with multiple X "screens"
+#: ../kupfer/plugin/multihead.py:4
+msgid "Multihead Support"
+msgstr ""
+
+#: ../kupfer/plugin/notes.py:6 ../kupfer/plugin/notes.py:178
+#: ../kupfer/plugin/notes.py:230
+msgid "Notes"
+msgstr "Anotacions"
+
+#: ../kupfer/plugin/notes.py:13
+msgid "Gnote or Tomboy notes"
+msgstr ""
+
+#: ../kupfer/plugin/notes.py:35
+msgid "Work with application"
+msgstr ""
+
+#: ../kupfer/plugin/notes.py:95
+msgid "Open with notes application"
+msgstr ""
+
+#: ../kupfer/plugin/notes.py:102
+msgid "Append to Note..."
+msgstr ""
+
+#: ../kupfer/plugin/notes.py:125
+msgid "Add text to existing note"
+msgstr ""
+
+#: ../kupfer/plugin/notes.py:140
+#, fuzzy
+msgid "Create Note"
+msgstr "Crea arxiu"
+
+#: ../kupfer/plugin/notes.py:154
+msgid "Create a new note from this text"
+msgstr ""
+
+#: ../kupfer/plugin/notes.py:160
+msgid "Get Note Search Results..."
+msgstr ""
+
+#: ../kupfer/plugin/notes.py:173
+msgid "Show search results for this query"
+msgstr ""
+
+#: ../kupfer/plugin/notes.py:213
+#, python-format
+msgid "today, %s"
+msgstr ""
+
+#: ../kupfer/plugin/notes.py:215
+#, python-format
+msgid "yesterday, %s"
+msgstr ""
+
+#. TRANS: Note description, %s is last changed time in locale format
+#: ../kupfer/plugin/notes.py:219
+#, python-format
+msgid "Last updated %s"
+msgstr ""
+
+#: ../kupfer/plugin/session_support.py:31
+msgid "Log Out..."
+msgstr ""
+
+#: ../kupfer/plugin/session_support.py:34
+msgid "Log out or change user"
+msgstr ""
+
+#: ../kupfer/plugin/session_support.py:41
+msgid "Shut Down..."
+msgstr ""
+
+#: ../kupfer/plugin/session_support.py:44
+msgid "Shut down, restart or suspend computer"
+msgstr ""
+
+#: ../kupfer/plugin/session_support.py:51
+msgid "Lock Screen"
+msgstr "Bloca la pantalla"
+
+#: ../kupfer/plugin/session_support.py:54
+msgid "Enable screensaver and lock"
+msgstr ""
+
+#. -*- coding: utf-8 -*
+#: ../kupfer/plugin/session_xfce.py:3 ../kupfer/plugin/session_xfce.py:20
+msgid "XFCE Session Management"
+msgstr ""
+
+#: ../kupfer/plugin/session_xfce.py:5
+msgid "Special items and actions for XFCE environment"
+msgstr ""
+
+#: ../kupfer/plugin/show_text.py:1 ../kupfer/plugin/show_text.py:18
+#: ../kupfer/plugin/show_text.py:25
+msgid "Show Text"
+msgstr "Mostra el text"
+
+#: ../kupfer/plugin/show_text.py:7 ../kupfer/plugin/show_text.py:31
+#: ../kupfer/plugin/show_text.py:58
+msgid "Display text in a window"
+msgstr ""
+
+#: ../kupfer/plugin/show_text.py:37
+msgid "Large Type"
+msgstr ""
+
+#: ../kupfer/plugin/show_text.py:66
+#, fuzzy
+msgid "Show Notification"
+msgstr "Mostra la icona a l'àrea de notificació"
+
+#: ../kupfer/plugin/trash.py:1 ../kupfer/plugin/trash.py:197
+msgid "Trash"
+msgstr "Paperera"
+
+#: ../kupfer/plugin/trash.py:4
+msgid "Access trash contents"
+msgstr ""
+
+#: ../kupfer/plugin/trash.py:24
+msgid "Move to Trash"
+msgstr "Mou a la paperera"
+
+#: ../kupfer/plugin/trash.py:40
+#, fuzzy
+msgid "Move this file to trash"
+msgstr "Mou a la paperera"
+
+#: ../kupfer/plugin/trash.py:49
+msgid "Restore"
+msgstr "Restaura"
+
+#: ../kupfer/plugin/trash.py:68
+msgid "Move file back to original location"
+msgstr ""
+
+#: ../kupfer/plugin/trash.py:75 ../kupfer/plugin/thunar.py:304
+msgid "Empty Trash"
+msgstr "Buida la paperera"
+
+#: ../kupfer/plugin/trash.py:84
+msgid ""
+"Could not delete files:\n"
+"    "
+msgstr ""
+
+#: ../kupfer/plugin/trash.py:185
+msgid "Trash is empty"
+msgstr ""
+
+#. proper translation of plural
+#: ../kupfer/plugin/trash.py:187
+#, python-format
+msgid "Trash contains one file"
+msgid_plural "Trash contains %(num)s files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../kupfer/plugin/triggers.py:1 ../kupfer/plugin/triggers.py:50
+msgid "Triggers"
+msgstr "Gallets"
+
+#: ../kupfer/plugin/triggers.py:6
+msgid ""
+"Assign global keybindings (triggers) to objects created with 'Compose "
+"Command'."
+msgstr ""
+
+#: ../kupfer/plugin/triggers.py:161
+msgid "Add Trigger..."
+msgstr ""
+
+#: ../kupfer/plugin/triggers.py:180
+#, fuzzy
+msgid "Remove Trigger"
+msgstr "Gallets"
+
+#: ../kupfer/plugin/urlactions.py:1 ../kupfer/plugin/urlactions.py:8
+#, fuzzy
+msgid "URL Actions"
+msgstr "Accions"
+
+#: ../kupfer/plugin/urlactions.py:63
+msgid "Download and Open"
+msgstr ""
+
+#: ../kupfer/plugin/urlactions.py:83
+#, fuzzy
+msgid "Download To..."
+msgstr "Envia a..."
+
+#: ../kupfer/plugin/urlactions.py:104
+msgid "Download URL to a chosen location"
+msgstr ""
+
+#: ../kupfer/plugin/volumes.py:1 ../kupfer/plugin/volumes.py:91
+msgid "Volumes and Disks"
+msgstr ""
+
+#: ../kupfer/plugin/volumes.py:3 ../kupfer/plugin/volumes.py:101
+msgid "Mounted volumes and disks"
+msgstr ""
+
+#: ../kupfer/plugin/volumes.py:42
+#, python-format
+msgid "Volume mounted at %s"
+msgstr ""
+
+#: ../kupfer/plugin/volumes.py:51
+msgid "Unmount"
+msgstr ""
+
+#: ../kupfer/plugin/volumes.py:78
+msgid "Unmount this volume"
+msgstr ""
+
+#: ../kupfer/plugin/volumes.py:85
+msgid "Eject"
+msgstr "Expulsa"
+
+#: ../kupfer/plugin/volumes.py:88
+msgid "Unmount and eject this media"
+msgstr ""
+
+#: ../kupfer/plugin/websearch.py:1
+msgid "Search the Web"
+msgstr "Cerca al web"
+
+#: ../kupfer/plugin/websearch.py:8 ../kupfer/plugin/websearch.py:63
+#: ../kupfer/plugin/websearch.py:90
+msgid "Search the web with OpenSearch search engines"
+msgstr ""
+
+#: ../kupfer/plugin/websearch.py:44
+msgid "Search With..."
+msgstr ""
+
+#: ../kupfer/plugin/websearch.py:73
+msgid "Search For..."
+msgstr ""
+
+#: ../kupfer/plugin/websearch.py:114
+msgid "Search Engines"
+msgstr "Motors de cerca"
+
+#: ../kupfer/plugin/wikipedia.py:5
+msgid "Wikipedia"
+msgstr "Viquipèdia"
+
+#: ../kupfer/plugin/wikipedia.py:8 ../kupfer/plugin/wikipedia.py:31
+msgid "Search in Wikipedia"
+msgstr ""
+
+#: ../kupfer/plugin/wikipedia.py:21
+msgid "Wikipedia language"
+msgstr ""
+
+#. TRANS: Default wikipedia language code
+#: ../kupfer/plugin/wikipedia.py:24
+msgid "en"
+msgstr "ca"
+
+#: ../kupfer/plugin/wikipedia.py:44
+#, python-format
+msgid "Search for this term in %s.wikipedia.org"
+msgstr ""
+
+#: ../kupfer/plugin/windows.py:1 ../kupfer/plugin/windows.py:210
+msgid "Window List"
+msgstr "Llista de finestres"
+
+#: ../kupfer/plugin/windows.py:3 ../kupfer/plugin/windows.py:233
+msgid "All windows on all workspaces"
+msgstr ""
+
+#: ../kupfer/plugin/windows.py:18
+msgid "Activate"
+msgstr "Activa"
+
+#: ../kupfer/plugin/windows.py:22
+msgid "Shade"
+msgstr "Ombra"
+
+#: ../kupfer/plugin/windows.py:22
+#, fuzzy
+msgid "Unshade"
+msgstr "Ombra"
+
+#: ../kupfer/plugin/windows.py:25
+msgid "Minimize"
+msgstr "Minimitza"
+
+#: ../kupfer/plugin/windows.py:25
+#, fuzzy
+msgid "Unminimize"
+msgstr "Minimitza"
+
+#: ../kupfer/plugin/windows.py:29
+msgid "Maximize"
+msgstr "Maximitza"
+
+#: ../kupfer/plugin/windows.py:29
+#, fuzzy
+msgid "Unmaximize"
+msgstr "Maximitza"
+
+#: ../kupfer/plugin/windows.py:33
+msgid "Maximize Vertically"
+msgstr "Maximitza verticalment"
+
+#: ../kupfer/plugin/windows.py:33
+#, fuzzy
+msgid "Unmaximize Vertically"
+msgstr "Maximitza verticalment"
+
+#. TRANS: Window on (Workspace name), window description
+#: ../kupfer/plugin/windows.py:48
+#, python-format
+msgid "Window on %(wkspc)s"
+msgstr ""
+
+#: ../kupfer/plugin/windows.py:56
+msgid "Frontmost Window"
+msgstr ""
+
+#: ../kupfer/plugin/windows.py:85
+msgid "Next Window"
+msgstr "Finestra següent"
+
+#: ../kupfer/plugin/windows.py:116
+msgid "Jump to this window's workspace and focus"
+msgstr ""
+
+#: ../kupfer/plugin/windows.py:252
+#, fuzzy, python-format
+msgid "%d window"
+msgid_plural "%d windows"
+msgstr[0] "Finestra següent"
+msgstr[1] "Finestra següent"
+
+#: ../kupfer/plugin/windows.py:256
+msgid "Active workspace"
+msgstr ""
+
+#: ../kupfer/plugin/windows.py:274
+msgid "Jump to this workspace"
+msgstr ""
+
+#: ../kupfer/plugin/windows.py:281
+msgid "Workspaces"
+msgstr "Espais de treball"
+
+#: ../kupfer/plugin/abiword.py:1
+msgid "Abiword"
+msgstr "Abiword"
+
+#: ../kupfer/plugin/abiword.py:3 ../kupfer/plugin/abiword.py:88
+msgid "Recently used documents in Abiword"
+msgstr ""
+
+#: ../kupfer/plugin/abiword.py:34
+msgid "Abiword Recent Items"
+msgstr ""
+
+#: ../kupfer/plugin/apt_tools.py:1
+msgid "APT"
+msgstr ""
+
+#: ../kupfer/plugin/apt_tools.py:9
+msgid "Interface with the package manager APT"
+msgstr ""
+
+#: ../kupfer/plugin/apt_tools.py:25
+msgid "Installation method"
+msgstr ""
+
+#: ../kupfer/plugin/apt_tools.py:61 ../kupfer/plugin/apt_tools.py:66
+#, fuzzy
+msgid "Show Package Information"
+msgstr "mostra la informació de la versió"
+
+#: ../kupfer/plugin/apt_tools.py:87
+msgid "Install"
+msgstr "Instal·la"
+
+#: ../kupfer/plugin/apt_tools.py:103
+msgid "Install package using the configured method"
+msgstr ""
+
+#: ../kupfer/plugin/apt_tools.py:122
+#, python-format
+msgid "Packages matching \"%s\""
+msgstr ""
+
+#: ../kupfer/plugin/apt_tools.py:154
+msgid "Search Package Name..."
+msgstr ""
+
+#: ../kupfer/plugin/archiveinside.py:8
+msgid "Deep Archives"
+msgstr ""
+
+#: ../kupfer/plugin/archiveinside.py:10
+msgid "Allow browsing inside compressed archive files"
+msgstr ""
+
+#: ../kupfer/plugin/archiveinside.py:49
+#, python-format
+msgid "Content of %s"
+msgstr ""
+
+#. encoding: utf-8
+#. don't panic! This is just because it's crazy and fun! ツ
+#: ../kupfer/plugin/asciiunicodeiconset.py:3
+msgid "Ascii & Unicode Icon Set"
+msgstr ""
+
+#: ../kupfer/plugin/asciiunicodeiconset.py:5
+msgid ""
+"Provides the Ascii and Unicode icon sets that use letters and symbols to "
+"produce icons for the objects found in Kupfer."
+msgstr ""
+
+#: ../kupfer/plugin/asciiunicodeiconset.py:21
+msgid "Ascii"
+msgstr ""
+
+#: ../kupfer/plugin/asciiunicodeiconset.py:23
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../kupfer/plugin/audacious.py:1 ../kupfer/plugin/audacious.py:187
+msgid "Audacious"
+msgstr ""
+
+#: ../kupfer/plugin/audacious.py:3
+msgid "Control Audacious playback and playlist"
+msgstr ""
+
+#: ../kupfer/plugin/audacious.py:20
+msgid "Include songs in top level"
+msgstr ""
+
+#: ../kupfer/plugin/audacious.py:58
+msgid "Enqueue"
+msgstr "Encuar"
+
+#: ../kupfer/plugin/audacious.py:62
+msgid "Add track to the Audacious play queue"
+msgstr ""
+
+#: ../kupfer/plugin/audacious.py:70
+msgid "Dequeue"
+msgstr ""
+
+#: ../kupfer/plugin/audacious.py:74
+msgid "Remove track from the Audacious play queue"
+msgstr ""
+
+#: ../kupfer/plugin/audacious.py:82 ../kupfer/plugin/audacious.py:92
+msgid "Play"
+msgstr "Reprodueix"
+
+#: ../kupfer/plugin/audacious.py:86
+msgid "Jump to track in Audacious"
+msgstr ""
+
+#: ../kupfer/plugin/audacious.py:96
+msgid "Resume playback in Audacious"
+msgstr ""
+
+#: ../kupfer/plugin/audacious.py:102
+#: ../kupfer/plugin/virtualbox/__init__.py:93
+msgid "Pause"
+msgstr "Pausa"
+
+#: ../kupfer/plugin/audacious.py:106
+msgid "Pause playback in Audacious"
+msgstr ""
+
+#: ../kupfer/plugin/audacious.py:112
+msgid "Next"
+msgstr "Següent"
+
+#: ../kupfer/plugin/audacious.py:116
+msgid "Jump to next track in Audacious"
+msgstr ""
+
+#: ../kupfer/plugin/audacious.py:122
+msgid "Previous"
+msgstr "Anterior"
+
+#: ../kupfer/plugin/audacious.py:126
+msgid "Jump to previous track in Audacious"
+msgstr ""
+
+#: ../kupfer/plugin/audacious.py:132
+#, fuzzy
+msgid "Clear Queue"
+msgstr "Esborra"
+
+#: ../kupfer/plugin/audacious.py:136
+msgid "Clear the Audacious play queue"
+msgstr ""
+
+#: ../kupfer/plugin/audacious.py:142
+msgid "Shuffle"
+msgstr "Mescla"
+
+#: ../kupfer/plugin/audacious.py:146
+msgid "Toggle shuffle in Audacious"
+msgstr ""
+
+#: ../kupfer/plugin/audacious.py:152
+msgid "Repeat"
+msgstr "Repeteix"
+
+#: ../kupfer/plugin/audacious.py:156
+msgid "Toggle repeat in Audacious"
+msgstr ""
+
+#: ../kupfer/plugin/audacious.py:171
+msgid "Playlist"
+msgstr "Llista de reproducció"
+
+#: ../kupfer/plugin/chromium.py:1 ../kupfer/plugin/chromium.py:16
+msgid "Chromium Bookmarks"
+msgstr ""
+
+#: ../kupfer/plugin/chromium.py:3 ../kupfer/plugin/chromium.py:43
+msgid "Index of Chromium bookmarks"
+msgstr ""
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/clawsmail.py:2
+msgid "Claws Mail"
+msgstr ""
+
+#: ../kupfer/plugin/clawsmail.py:5
+msgid "Claws Mail Contacts and Actions"
+msgstr ""
+
+#: ../kupfer/plugin/clawsmail.py:26 ../kupfer/plugin/evolution.py:24
+#: ../kupfer/plugin/operamail.py:26 ../kupfer/plugin/thunderbird.py:31
+msgid "Compose New Email"
+msgstr ""
+
+#: ../kupfer/plugin/clawsmail.py:32
+msgid "Compose a new message in Claws Mail"
+msgstr ""
+
+#: ../kupfer/plugin/clawsmail.py:41
+msgid "Receive All Email"
+msgstr ""
+
+#: ../kupfer/plugin/clawsmail.py:47
+msgid "Receive new messages from all accounts in ClawsMail"
+msgstr ""
+
+#: ../kupfer/plugin/clawsmail.py:56 ../kupfer/plugin/defaultmail.py:18
+#: ../kupfer/plugin/evolution.py:40 ../kupfer/plugin/operamail.py:41
+#: ../kupfer/plugin/thunderbird.py:47
+#, fuzzy
+msgid "Compose Email"
+msgstr "Adreça electrònica particular"
+
+#: ../kupfer/plugin/clawsmail.py:81 ../kupfer/plugin/defaultmail.py:43
+#: ../kupfer/plugin/evolution.py:65
+msgid "Send in Email To..."
+msgstr ""
+
+#: ../kupfer/plugin/clawsmail.py:107
+msgid "Compose new message in Claws Mail and attach file"
+msgstr ""
+
+#: ../kupfer/plugin/clawsmail.py:116
+msgid "Claws Mail Address Book"
+msgstr ""
+
+#: ../kupfer/plugin/clawsmail.py:164
+msgid "Contacts from Claws Mail Address Book"
+msgstr ""
+
+#: ../kupfer/plugin/custom_terminal.py:1
+#: ../kupfer/plugin/custom_terminal.py:39
+msgid "Custom Terminal"
+msgstr ""
+
+#: ../kupfer/plugin/custom_terminal.py:2
+msgid "Configure a custom terminal emulator"
+msgstr ""
+
+#: ../kupfer/plugin/custom_terminal.py:18
+msgid "Execute flag"
+msgstr ""
+
+#: ../kupfer/plugin/customtheme.py:1
+msgid "Custom Theme"
+msgstr ""
+
+#: ../kupfer/plugin/customtheme.py:3
+msgid "Use a custom color theme"
+msgstr ""
+
+#: ../kupfer/plugin/customtheme.py:110
+msgid "Theme:"
+msgstr "Tema:"
+
+#: ../kupfer/plugin/defaultmail.py:1
+msgid "Default Email Client"
+msgstr ""
+
+#: ../kupfer/plugin/defaultmail.py:6
+msgid "Compose email using the system's default mailto: handler"
+msgstr ""
+
+#: ../kupfer/plugin/devhelp.py:1
+msgid "Devhelp"
+msgstr "Devhelp"
+
+#: ../kupfer/plugin/devhelp.py:3 ../kupfer/plugin/devhelp.py:13
+msgid "Search in Devhelp"
+msgstr ""
+
+#: ../kupfer/plugin/duckduckgo.py:5 ../kupfer/plugin/duckduckgo.py:19
+msgid "DuckDuckGo Search"
+msgstr ""
+
+#: ../kupfer/plugin/duckduckgo.py:8 ../kupfer/plugin/duckduckgo.py:30
+msgid "Search the web securely with DuckDuckGo"
+msgstr ""
+
+#. -*- coding: UTF-8 -*-
+#. vim: set noexpandtab ts=8 sw=8:
+#: ../kupfer/plugin/empathy.py:3
+msgid "Empathy"
+msgstr "Empathy"
+
+#: ../kupfer/plugin/empathy.py:6
+msgid "Access to Empathy Contacts"
+msgstr ""
+
+#: ../kupfer/plugin/empathy.py:26 ../kupfer/plugin/pidgin.py:29
+msgid "Show offline contacts"
+msgstr "Mostra els contactes fora de línia"
+
+#: ../kupfer/plugin/empathy.py:35 ../kupfer/plugin/gajim.py:26
+#: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:30
+msgid "Available"
+msgstr "Disponible"
+
+#: ../kupfer/plugin/empathy.py:36 ../kupfer/plugin/gajim.py:28
+#: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:32
+msgid "Away"
+msgstr "Absent"
+
+#: ../kupfer/plugin/empathy.py:37 ../kupfer/plugin/gajim.py:30
+#: ../kupfer/plugin/skype.py:34
+msgid "Busy"
+msgstr "Ocupat"
+
+#: ../kupfer/plugin/empathy.py:38 ../kupfer/plugin/gajim.py:29
+#: ../kupfer/plugin/skype.py:33
+msgid "Not Available"
+msgstr "No és disponible"
+
+#: ../kupfer/plugin/empathy.py:39 ../kupfer/plugin/gajim.py:31
+#: ../kupfer/plugin/skype.py:35
+msgid "Invisible"
+msgstr "Invisible"
+
+#: ../kupfer/plugin/empathy.py:40 ../kupfer/plugin/gajim.py:32
+#: ../kupfer/plugin/skype.py:36
+msgid "Offline"
+msgstr "Fora de línia"
+
+#: ../kupfer/plugin/empathy.py:100 ../kupfer/plugin/gajim.py:93
+#: ../kupfer/plugin/pidgin.py:97 ../kupfer/plugin/skype.py:197
+msgid "Open Chat"
+msgstr ""
+
+#: ../kupfer/plugin/empathy.py:133 ../kupfer/plugin/gajim.py:121
+#: ../kupfer/plugin/skype.py:243
+msgid "Change Global Status To..."
+msgstr ""
+
+#: ../kupfer/plugin/empathy.py:175
+msgid "Empathy Contacts"
+msgstr ""
+
+#: ../kupfer/plugin/empathy.py:249
+msgid "Empathy Account Status"
+msgstr ""
+
+#: ../kupfer/plugin/evolution.py:4
+msgid "Evolution"
+msgstr "Evolution"
+
+#: ../kupfer/plugin/evolution.py:7 ../kupfer/plugin/evolution.py:119
+msgid "Evolution contacts"
+msgstr "Contactes de l'Evolution"
+
+#: ../kupfer/plugin/evolution.py:31
+msgid "Compose a new message in Evolution"
+msgstr ""
+
+#: ../kupfer/plugin/evolution.py:92
+msgid "Compose new message in Evolution and attach file"
+msgstr ""
+
+#: ../kupfer/plugin/evolution.py:100
+msgid "Evolution Address Book"
+msgstr ""
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/filezilla.py:3
+msgid "Filezilla"
+msgstr ""
+
+#: ../kupfer/plugin/filezilla.py:6
+msgid "Show sites and handle ftp addresses by Filezilla"
+msgstr ""
+
+#: ../kupfer/plugin/filezilla.py:42
+msgid "Open Site with Filezilla"
+msgstr ""
+
+#: ../kupfer/plugin/filezilla.py:87
+msgid "Filezilla Sites"
+msgstr ""
+
+#: ../kupfer/plugin/filezilla.py:122
+msgid "Sites from Filezilla"
+msgstr ""
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/gajim.py:2
+msgid "Gajim"
+msgstr ""
+
+#: ../kupfer/plugin/gajim.py:5
+msgid "Access to Gajim Contacts"
+msgstr ""
+
+#: ../kupfer/plugin/gajim.py:27
+msgid "Free for Chat"
+msgstr ""
+
+#: ../kupfer/plugin/gajim.py:149
+msgid "Gajim Contacts"
+msgstr "Contactes del Gajim"
+
+#: ../kupfer/plugin/gajim.py:213
+msgid "Gajim Account Status"
+msgstr ""
+
+#. TRANS: "Glob" is the matching files like a shell with "*.py" etc.
+#: ../kupfer/plugin/glob.py:3 ../kupfer/plugin/glob.py:17
+msgid "Glob"
+msgstr ""
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/gmail/__init__.py:2 ../kupfer/plugin/gmail/__init__.py:234
+msgid "Gmail"
+msgstr "Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:5
+msgid "Load contacts and compose new email in Gmail"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:33
+msgid "Load contacts' pictures"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:39
+#, fuzzy
+msgid "Load additional information"
+msgstr "mostra la informació de la versió"
+
+#: ../kupfer/plugin/gmail/__init__.py:50
+msgid "Work email"
+msgstr "Correu electrònic de la feina"
+
+#: ../kupfer/plugin/gmail/__init__.py:51
+msgid "Home email"
+msgstr "Adreça electrònica particular"
+
+#: ../kupfer/plugin/gmail/__init__.py:52
+msgid "Other email"
+msgstr "Una altra adreça electrònica"
+
+#: ../kupfer/plugin/gmail/__init__.py:54
+msgid "Work address"
+msgstr "Adreça de la feina"
+
+#: ../kupfer/plugin/gmail/__init__.py:55
+msgid "Home address"
+msgstr "Adreça de casa"
+
+#: ../kupfer/plugin/gmail/__init__.py:56
+msgid "Other address"
+msgstr "Altres adreces"
+
+#: ../kupfer/plugin/gmail/__init__.py:58
+msgid "Car phone"
+msgstr "Telèfon del cotxe"
+
+#: ../kupfer/plugin/gmail/__init__.py:59
+msgid "Fax"
+msgstr "Fax"
+
+#: ../kupfer/plugin/gmail/__init__.py:61
+msgid "Home phone"
+msgstr "Telèfon fix"
+
+#: ../kupfer/plugin/gmail/__init__.py:62
+msgid "Home fax"
+msgstr "Fax de casa"
+
+#: ../kupfer/plugin/gmail/__init__.py:63
+msgid "Internal phone"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:64
+msgid "Mobile"
+msgstr "Mòbil"
+
+#: ../kupfer/plugin/gmail/__init__.py:65
+msgid "Other"
+msgstr "Altres"
+
+#: ../kupfer/plugin/gmail/__init__.py:66
+msgid "VOIP"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:67
+msgid "Work phone"
+msgstr "Telèfon de la feina"
+
+#: ../kupfer/plugin/gmail/__init__.py:68
+msgid "Work fax"
+msgstr "Fax de la feina"
+
+#: ../kupfer/plugin/gmail/__init__.py:93
+msgid "Compose Email in Gmail"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:117
+msgid "Open web browser and compose new email in Gmail"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:123
+msgid "Edit Contact in Gmail"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:133
+msgid "Open web browser and edit contact in Gmail"
+msgstr ""
+
+#: ../kupfer/plugin/gmail/__init__.py:263
+msgid "Contacts from Google services (Gmail)"
+msgstr ""
+
+#: ../kupfer/plugin/gnome_terminal.py:1 ../kupfer/plugin/gnome_terminal.py:56
+#, fuzzy
+msgid "GNOME Terminal Profiles"
+msgstr "Terminal del GNOME"
+
+#: ../kupfer/plugin/gnome_terminal.py:3
+#, fuzzy
+msgid "Launch GNOME Terminal profiles"
+msgstr "Terminal del GNOME"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/google_picasa/__init__.py:2
+msgid "Google Picasa"
+msgstr ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:5
+msgid "Show albums and upload files to Picasa"
+msgstr ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:35
+msgid "Users to show: (,-separated)"
+msgstr ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:41
+msgid "Load user and album icons"
+msgstr ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:92
+msgid "Uploading Pictures"
+msgstr "S'estan pujant les fotografies"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:93
+msgid "Uploading pictures to Picasa Web Album"
+msgstr ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:102
+msgid "Creating album:"
+msgstr ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:105
+msgid "Album created by Kupfer"
+msgstr ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:112
+msgid "File:"
+msgstr "Fitxer:"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:252
+#, python-format
+msgid "One album"
+msgid_plural "%(num)d albums"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:279
+#, python-format
+msgid "one photo"
+msgid_plural "%(num)s photos"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:299
+msgid "Upload to Picasa Album..."
+msgstr ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:343
+msgid "Upload files to Picasa album"
+msgstr ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:349
+msgid "Upload to Picasa as New Album"
+msgstr ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:377
+msgid "Create album from selected local directory"
+msgstr ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:381
+#: ../kupfer/plugin/google_picasa/__init__.py:404
+msgid "Picasa Albums"
+msgstr ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:436
+msgid "User albums in Picasa"
+msgstr ""
+
+#: ../kupfer/plugin/google_picasa/__init__.py:444
+msgid "Albums"
+msgstr "Àlbums"
+
+#: ../kupfer/plugin/google_search.py:1 ../kupfer/plugin/google_search.py:30
+msgid "Google Search"
+msgstr ""
+
+#: ../kupfer/plugin/google_search.py:3
+msgid "Search Google with results shown directly"
+msgstr ""
+
+#: ../kupfer/plugin/google_search.py:58 ../kupfer/plugin/locate.py:46
+#: ../kupfer/plugin/tracker1.py:168 ../kupfer/plugin/tracker1.py:179
+#, python-format
+msgid "Results for \"%s\""
+msgstr ""
+
+#: ../kupfer/plugin/google_search.py:91
+#, python-format
+msgid "Show More Results For \"%s\""
+msgstr ""
+
+#: ../kupfer/plugin/google_search.py:92
+#, python-format
+msgid "%s total found"
+msgstr ""
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/gtg.py:2
+msgid "Getting Things GNOME"
+msgstr ""
+
+#: ../kupfer/plugin/gtg.py:5
+msgid "Browse and create new tasks in GTG"
+msgstr ""
+
+#: ../kupfer/plugin/gtg.py:116
+#, python-format
+msgid "due: %s"
+msgstr ""
+
+#: ../kupfer/plugin/gtg.py:118
+#, python-format
+msgid "start: %s"
+msgstr ""
+
+#: ../kupfer/plugin/gtg.py:120
+#, python-format
+msgid "tags: %s"
+msgstr ""
+
+#: ../kupfer/plugin/gtg.py:150
+msgid "Open task in Getting Things GNOME!"
+msgstr ""
+
+#: ../kupfer/plugin/gtg.py:157
+msgid "Delete"
+msgstr "Suprimeix"
+
+#: ../kupfer/plugin/gtg.py:170
+msgid "Permanently remove this task"
+msgstr ""
+
+#: ../kupfer/plugin/gtg.py:175
+msgid "Mark Done"
+msgstr ""
+
+#: ../kupfer/plugin/gtg.py:184
+msgid "Mark this task as done"
+msgstr ""
+
+#: ../kupfer/plugin/gtg.py:189
+msgid "Dismiss"
+msgstr ""
+
+#: ../kupfer/plugin/gtg.py:198
+msgid "Mark this task as not to be done anymore"
+msgstr ""
+
+#: ../kupfer/plugin/gtg.py:203
+msgid "Create Task"
+msgstr ""
+
+#: ../kupfer/plugin/gtg.py:220
+msgid "Create new task in Getting Things GNOME"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:3
+msgid "Gwibber"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:6
+msgid ""
+"Microblogging with Gwibber. Allows sending and receiving messages from "
+"social networks like Twitter, Identi.ca etc. Requires the package 'gwibber-"
+"service'."
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:45
+msgid "Maximum number of messages to show"
+msgstr ""
+
+#. TRANS: Account description, similar to "John on Identi.ca"
+#: ../kupfer/plugin/gwibber.py:98
+#, python-format
+msgid "%(user)s on %(service)s"
+msgstr ""
+
+#. TRANS: Gwibber Message description
+#. TRANS: Similar to "John  May 5 2011 11:40 on Identi.ca"
+#. TRANS: the %(user)s and similar tokens must be unchanged
+#: ../kupfer/plugin/gwibber.py:153
+#, python-format
+msgid "%(user)s %(when)s on %(where)s"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:187
+msgid "Send Message"
+msgstr "Envia el missatge"
+
+#: ../kupfer/plugin/gwibber.py:205
+msgid "Send message to all Gwibber accounts"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:210
+msgid "Send Message To..."
+msgstr "Envia el missatge a..."
+
+#: ../kupfer/plugin/gwibber.py:238
+msgid "Send message to a Gwibber account"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:243 ../kupfer/plugin/pidgin.py:120
+msgid "Send Message..."
+msgstr "Envia el missatge..."
+
+#: ../kupfer/plugin/gwibber.py:273
+msgid "Send message to selected Gwibber account"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:278
+msgid "Reply..."
+msgstr "Respon..."
+
+#: ../kupfer/plugin/gwibber.py:314
+msgid "Delete Message"
+msgstr "Suprimeix el missatge"
+
+#: ../kupfer/plugin/gwibber.py:337
+msgid "Send Private Message..."
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:370
+msgid "Send direct message to user"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:376
+msgid "Retweet"
+msgstr "Repiula"
+
+#: ../kupfer/plugin/gwibber.py:376
+msgid "Retweet To..."
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:407
+msgid "Retweet message to all Gwibber accounts"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:408
+msgid "Retweet message to a Gwibber account"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:413
+#, fuzzy
+msgid "Open in Browser"
+msgstr "Obre un terminal aquí"
+
+#: ../kupfer/plugin/gwibber.py:419
+msgid "Open message in default web browser"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:425 ../kupfer/plugin/gwibber.py:463
+msgid "Gwibber Accounts"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:456
+msgid "Accounts configured in Gwibber"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:495
+msgid "Gwibber Messages"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:518
+msgid "Recent messages received by Gwibber"
+msgstr ""
+
+#. TRANS:  %s is a service name
+#: ../kupfer/plugin/gwibber.py:527
+#, python-format
+msgid "Gwibber Messages for %s"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:543
+msgid "Gwibber Streams"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber.py:566
+msgid "Streams configured in Gwibber"
+msgstr ""
+
+#. TRANS: Gwibber messages in %s :: %s is a Stream name
+#: ../kupfer/plugin/gwibber.py:574
+#, python-format
+msgid "Gwibber Messages in %s"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber_simple.py:3
+msgid "Gwibber (Simple)"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber_simple.py:7
+msgid "Send updates via the microblogging client Gwibber"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber_simple.py:45
+msgid "Send Update"
+msgstr ""
+
+#: ../kupfer/plugin/gwibber_simple.py:65
+msgid "Unable to activate Gwibber service"
+msgstr ""
+
+#: ../kupfer/plugin/higherorder.py:1
+msgid "Higher-order Actions"
+msgstr ""
+
+#: ../kupfer/plugin/higherorder.py:7
+msgid "Tools to work with commands as objects"
+msgstr ""
+
+#: ../kupfer/plugin/higherorder.py:20
+msgid "Select in Kupfer"
+msgstr ""
+
+#: ../kupfer/plugin/higherorder.py:59
+#, python-format
+msgid "Result of %s (%s)"
+msgstr ""
+
+#: ../kupfer/plugin/higherorder.py:75
+msgid "Run (Take Result)"
+msgstr ""
+
+#: ../kupfer/plugin/higherorder.py:90
+msgid "Take the command result as a proxy object"
+msgstr ""
+
+#: ../kupfer/plugin/higherorder.py:95
+msgid "Run (Discard Result)"
+msgstr ""
+
+#: ../kupfer/plugin/image.py:1
+msgid "Image Tools"
+msgstr ""
+
+#: ../kupfer/plugin/image.py:10
+msgid "Image transformation tools"
+msgstr ""
+
+#: ../kupfer/plugin/image.py:25
+msgid "Scale..."
+msgstr ""
+
+#: ../kupfer/plugin/image.py:77
+msgid "Scale image to fit inside given pixel measure(s)"
+msgstr ""
+
+#: ../kupfer/plugin/image.py:112
+msgid "Rotate Clockwise"
+msgstr "Gira cap a la dreta"
+
+#: ../kupfer/plugin/image.py:119
+#, fuzzy
+msgid "Rotate Counter-Clockwise"
+msgstr "Gira cap a la dreta"
+
+#: ../kupfer/plugin/image.py:126
+msgid "Autorotate"
+msgstr ""
+
+#: ../kupfer/plugin/image.py:155
+msgid "Rotate JPEG (in-place) according to its EXIF metadata"
+msgstr ""
+
+#: ../kupfer/plugin/kupfer_plugins.py:1 ../kupfer/plugin/kupfer_plugins.py:86
+msgid "Kupfer Plugins"
+msgstr ""
+
+#: ../kupfer/plugin/kupfer_plugins.py:3
+msgid "Access Kupfer's plugin list in Kupfer"
+msgstr ""
+
+#: ../kupfer/plugin/kupfer_plugins.py:19
+#, fuzzy
+msgid "Show Information"
+msgstr "mostra la informació de la versió"
+
+#: ../kupfer/plugin/kupfer_plugins.py:35
+msgid "Show Source Code"
+msgstr ""
+
+#: ../kupfer/plugin/kupfer_plugins.py:80
+msgid "enabled"
+msgstr "habilitat"
+
+#: ../kupfer/plugin/locate.py:1 ../kupfer/plugin/locate.py:28
+msgid "Locate Files"
+msgstr ""
+
+#: ../kupfer/plugin/locate.py:5 ../kupfer/plugin/locate.py:38
+msgid "Search filesystem using locate"
+msgstr ""
+
+#: ../kupfer/plugin/locate.py:20
+msgid "Ignore case distinctions when searching files"
+msgstr ""
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/openoffice.py:3
+msgid "OpenOffice / LibreOffice"
+msgstr ""
+
+#: ../kupfer/plugin/openoffice.py:5 ../kupfer/plugin/openoffice.py:136
+msgid "Recently used documents in OpenOffice/LibreOffice"
+msgstr ""
+
+#: ../kupfer/plugin/openoffice.py:84
+msgid "OpenOffice/LibreOffice Recent Items"
+msgstr ""
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/operamail.py:2
+msgid "Opera Mail"
+msgstr ""
+
+#: ../kupfer/plugin/operamail.py:5
+msgid "Opera Mail contacts and actions"
+msgstr ""
+
+#: ../kupfer/plugin/operamail.py:32
+msgid "Compose a new message in Opera Mail"
+msgstr ""
+
+#: ../kupfer/plugin/operamail.py:64
+msgid "Opera Mail Contacts"
+msgstr ""
+
+#: ../kupfer/plugin/operamail.py:120
+msgid "Contacts from Opera Mail"
+msgstr ""
+
+#: ../kupfer/plugin/opera.py:4 ../kupfer/plugin/opera.py:22
+#, fuzzy
+msgid "Opera Bookmarks"
+msgstr "Adreces d'interès de l'Epiphany"
+
+#: ../kupfer/plugin/opera.py:6 ../kupfer/plugin/opera.py:54
+msgid "Index of Opera bookmarks"
+msgstr ""
+
+#: ../kupfer/plugin/pidgin.py:3
+msgid "Pidgin"
+msgstr ""
+
+#: ../kupfer/plugin/pidgin.py:9
+msgid "Access to Pidgin Contacts"
+msgstr ""
+
+#: ../kupfer/plugin/pidgin.py:111
+#, python-format
+msgid "%s (%d character)"
+msgid_plural "%s (%d characters)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../kupfer/plugin/pidgin.py:192
+msgid "Pidgin Contacts"
+msgstr ""
+
+#: ../kupfer/plugin/putty.py:5 ../kupfer/plugin/putty.py:80
+msgid "PuTTY Sessions"
+msgstr ""
+
+#: ../kupfer/plugin/putty.py:8
+msgid "Quick access to PuTTY Sessions"
+msgstr ""
+
+#: ../kupfer/plugin/putty.py:46 ../kupfer/plugin/tsclient.py:50
+msgid "Start Session"
+msgstr ""
+
+#: ../kupfer/plugin/qsicons/__init__.py:24
+msgid "Quicksilver Icons"
+msgstr ""
+
+#: ../kupfer/plugin/quickview.py:1
+msgid "Quick Image Viewer"
+msgstr ""
+
+#: ../kupfer/plugin/quickview.py:53
+msgid "View Image"
+msgstr ""
+
+#: ../kupfer/plugin/rst.py:1
+msgid "reStructuredText"
+msgstr ""
+
+#: ../kupfer/plugin/rst.py:3
+msgid "Render reStructuredText and show the result"
+msgstr ""
+
+#: ../kupfer/plugin/rst.py:18
+msgid "View as HTML Document"
+msgstr ""
+
+#: ../kupfer/plugin/screen.py:1
+msgid "GNU Screen"
+msgstr ""
+
+#: ../kupfer/plugin/screen.py:3 ../kupfer/plugin/screen.py:89
+msgid "Active GNU Screen sessions"
+msgstr ""
+
+#: ../kupfer/plugin/screen.py:57
+#, fuzzy
+msgid "Attached"
+msgstr "Adjunta"
+
+#: ../kupfer/plugin/screen.py:58
+msgid "Detached"
+msgstr ""
+
+#: ../kupfer/plugin/screen.py:61
+#, python-format
+msgid "%(status)s session (%(pid)s) created %(time)s"
+msgstr ""
+
+#: ../kupfer/plugin/screen.py:70
+msgid "Screen Sessions"
+msgstr ""
+
+#: ../kupfer/plugin/screen.py:99
+msgid "Attach"
+msgstr "Adjunta"
+
+#: ../kupfer/plugin/sendkeys.py:2 ../kupfer/plugin/sendkeys.py:52
+#, fuzzy
+msgid "Send Keys"
+msgstr "Envia el missatge"
+
+#: ../kupfer/plugin/sendkeys.py:8
+msgid "Send synthetic keyboard events using xautomation"
+msgstr ""
+
+#: ../kupfer/plugin/sendkeys.py:28
+msgid "Paste to Foreground Window"
+msgstr ""
+
+#: ../kupfer/plugin/sendkeys.py:46
+msgid "Copy to clipboard and send Ctrl+V to foreground window"
+msgstr ""
+
+#: ../kupfer/plugin/sendkeys.py:101
+msgid "Send keys to foreground window"
+msgstr ""
+
+#: ../kupfer/plugin/sendkeys.py:106
+#, fuzzy
+msgid "Type Text"
+msgstr "Text"
+
+#: ../kupfer/plugin/sendkeys.py:127
+msgid "Type the text to foreground window"
+msgstr ""
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/services.py:2 ../kupfer/plugin/services.py:96
+msgid "System Services"
+msgstr ""
+
+#: ../kupfer/plugin/services.py:4
+msgid "Start, stop or restart system services via init scripts"
+msgstr ""
+
+#: ../kupfer/plugin/services.py:18
+msgid "Sudo-like Command"
+msgstr ""
+
+#: ../kupfer/plugin/services.py:78
+#, fuzzy
+msgid "Start Service"
+msgstr "Serveis"
+
+#: ../kupfer/plugin/services.py:84
+msgid "Restart Service"
+msgstr ""
+
+#: ../kupfer/plugin/services.py:90
+#, fuzzy
+msgid "Stop Service"
+msgstr "Serveis"
+
+#: ../kupfer/plugin/services.py:126
+#, fuzzy, python-format
+msgid "%s Service"
+msgstr "Serveis"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/shorten_links.py:2
+msgid "Shorten Links"
+msgstr ""
+
+#: ../kupfer/plugin/shorten_links.py:4
+msgid "Create short aliases of long URLs"
+msgstr ""
+
+#: ../kupfer/plugin/shorten_links.py:48
+msgid "Error"
+msgstr "Error"
+
+#: ../kupfer/plugin/shorten_links.py:121
+msgid "Shorten With..."
+msgstr ""
+
+#: ../kupfer/plugin/shorten_links.py:151
+msgid "Services"
+msgstr "Serveis"
+
+#: ../kupfer/plugin/show_qrcode.py:5 ../kupfer/plugin/show_qrcode.py:25
+msgid "Show QRCode"
+msgstr ""
+
+#: ../kupfer/plugin/show_qrcode.py:9 ../kupfer/plugin/show_qrcode.py:60
+msgid "Display text as QRCode in a window"
+msgstr ""
+
+#: ../kupfer/plugin/skype.py:5
+msgid "Access to Skype contacts"
+msgstr ""
+
+#: ../kupfer/plugin/skype.py:31
+msgid "Skype Me"
+msgstr ""
+
+#: ../kupfer/plugin/skype.py:37
+msgid "Logged Out"
+msgstr ""
+
+#: ../kupfer/plugin/skype.py:179
+#, python-format
+msgid "[%(status)s] %(userid)s"
+msgstr ""
+
+#: ../kupfer/plugin/skype.py:218
+msgid "Call"
+msgstr "Truca"
+
+#: ../kupfer/plugin/skype.py:232
+msgid "Place a call to contact"
+msgstr ""
+
+#: ../kupfer/plugin/skype.py:267
+msgid "Skype Contacts"
+msgstr ""
+
+#: ../kupfer/plugin/skype.py:287
+msgid "Skype Statuses"
+msgstr ""
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/ssh_hosts.py:2 ../kupfer/plugin/ssh_hosts.py:70
+msgid "SSH Hosts"
+msgstr ""
+
+#: ../kupfer/plugin/ssh_hosts.py:3
+msgid "Adds the SSH hosts found in ~/.ssh/config."
+msgstr ""
+
+#: ../kupfer/plugin/ssh_hosts.py:32
+msgid "SSH host"
+msgstr ""
+
+#: ../kupfer/plugin/ssh_hosts.py:43
+msgid "Connect"
+msgstr "Connecta"
+
+#: ../kupfer/plugin/ssh_hosts.py:49
+msgid "Connect to SSH host"
+msgstr ""
+
+#: ../kupfer/plugin/ssh_hosts.py:102
+msgid "SSH hosts as specified in ~/.ssh/config"
+msgstr ""
+
+#: ../kupfer/plugin_support.py:144
+msgid "No D-Bus connection to desktop session"
+msgstr ""
+
+#: ../kupfer/plugin_support.py:171
+msgid "GNOME Keyring"
+msgstr ""
+
+#: ../kupfer/plugin_support.py:172
+msgid "KWallet"
+msgstr ""
+
+#: ../kupfer/plugin_support.py:173
+msgid "Unencrypted File"
+msgstr ""
+
+#: ../kupfer/plugin/templates.py:1 ../kupfer/plugin/templates.py:107
+msgid "Document Templates"
+msgstr ""
+
+#: ../kupfer/plugin/templates.py:4
+msgid "Create new documents from your templates"
+msgstr ""
+
+#: ../kupfer/plugin/templates.py:24
+#, python-format
+msgid "%s template"
+msgstr ""
+
+#: ../kupfer/plugin/templates.py:37 ../kupfer/plugin/textfiles.py:86
+msgid "Empty File"
+msgstr ""
+
+#: ../kupfer/plugin/templates.py:47
+msgid "New Folder"
+msgstr "Afegeix la carpeta"
+
+#: ../kupfer/plugin/templates.py:57
+#, fuzzy
+msgid "Create New Document..."
+msgstr "Crea arxiu..."
+
+#: ../kupfer/plugin/templates.py:96
+msgid "Create a new document from template"
+msgstr ""
+
+#: ../kupfer/plugin/templates.py:103
+#, fuzzy
+msgid "Create Document In..."
+msgstr "Crea arxiu..."
+
+#: ../kupfer/plugin/textfiles.py:13
+#, fuzzy
+msgid "Textfiles"
+msgstr "Text"
+
+#: ../kupfer/plugin/textfiles.py:51
+msgid "Append To..."
+msgstr ""
+
+#: ../kupfer/plugin/textfiles.py:75
+msgid "Append..."
+msgstr ""
+
+#: ../kupfer/plugin/textfiles.py:79
+#, fuzzy
+msgid "Write To..."
+msgstr "Envia a..."
+
+#: ../kupfer/plugin/textfiles.py:111
+msgid "Get Text Contents"
+msgstr ""
+
+#: ../kupfer/plugin/thunar.py:1 ../kupfer/plugin/thunar.py:185
+#: ../kupfer/plugin/thunar.py:225 ../kupfer/plugin/thunar.py:278
+#: ../kupfer/plugin/thunar.py:329
+msgid "Thunar"
+msgstr ""
+
+#: ../kupfer/plugin/thunar.py:11
+msgid "File manager Thunar actions"
+msgstr ""
+
+#: ../kupfer/plugin/thunar.py:67
+msgid "Select in File Manager"
+msgstr ""
+
+#: ../kupfer/plugin/thunar.py:95
+#, fuzzy
+msgid "Show Properties"
+msgstr "Mostra les preferències"
+
+#: ../kupfer/plugin/thunar.py:118
+msgid "Show information about file in file manager"
+msgstr ""
+
+#: ../kupfer/plugin/thunar.py:127
+msgid "Send To..."
+msgstr "Envia a..."
+
+#: ../kupfer/plugin/thunar.py:259
+msgid "Symlink In..."
+msgstr ""
+
+#: ../kupfer/plugin/thunar.py:300
+msgid "Create a symlink to file in a chosen location"
+msgstr ""
+
+#: ../kupfer/plugin/thunar.py:344
+msgid "Thunar Send To Objects"
+msgstr ""
+
+#: ../kupfer/plugin/thunderbird.py:4
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: ../kupfer/plugin/thunderbird.py:7
+msgid "Thunderbird/Icedove Contacts and Actions"
+msgstr ""
+
+#: ../kupfer/plugin/thunderbird.py:38
+msgid "Compose a new message in Thunderbird"
+msgstr ""
+
+#: ../kupfer/plugin/thunderbird.py:74
+#, fuzzy
+msgid "Thunderbird Address Book"
+msgstr "Thunderbird"
+
+#: ../kupfer/plugin/thunderbird.py:99
+msgid "Contacts from Thunderbird Address Book"
+msgstr ""
+
+#: ../kupfer/plugin/top.py:4
+msgid "Top"
+msgstr "Part superior"
+
+#: ../kupfer/plugin/top.py:6
+msgid "Show running tasks and allow sending signals to them"
+msgstr ""
+
+#: ../kupfer/plugin/top.py:23
+msgid "Sort Order"
+msgstr ""
+
+#: ../kupfer/plugin/top.py:25 ../kupfer/plugin/top.py:26
+#: ../kupfer/plugin/top.py:115
+#, fuzzy
+msgid "Commandline"
+msgstr "Ordre"
+
+#: ../kupfer/plugin/top.py:26
+msgid "CPU usage (descending)"
+msgstr ""
+
+#. sort processes (top don't allow to sort via cmd line)
+#: ../kupfer/plugin/top.py:27 ../kupfer/plugin/top.py:112
+msgid "Memory usage (descending)"
+msgstr ""
+
+#: ../kupfer/plugin/top.py:49
+msgid "Send Signal..."
+msgstr ""
+
+#: ../kupfer/plugin/top.py:79
+msgid "Signals"
+msgstr "Senyals"
+
+#: ../kupfer/plugin/top.py:91
+msgid "Running Tasks"
+msgstr ""
+
+#. default: by cpu
+#: ../kupfer/plugin/top.py:119
+#, python-format
+msgid "pid: %(pid)s  cpu: %(cpu)g%%  mem: %(mem)g%%  time: %(time)s"
+msgstr ""
+
+#: ../kupfer/plugin/top.py:139
+msgid "Running tasks for current user"
+msgstr ""
+
+#: ../kupfer/plugin/tracker1.py:10
+msgid "Tracker"
+msgstr "Tracker"
+
+#: ../kupfer/plugin/tracker1.py:18
+msgid "Tracker desktop search integration"
+msgstr ""
+
+#: ../kupfer/plugin/tracker1.py:49
+msgid "Search in Tracker"
+msgstr ""
+
+#: ../kupfer/plugin/tracker1.py:54
+msgid "Open Tracker Search Tool and search for this term"
+msgstr ""
+
+#: ../kupfer/plugin/tracker1.py:62
+msgid "Get Tracker Results..."
+msgstr ""
+
+#: ../kupfer/plugin/tracker1.py:71
+msgid "Show Tracker results for query"
+msgstr ""
+
+#. FIXME: Port tracker tag sources and actions
+#. to the new, much more powerful sparql + dbus API
+#. (using tracker-tag as in 0.6 is a plain hack and a dead end)
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/truecrypt.py:3
+msgid "TrueCrypt"
+msgstr ""
+
+#: ../kupfer/plugin/truecrypt.py:6 ../kupfer/plugin/truecrypt.py:140
+msgid "Volumes from TrueCrypt history"
+msgstr ""
+
+#: ../kupfer/plugin/truecrypt.py:44
+#, python-format
+msgid "TrueCrypt volume: %(file)s"
+msgstr ""
+
+#: ../kupfer/plugin/truecrypt.py:52
+msgid "Mount Volume"
+msgstr ""
+
+#: ../kupfer/plugin/truecrypt.py:63
+msgid "Mount in Truecrypt"
+msgstr ""
+
+#: ../kupfer/plugin/truecrypt.py:72
+msgid "Try to mount file as Truecrypt volume"
+msgstr ""
+
+#: ../kupfer/plugin/truecrypt.py:80
+msgid "Dismount All Volumes"
+msgstr ""
+
+#: ../kupfer/plugin/truecrypt.py:98
+msgid "TrueCrypt Volumes"
+msgstr ""
+
+#: ../kupfer/plugin/tsclient.py:4
+msgid "Terminal Server Client"
+msgstr ""
+
+#: ../kupfer/plugin/tsclient.py:7
+msgid "Session saved in Terminal Server Client"
+msgstr ""
+
+#: ../kupfer/plugin/tsclient.py:72
+msgid "TSClient sessions"
+msgstr ""
+
+#: ../kupfer/plugin/tsclient.py:94
+msgid "Saved sessions in Terminal Server Client"
+msgstr ""
+
+#: ../kupfer/plugin/vim/__init__.py:1
+msgid "Vim"
+msgstr ""
+
+#: ../kupfer/plugin/vim/__init__.py:4
+msgid "Recently used documents in Vim"
+msgstr ""
+
+#: ../kupfer/plugin/vim/plugin.py:56
+#, fuzzy
+msgid "Vim Recent Documents"
+msgstr "Documents"
+
+#: ../kupfer/plugin/vim/plugin.py:219
+msgid "Close (Save All)"
+msgstr ""
+
+#: ../kupfer/plugin/vim/plugin.py:237
+msgid "Send..."
+msgstr ""
+
+#: ../kupfer/plugin/vim/plugin.py:264
+msgid "Send ex command"
+msgstr ""
+
+#: ../kupfer/plugin/vim/plugin.py:272
+msgid "Insert in Vim..."
+msgstr ""
+
+#: ../kupfer/plugin/vim/plugin.py:309
+msgid "Active Vim Sessions"
+msgstr ""
+
+#: ../kupfer/plugin/vim/plugin.py:338
+#, python-format
+msgid "Vim Session %s"
+msgstr ""
+
+#: ../kupfer/plugin/vinagre.py:4
+msgid "Vinagre"
+msgstr ""
+
+#: ../kupfer/plugin/vinagre.py:7
+msgid "Vinagre bookmarks and actions"
+msgstr ""
+
+#: ../kupfer/plugin/vinagre.py:34
+msgid "Start Vinagre Session"
+msgstr ""
+
+#: ../kupfer/plugin/vinagre.py:72
+msgid "Vinagre Bookmarks"
+msgstr ""
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/virtualbox/__init__.py:3
+msgid "VirtualBox"
+msgstr ""
+
+#: ../kupfer/plugin/virtualbox/__init__.py:5
+msgid ""
+"Control VirtualBox Virtual Machines. Supports both Sun VirtualBox and Open "
+"Source Edition."
+msgstr ""
+
+#: ../kupfer/plugin/virtualbox/__init__.py:22
+msgid "Force use CLI interface"
+msgstr ""
+
+#: ../kupfer/plugin/virtualbox/__init__.py:86
+#: ../kupfer/plugin/virtualbox/__init__.py:97
+#, fuzzy
+msgid "Power On"
+msgstr "Apaga"
+
+#: ../kupfer/plugin/virtualbox/__init__.py:88
+#: ../kupfer/plugin/virtualbox/__init__.py:99
+msgid "Power On Headless"
+msgstr ""
+
+#: ../kupfer/plugin/virtualbox/__init__.py:91
+msgid "Send Power Off Signal"
+msgstr ""
+
+#: ../kupfer/plugin/virtualbox/__init__.py:94
+msgid "Reboot"
+msgstr "Reinicia"
+
+#. VM_STATE_PAUSED
+#: ../kupfer/plugin/virtualbox/__init__.py:102
+msgid "Resume"
+msgstr "Reprèn"
+
+#: ../kupfer/plugin/virtualbox/__init__.py:105
+msgid "Save State"
+msgstr "Desa l'estat"
+
+#: ../kupfer/plugin/virtualbox/__init__.py:107
+msgid "Power Off"
+msgstr "Apaga"
+
+#: ../kupfer/plugin/virtualbox/__init__.py:131
+msgid "VirtualBox Machines"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:4
+msgid "Zim"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:11
+msgid "Access to Pages stored in Zim - A Desktop Wiki and Outliner"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:30
+msgid "Page names start with :colon"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:36
+msgid "Default page name for quick notes"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:38
+#, python-format
+msgid "Note %x %X"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:39
+msgid ""
+"Strftime tags can be used: %H - hour, %M - minutes, etc\n"
+"Please check python documentation for details.\n"
+"NOTE: comma will be replaced by _"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:45
+msgid "Default namespace for quick notes"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:80
+#, python-format
+msgid "Zim Page from Notebook \"%s\""
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:89
+msgid "Create Zim Page"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:96
+msgid "Create page in default notebook"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:108
+msgid "Create Zim Page In..."
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:132
+msgid "Insert QuickNote into Zim"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:142
+msgid "Quick note selected text into Zim notebook"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:191
+msgid "Create Subpage..."
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:370
+msgid "Zim Notebooks"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:387
+msgid "Zim Pages"
+msgstr ""
+
+#: ../kupfer/plugin/zim.py:415
+msgid "Pages stored in Zim Notebooks"
+msgstr ""
+
+#~ msgid "Rhythmbox"
+#~ msgstr "Rhythmbox"
+
+#~ msgid "by %s"
+#~ msgstr "per %s"
+
+#~ msgid "Artists"
+#~ msgstr "Artistes"
+
+#~ msgid "Songs"
+#~ msgstr "Cançons"

--- a/po/de.po
+++ b/po/de.po
@@ -3,7 +3,7 @@
 # This file is distributed under the same license as the kupfer package. (GPLv3)
 # Ulrik Sverdrup <ulrik.sverdrup@gmail.com>, 2009.
 # Thibaud Roth <thibaud.roth@betriebsdirektor.de>, 2009.
-# Mario Blättermann <mario.blaettermann@gmail.com>, 2009-2011.
+# Mario Blättermann <mario.blaettermann@gmail.com>, 2009-2011, 2013.
 # Christian Kirbach <Christian.Kirbach@googlemail.com>, 2009.
 # Daniel Winzen <d@winzen4.de>, 2012.
 #
@@ -11,19 +11,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kupfer master\n"
 "Report-Msgid-Bugs-To: http://bugs.launchpad.net/kupfer\n"
-"POT-Creation-Date: 2012-05-22 15:22+0000\n"
-"PO-Revision-Date: 2012-06-16 01:29+0100\n"
-"Last-Translator: Christian Kirbach <Christian.Kirbach@googlemail.com>\n"
+"POT-Creation-Date: 2012-07-05 12:49+0000\n"
+"PO-Revision-Date: 2013-03-13 20:50+0100\n"
+"Last-Translator: Mario Blättermann <mario.blaettermann@gmail.com>\n"
 "Language-Team: German <gnome-de@gnome.org>\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Virtaal 0.7.1\n"
 
-#: ../auxdata/kupfer.desktop.in.h:1
-#: ../kupfer/version.py:15
+#: ../auxdata/kupfer.desktop.in.h:1 ../kupfer/version.py:15
 #: ../kupfer/plugin/core/contents.py:91
 msgid "Kupfer"
 msgstr "Kupfer"
@@ -72,8 +71,7 @@ msgstr "Bitte die gewünschte Tastenkombination drücken"
 msgid "Keybinding could not be bound"
 msgstr "Tastenkürzel konnte nicht gefunden werden"
 
-#: ../data/preferences.ui.h:1
-#: ../kupfer/plugin/core/contents.py:78
+#: ../data/preferences.ui.h:1 ../kupfer/plugin/core/contents.py:78
 msgid "Kupfer Preferences"
 msgstr "Kupfer-Einstellungen"
 
@@ -101,8 +99,7 @@ msgstr "Terminal-Emulator:"
 msgid "Desktop Environment"
 msgstr "Arbeitsumgebung"
 
-#: ../data/preferences.ui.h:8
-#: ../kupfer/plugin/gmail/__init__.py:60
+#: ../data/preferences.ui.h:8 ../kupfer/plugin/gmail/__init__.py:60
 msgid "General"
 msgstr "Allgemein"
 
@@ -110,8 +107,7 @@ msgstr "Allgemein"
 msgid "<b>Global Keyboard Shortcuts</b>"
 msgstr "<b>Globale Tastenkombinationen</b>"
 
-#: ../data/preferences.ui.h:10
-#: ../kupfer/ui/preferences.py:849
+#: ../data/preferences.ui.h:10 ../kupfer/ui/preferences.py:849
 msgid "Reset"
 msgstr "Zurücksetzen"
 
@@ -121,7 +117,9 @@ msgstr "<b>Tastenkombinationen für Browser</b>"
 
 #: ../data/preferences.ui.h:12
 msgid "Use single keystroke commands (Space, /, period, comma etc.)"
-msgstr "Einzelne Tastaturbefehle verwenden (Leerzeichen, Schrägstrich, Punkt, Komma usw.)"
+msgstr ""
+"Einzelne Tastaturbefehle verwenden (Leerzeichen, Schrägstrich, Punkt, Komma "
+"usw.)"
 
 #: ../data/preferences.ui.h:13
 msgid "Keyboard"
@@ -140,8 +138,10 @@ msgid ""
 "Marked sources have their objects included in top level searches.\n"
 "An unmarked source's contents are only available by locating its subcatalog."
 msgstr ""
-"Aktivierte Quellen beziehen ihre Objekte in Suchvorgänge der ersten Ebene ein.\n"
-"Die Inhalte einer deaktivierten Quelle sind nur über deren Unterkatalog verfügbar."
+"Aktivierte Quellen beziehen ihre Objekte in Suchvorgänge der ersten Ebene "
+"ein.\n"
+"Die Inhalte einer deaktivierten Quelle sind nur über deren Unterkatalog "
+"verfügbar."
 
 #: ../data/preferences.ui.h:18
 msgid "Indexed Folders"
@@ -151,8 +151,7 @@ msgstr "Indizierte Ordner"
 msgid "Folders whose files are always available in the catalog."
 msgstr "Ordner, deren Dateien immer im Katalog verfügbar sind."
 
-#: ../data/preferences.ui.h:20
-#: ../kupfer/obj/sources.py:157
+#: ../data/preferences.ui.h:20 ../kupfer/obj/sources.py:157
 msgid "Catalog"
 msgstr "Katalog"
 
@@ -322,8 +321,7 @@ msgid "Forget About \"%s\""
 msgstr "»%s« vergessen"
 
 #. TRANS: Names of global keyboard shortcuts
-#: ../kupfer/ui/browser.py:1960
-#: ../kupfer/ui/preferences.py:58
+#: ../kupfer/ui/browser.py:1960 ../kupfer/ui/preferences.py:58
 msgid "Show Main Interface"
 msgstr "Haupt-Bedienoberfläche anzeigen"
 
@@ -354,8 +352,7 @@ msgstr "Python-Modul »%s« wird benötigt"
 msgid "Plugin could not be read due to an error:"
 msgstr "Plugin konnte wegen eines Fehlers nicht gelesen werden:"
 
-#: ../kupfer/ui/preferences.py:465
-#: ../kupfer/plugin/kupfer_plugins.py:80
+#: ../kupfer/ui/preferences.py:465 ../kupfer/plugin/kupfer_plugins.py:80
 msgid "disabled"
 msgstr "deaktiviert"
 
@@ -401,8 +398,7 @@ msgstr "Einen Ordner auswählen"
 msgid "Reset all shortcuts to default values?"
 msgstr "Sollen alle Tastenkombinationen auf Standardwerte zurückgesetzt werden?"
 
-#: ../kupfer/ui/preferences.py:855
-#: ../kupfer/plugin/custom_terminal.py:12
+#: ../kupfer/ui/preferences.py:855 ../kupfer/plugin/custom_terminal.py:12
 msgid "Command"
 msgstr "Befehl"
 
@@ -444,14 +440,18 @@ msgstr ""
 "Dieses Programm ist freie Software, Sie können sie weitergeben und/oder\n"
 "verändern, solange Sie sich an die Regeln der GNU General Public License\n"
 "halten, so wie sie von der Free Software Foundation festgelegt wurden;\n"
-"entweder in Version 3 der Lizenz oder (nach Ihrem Ermessen) in jeder folgenden Lizenz.\n"
+"entweder in Version 3 der Lizenz oder (nach Ihrem Ermessen) in jeder "
+"folgenden Lizenz.\n"
 "\n"
-"Dieses Programm wurde mit dem Ziel veröffentlicht, dass Sie es nützlich finden,\n"
+"Dieses Programm wurde mit dem Ziel veröffentlicht, dass Sie es nützlich "
+"finden,\n"
 "jedoch OHNE JEDWEDE GARANTIE, sogar ohne eine implizite Garantie\n"
 "der VERKAUFBARKEIT oder der NUTZBARKEIT FÜR EINEN SPEZIELLEN ZWECK.\n"
-"Schauen Sie für weitere Informationen bitte in der GNU General Public License (GNU GPL) nach.\n"
+"Schauen Sie für weitere Informationen bitte in der GNU General Public License "
+"(GNU GPL) nach.\n"
 "\n"
-"Mit diesem Programm sollten Sie außerdem eine Kopie der GNU General Public License erhalten\n"
+"Mit diesem Programm sollten Sie außerdem eine Kopie der GNU General Public "
+"License erhalten\n"
 "haben. Wenn dem nicht so ist, so schreiben Sie bitte an die\n"
 "Free Software Foundation, Inc.,\n"
 "51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.\n"
@@ -461,8 +461,7 @@ msgstr ""
 msgid "Could not find running Kupfer"
 msgstr "Laufender Kupfer-Prozess konnte nicht gefunden werden"
 
-#: ../kupfer/obj/base.py:457
-#: ../kupfer/plugin/core/text.py:22
+#: ../kupfer/obj/base.py:457 ../kupfer/plugin/core/text.py:22
 msgid "Text"
 msgstr "Text"
 
@@ -485,8 +484,7 @@ msgid_plural "%s objects"
 msgstr[0] "%s Objekt"
 msgstr[1] "%s Objekte"
 
-#: ../kupfer/obj/contacts.py:129
-#: ../kupfer/plugin/pidgin.py:156
+#: ../kupfer/obj/contacts.py:129 ../kupfer/plugin/pidgin.py:156
 #, python-format
 msgid "[%(status)s] %(userid)s/%(service)s"
 msgstr "[%(status)s] %(userid)s/%(service)s"
@@ -520,8 +518,7 @@ msgid "Yahoo"
 msgstr "Yahoo"
 
 #. -*- coding: UTF-8 -*-
-#: ../kupfer/obj/contacts.py:187
-#: ../kupfer/plugin/skype.py:2
+#: ../kupfer/obj/contacts.py:187 ../kupfer/plugin/skype.py:2
 msgid "Skype"
 msgstr "Skype"
 
@@ -534,10 +531,8 @@ msgstr "%s unterstützt diesen Vorgang nicht"
 msgid "Can not be used with multiple objects"
 msgstr "Kann nicht mit mehreren Objekten verwendet werden"
 
-#: ../kupfer/obj/fileactions.py:30
-#: ../kupfer/plugin/notes.py:89
-#: ../kupfer/plugin/gnome_terminal.py:36
-#: ../kupfer/plugin/gtg.py:108
+#: ../kupfer/obj/fileactions.py:30 ../kupfer/plugin/notes.py:89
+#: ../kupfer/plugin/gnome_terminal.py:36 ../kupfer/plugin/gtg.py:135
 #: ../kupfer/plugin/zim.py:176
 msgid "Open"
 msgstr "Öffnen"
@@ -552,8 +547,7 @@ msgstr "Keine Standardanwendung für %(file)s (%(type)s)"
 msgid "Please use \"%s\""
 msgstr "Bitte benutzen Sie »%s«"
 
-#: ../kupfer/obj/fileactions.py:45
-#: ../kupfer/plugin/applications.py:109
+#: ../kupfer/obj/fileactions.py:45 ../kupfer/plugin/applications.py:109
 msgid "Set Default Application..."
 msgstr "Standardanwendung auswählen …"
 
@@ -593,10 +587,8 @@ msgstr "Dieses Programm in einem Terminal ausführen"
 msgid "Run this program"
 msgstr "Dieses Programm ausführen"
 
-#: ../kupfer/obj/objects.py:252
-#: ../kupfer/plugin/windows.py:105
-#: ../kupfer/plugin/windows.py:264
-#: ../kupfer/plugin/vim/plugin.py:172
+#: ../kupfer/obj/objects.py:252 ../kupfer/plugin/windows.py:105
+#: ../kupfer/plugin/windows.py:264 ../kupfer/plugin/vim/plugin.py:172
 msgid "Go To"
 msgstr "Gehe zu"
 
@@ -628,8 +620,7 @@ msgstr "Neu starten"
 msgid "Launch another instance of this application"
 msgstr "Eine andere Instanz dieser Anwendung starten"
 
-#: ../kupfer/obj/objects.py:341
-#: ../kupfer/plugin/windows.py:37
+#: ../kupfer/obj/objects.py:341 ../kupfer/plugin/windows.py:37
 msgid "Close"
 msgstr "Schließen"
 
@@ -638,21 +629,21 @@ msgid "Attempt to close all application windows"
 msgstr "Versuchen, alle Anwendungsfenster zu schließen"
 
 #. TRANS: 'Run' as in Perform a (saved) command
-#: ../kupfer/obj/objects.py:396
+#: ../kupfer/obj/objects.py:398
 msgid "Run"
 msgstr "Ausführen"
 
-#: ../kupfer/obj/objects.py:406
+#: ../kupfer/obj/objects.py:408
 msgid "Perform command"
 msgstr "Befehl ausführen"
 
-#: ../kupfer/obj/objects.py:419
+#: ../kupfer/obj/objects.py:421
 msgid "(Empty Text)"
 msgstr "(Leerer Text)"
 
 #. TRANS: This is description for a TextLeaf, a free-text search
 #. TRANS: The plural parameter is the number of lines %(num)d
-#: ../kupfer/obj/objects.py:449
+#: ../kupfer/obj/objects.py:451
 #, python-format
 msgid "\"%(text)s\""
 msgid_plural "(%(num)d lines) \"%(text)s\""
@@ -660,8 +651,7 @@ msgstr[0] "»%(text)s«"
 msgstr[1] "(%(num)d Zeilen) »%(text)s«"
 
 #. TRANS: Multiple artist description "Artist1 et. al. "
-#: ../kupfer/obj/sources.py:24
-#: ../kupfer/plugin/rhythmbox.py:247
+#: ../kupfer/obj/sources.py:24 ../kupfer/plugin/rhythmbox.py:247
 #, python-format
 msgid "%s et. al."
 msgstr "%s et. al."
@@ -706,13 +696,11 @@ msgstr "Plugin %s ist nicht konfiguriert"
 msgid "Invalid user credentials for %s"
 msgstr "Ungültige Anmeldedaten für %s"
 
-#: ../kupfer/plugin/applications.py:2
-#: ../kupfer/plugin/applications.py:38
+#: ../kupfer/plugin/applications.py:2 ../kupfer/plugin/applications.py:38
 msgid "Applications"
 msgstr "Anwendungen"
 
-#: ../kupfer/plugin/applications.py:8
-#: ../kupfer/plugin/applications.py:74
+#: ../kupfer/plugin/applications.py:8 ../kupfer/plugin/applications.py:74
 msgid "All applications and preferences"
 msgstr "Alle Anwendungen und Einstellungen"
 
@@ -756,8 +744,7 @@ msgstr "Komprimiertes Archiv entpacken"
 msgid "Create Archive"
 msgstr "Archiv erstellen"
 
-#: ../kupfer/plugin/archivemanager.py:86
-#: ../kupfer/plugin/archivemanager.py:129
+#: ../kupfer/plugin/archivemanager.py:86 ../kupfer/plugin/archivemanager.py:129
 msgid "Create a compressed archive from folder"
 msgstr "Ein komprimiertes Archiv aus einem Ordner erstellen"
 
@@ -770,8 +757,7 @@ msgstr "Archiv erstellen in …"
 msgid "Archive"
 msgstr "Archiv"
 
-#: ../kupfer/plugin/calculator.py:2
-#: ../kupfer/plugin/calculator.py:69
+#: ../kupfer/plugin/calculator.py:2 ../kupfer/plugin/calculator.py:69
 msgid "Calculator"
 msgstr "Rechner"
 
@@ -783,8 +769,7 @@ msgstr "Ausdrücke beginnend mit »=« berechnen"
 msgid "Calculate"
 msgstr "Berechnen"
 
-#: ../kupfer/plugin/clipboard.py:1
-#: ../kupfer/plugin/clipboard.py:112
+#: ../kupfer/plugin/clipboard.py:1 ../kupfer/plugin/clipboard.py:112
 msgid "Clipboards"
 msgstr "Zwischenablagen"
 
@@ -835,15 +820,18 @@ msgstr "Leeren"
 msgid "Remove all recent clipboards"
 msgstr "Alle aktuellen Zwischenablagen entfernen"
 
-#: ../kupfer/plugin/commands.py:1
-#: ../kupfer/plugin/commands.py:187
+#: ../kupfer/plugin/commands.py:1 ../kupfer/plugin/commands.py:187
 msgid "Shell Commands"
 msgstr "Shell-Befehle"
 
 #: ../kupfer/plugin/commands.py:9
 #, python-format
-msgid "Run command-line programs. Actions marked with the symbol %s run in a subshell."
-msgstr "Befehlszeilenprogramme ausführen. Mit dem Symbol %s markierte Aktionen werden in einer Subshell ausgeführt."
+msgid ""
+"Run command-line programs. Actions marked with the symbol %s run in a "
+"subshell."
+msgstr ""
+"Befehlszeilenprogramme ausführen. Mit dem Symbol %s markierte Aktionen werden "
+"in einer Subshell ausgeführt."
 
 #: ../kupfer/plugin/commands.py:41
 msgid "Run (Get Output)"
@@ -869,8 +857,7 @@ msgstr "Programm mit Objekt als zusätzlichem Parameter ausführen"
 msgid "Write to Command..."
 msgstr "In Befehl schreiben …"
 
-#: ../kupfer/plugin/commands.py:149
-#: ../kupfer/plugin/commands.py:161
+#: ../kupfer/plugin/commands.py:149 ../kupfer/plugin/commands.py:161
 msgid "Run program and supply text on the standard input"
 msgstr "Programm ausführen und Text über die Standardausgabe zurückgeben"
 
@@ -909,8 +896,11 @@ msgstr "X-Terminal"
 msgid "Urxvt"
 msgstr "Urxvt"
 
-#: ../kupfer/plugin/core/commands.py:13
-#: ../kupfer/plugin/core/commands.py:32
+#: ../kupfer/plugin/core/alternatives.py:58
+msgid "Konsole"
+msgstr "Konsole"
+
+#: ../kupfer/plugin/core/commands.py:13 ../kupfer/plugin/core/commands.py:32
 msgid "Save As..."
 msgstr "Speichern unter …"
 
@@ -974,8 +964,7 @@ msgstr "Letzter Befehl"
 msgid "Internal Kupfer Objects"
 msgstr "Interne Kupfer-Objekte"
 
-#: ../kupfer/plugin/core/internal.py:46
-#: ../kupfer/plugin/core/internal.py:48
+#: ../kupfer/plugin/core/internal.py:46 ../kupfer/plugin/core/internal.py:48
 msgid "Last Result"
 msgstr "Letzte Ausgabe"
 
@@ -983,13 +972,11 @@ msgstr "Letzte Ausgabe"
 msgid "Command Results"
 msgstr "Befehlsausgaben"
 
-#: ../kupfer/plugin/dictionary.py:1
-#: ../kupfer/plugin/dictionary.py:21
+#: ../kupfer/plugin/dictionary.py:1 ../kupfer/plugin/dictionary.py:21
 msgid "Dictionary"
 msgstr "Wörterbuch"
 
-#: ../kupfer/plugin/dictionary.py:3
-#: ../kupfer/plugin/dictionary.py:47
+#: ../kupfer/plugin/dictionary.py:3 ../kupfer/plugin/dictionary.py:47
 msgid "Look up word in dictionary"
 msgstr "Ein Wort im Wörterbuch nachschlagen"
 
@@ -1035,18 +1022,15 @@ msgstr "Orte"
 msgid "Bookmarked folders"
 msgstr "Als Lesezeichen gespeicherte Ordner"
 
-#: ../kupfer/plugin/epiphany.py:1
-#: ../kupfer/plugin/epiphany.py:18
+#: ../kupfer/plugin/epiphany.py:1 ../kupfer/plugin/epiphany.py:18
 msgid "Epiphany Bookmarks"
 msgstr "Lesezeichen in Epiphany"
 
-#: ../kupfer/plugin/epiphany.py:3
-#: ../kupfer/plugin/epiphany.py:35
+#: ../kupfer/plugin/epiphany.py:3 ../kupfer/plugin/epiphany.py:35
 msgid "Index of Epiphany bookmarks"
 msgstr "Index der Lesezeichen in Epiphany"
 
-#: ../kupfer/plugin/favorites.py:1
-#: ../kupfer/plugin/favorites.py:21
+#: ../kupfer/plugin/favorites.py:1 ../kupfer/plugin/favorites.py:21
 msgid "Favorites"
 msgstr "Favoriten"
 
@@ -1082,45 +1066,42 @@ msgstr "Datei-Aktionen"
 msgid "More file actions"
 msgstr "Mehr Datei-Aktionen"
 
-#: ../kupfer/plugin/fileactions.py:40
-#: ../kupfer/plugin/windows.py:122
+#: ../kupfer/plugin/fileactions.py:40 ../kupfer/plugin/windows.py:122
 #: ../kupfer/plugin/thunar.py:211
 msgid "Move To..."
 msgstr "Verschieben nach …"
 
-#: ../kupfer/plugin/fileactions.py:67
-#: ../kupfer/plugin/thunar.py:253
+#: ../kupfer/plugin/fileactions.py:67 ../kupfer/plugin/thunar.py:253
 msgid "Move file to new location"
 msgstr "Archiv an einen neuen Ort verschieben"
 
-#: ../kupfer/plugin/fileactions.py:80
-#: ../kupfer/plugin/fileactions.py:103
+#: ../kupfer/plugin/fileactions.py:80 ../kupfer/plugin/fileactions.py:103
 msgid "Rename To..."
 msgstr "Umbenennen in …"
 
-#: ../kupfer/plugin/fileactions.py:145
-#: ../kupfer/plugin/thunar.py:166
+#: ../kupfer/plugin/fileactions.py:145 ../kupfer/plugin/thunar.py:166
 msgid "Copy To..."
 msgstr "Kopieren nach …"
 
-#: ../kupfer/plugin/fileactions.py:186
-#: ../kupfer/plugin/thunar.py:207
+#: ../kupfer/plugin/fileactions.py:186 ../kupfer/plugin/thunar.py:207
 msgid "Copy file to a chosen location"
 msgstr "Datei an einen ausgesuchten Ort kopieren"
 
-#: ../kupfer/plugin/firefox.py:4
-#: ../kupfer/plugin/firefox.py:36
+#: ../kupfer/plugin/firefox.py:4 ../kupfer/plugin/firefox.py:61
 msgid "Firefox Bookmarks"
 msgstr "Lesezeichen in Firefox"
 
-#: ../kupfer/plugin/firefox.py:6
-#: ../kupfer/plugin/firefox.py:120
+#: ../kupfer/plugin/firefox.py:6 ../kupfer/plugin/firefox.py:147
 msgid "Index of Firefox bookmarks"
 msgstr "Index der Lesezeichen in Firefox"
 
 #: ../kupfer/plugin/firefox.py:26
 msgid "Include visited sites"
 msgstr "Besuchte Seiten einbeziehen"
+
+#: ../kupfer/plugin/firefox.py:44
+msgid "Firefox tag"
+msgstr "Firefox-Tag"
 
 #. TRANS: Multihead refers to support for multiple computer displays
 #. TRANS: In this case, it only concerns the special configuration
@@ -1129,26 +1110,7 @@ msgstr "Besuchte Seiten einbeziehen"
 msgid "Multihead Support"
 msgstr "Multihead-Unterstützung"
 
-#: ../kupfer/plugin/nautilusselection.py:1
-#: ../kupfer/plugin/nautilusselection.py:46
-msgid "Selected File"
-msgstr "Ausgewählte Datei"
-
-#: ../kupfer/plugin/nautilusselection.py:3
-msgid "Provides current nautilus selection, using Kupfer's Nautilus Extension"
-msgstr "Gibt aktuelle Nautilus-Auswahl aus, indem es Kupfers Nautilus-Erweiterung verwendet"
-
-#: ../kupfer/plugin/nautilusselection.py:25
-#, python-format
-msgid "Selected File \"%s\""
-msgstr "Ausgewählte Datei »%s«"
-
-#: ../kupfer/plugin/nautilusselection.py:34
-msgid "Selected Files"
-msgstr "Ausgewählte Dateien"
-
-#: ../kupfer/plugin/notes.py:6
-#: ../kupfer/plugin/notes.py:178
+#: ../kupfer/plugin/notes.py:6 ../kupfer/plugin/notes.py:178
 #: ../kupfer/plugin/notes.py:230
 msgid "Notes"
 msgstr "Notizen"
@@ -1205,15 +1167,15 @@ msgstr "gestern, %s"
 msgid "Last updated %s"
 msgstr "Zuletzt aktualisiert %s"
 
-#: ../kupfer/plugin/rhythmbox.py:1
-#: ../kupfer/plugin/rhythmbox.py:399
+#: ../kupfer/plugin/rhythmbox.py:1 ../kupfer/plugin/rhythmbox.py:399
 msgid "Rhythmbox"
 msgstr "Rhythmbox"
 
-#: ../kupfer/plugin/rhythmbox.py:3
-#: ../kupfer/plugin/rhythmbox.py:433
+#: ../kupfer/plugin/rhythmbox.py:3 ../kupfer/plugin/rhythmbox.py:433
 msgid "Play and enqueue tracks and browse the music library"
-msgstr "Titel abspielen und zur Wiedergabeliste hinzufügen und die Musikbibliothek durchsuchen"
+msgstr ""
+"Titel abspielen und zur Wiedergabeliste hinzufügen und die Musikbibliothek "
+"durchsuchen"
 
 #: ../kupfer/plugin/rhythmbox.py:22
 msgid "Include artists in top level"
@@ -1223,15 +1185,12 @@ msgstr "Künstler auf der ersten Ebene anzeigen"
 msgid "Include albums in top level"
 msgstr "Alben auf der ersten Ebene anzeigen"
 
-#: ../kupfer/plugin/rhythmbox.py:34
-#: ../kupfer/plugin/audacious.py:20
+#: ../kupfer/plugin/rhythmbox.py:34 ../kupfer/plugin/audacious.py:20
 msgid "Include songs in top level"
 msgstr "Lieder auf der ersten Ebene anzeigen"
 
-#: ../kupfer/plugin/rhythmbox.py:63
-#: ../kupfer/plugin/rhythmbox.py:131
-#: ../kupfer/plugin/audacious.py:82
-#: ../kupfer/plugin/audacious.py:92
+#: ../kupfer/plugin/rhythmbox.py:63 ../kupfer/plugin/rhythmbox.py:131
+#: ../kupfer/plugin/audacious.py:82 ../kupfer/plugin/audacious.py:92
 msgid "Play"
 msgstr "Abspielen"
 
@@ -1239,8 +1198,7 @@ msgstr "Abspielen"
 msgid "Resume playback in Rhythmbox"
 msgstr "Wiedergabe in Rhythmbox fortsetzen"
 
-#: ../kupfer/plugin/rhythmbox.py:73
-#: ../kupfer/plugin/audacious.py:102
+#: ../kupfer/plugin/rhythmbox.py:73 ../kupfer/plugin/audacious.py:102
 #: ../kupfer/plugin/virtualbox/__init__.py:93
 msgid "Pause"
 msgstr "Pause"
@@ -1249,8 +1207,7 @@ msgstr "Pause"
 msgid "Pause playback in Rhythmbox"
 msgstr "Wiedergabe in Rhythmbox pausieren"
 
-#: ../kupfer/plugin/rhythmbox.py:83
-#: ../kupfer/plugin/audacious.py:112
+#: ../kupfer/plugin/rhythmbox.py:83 ../kupfer/plugin/audacious.py:112
 msgid "Next"
 msgstr "Nächstes"
 
@@ -1258,8 +1215,7 @@ msgstr "Nächstes"
 msgid "Jump to next track in Rhythmbox"
 msgstr "In Rhythmbox zum nächsten Titel springen"
 
-#: ../kupfer/plugin/rhythmbox.py:93
-#: ../kupfer/plugin/audacious.py:122
+#: ../kupfer/plugin/rhythmbox.py:93 ../kupfer/plugin/audacious.py:122
 msgid "Previous"
 msgstr "Vorheriges"
 
@@ -1275,8 +1231,7 @@ msgstr "Wiedergegebenen Titel anzeigen"
 msgid "Tell which song is currently playing"
 msgstr "Aktuell gespieltes Lied anzeigen"
 
-#: ../kupfer/plugin/rhythmbox.py:115
-#: ../kupfer/plugin/audacious.py:132
+#: ../kupfer/plugin/rhythmbox.py:115 ../kupfer/plugin/audacious.py:132
 msgid "Clear Queue"
 msgstr "Warteschlange leeren"
 
@@ -1284,8 +1239,7 @@ msgstr "Warteschlange leeren"
 msgid "Play tracks in Rhythmbox"
 msgstr "Titel in Rhythmbox abspielen"
 
-#: ../kupfer/plugin/rhythmbox.py:161
-#: ../kupfer/plugin/audacious.py:58
+#: ../kupfer/plugin/rhythmbox.py:161 ../kupfer/plugin/audacious.py:58
 msgid "Enqueue"
 msgstr "Zur Wiedergabeliste hinzufügen"
 
@@ -1336,8 +1290,7 @@ msgstr "Lieder"
 msgid "Songs in Rhythmbox library"
 msgstr "Lieder in der Rhythmbox-Bibliothek"
 
-#: ../kupfer/plugin/session_gnome.py:1
-#: ../kupfer/plugin/session_gnome.py:20
+#: ../kupfer/plugin/session_gnome.py:1 ../kupfer/plugin/session_gnome.py:20
 msgid "GNOME Session Management"
 msgstr "GNOME-Sitzungsverwaltung"
 
@@ -1359,7 +1312,8 @@ msgstr "Herunterfahren …"
 
 #: ../kupfer/plugin/session_support.py:44
 msgid "Shut down, restart or suspend computer"
-msgstr "Den Rechner herunterfahren, neu starten oder in den Ruhezustand versetzen"
+msgstr ""
+"Den Rechner herunterfahren, neu starten oder in den Ruhezustand versetzen"
 
 #: ../kupfer/plugin/session_support.py:51
 msgid "Lock Screen"
@@ -1370,8 +1324,7 @@ msgid "Enable screensaver and lock"
 msgstr "Bildschirmschoner aktivieren und sperren"
 
 #. -*- coding: utf-8 -*
-#: ../kupfer/plugin/session_xfce.py:3
-#: ../kupfer/plugin/session_xfce.py:20
+#: ../kupfer/plugin/session_xfce.py:3 ../kupfer/plugin/session_xfce.py:20
 msgid "XFCE Session Management"
 msgstr "XFCE-Sitzungsverwaltung"
 
@@ -1379,14 +1332,12 @@ msgstr "XFCE-Sitzungsverwaltung"
 msgid "Special items and actions for XFCE environment"
 msgstr "Spezielle Objekte und Aktionen für die XFCE-Arbeitsumgebung"
 
-#: ../kupfer/plugin/show_text.py:1
-#: ../kupfer/plugin/show_text.py:18
+#: ../kupfer/plugin/show_text.py:1 ../kupfer/plugin/show_text.py:18
 #: ../kupfer/plugin/show_text.py:25
 msgid "Show Text"
 msgstr "Text anzeigen"
 
-#: ../kupfer/plugin/show_text.py:7
-#: ../kupfer/plugin/show_text.py:31
+#: ../kupfer/plugin/show_text.py:7 ../kupfer/plugin/show_text.py:31
 #: ../kupfer/plugin/show_text.py:58
 msgid "Display text in a window"
 msgstr "Text in einem Fenster anzeigen"
@@ -1399,22 +1350,21 @@ msgstr "Groß"
 msgid "Show Notification"
 msgstr "Benachrichtigung anzeigen"
 
-#: ../kupfer/plugin/trash.py:1
-#: ../kupfer/plugin/trash.py:173
+#: ../kupfer/plugin/trash.py:1 ../kupfer/plugin/trash.py:173
 msgid "Trash"
-msgstr "Müll"
+msgstr "Papierkorb"
 
 #: ../kupfer/plugin/trash.py:4
 msgid "Access trash contents"
-msgstr "Zugriff auf den Inhalt des Mülls"
+msgstr "Zugriff auf den Inhalt des Papierkorbs"
 
 #: ../kupfer/plugin/trash.py:23
 msgid "Move to Trash"
-msgstr "In den Müll verschieben"
+msgstr "In den Papierkorb verschieben"
 
 #: ../kupfer/plugin/trash.py:39
 msgid "Move this file to trash"
-msgstr "Diese Datei in den Müll verschieben"
+msgstr "Diese Datei in den Papierkorb verschieben"
 
 #: ../kupfer/plugin/trash.py:48
 msgid "Restore"
@@ -1426,24 +1376,27 @@ msgstr "Datei wieder an den ursprünglichen Ort verschieben"
 
 #: ../kupfer/plugin/trash.py:161
 msgid "Trash is empty"
-msgstr "Der Mülleimer ist leer"
+msgstr "Der Papierkorb ist leer"
 
 #. proper translation of plural
 #: ../kupfer/plugin/trash.py:163
 #, python-format
 msgid "Trash contains one file"
 msgid_plural "Trash contains %(num)s files"
-msgstr[0] "Es ist ein Objekt im Mülleimer"
-msgstr[1] "Es sind %(num)s Objekte im Mülleimer"
+msgstr[0] "Es ist ein Objekt im Papierkorb"
+msgstr[1] "Es sind %(num)s Objekte im Papierkorb"
 
-#: ../kupfer/plugin/triggers.py:1
-#: ../kupfer/plugin/triggers.py:50
+#: ../kupfer/plugin/triggers.py:1 ../kupfer/plugin/triggers.py:50
 msgid "Triggers"
 msgstr "Auslöser"
 
 #: ../kupfer/plugin/triggers.py:6
-msgid "Assign global keybindings (triggers) to objects created with 'Compose Command'."
-msgstr "Globale Tastenkürzel (Auslöser) zu mit dem »Compose-Befehl« (Strg+Eingabe) erstellten Objekten hinzufügen"
+msgid ""
+"Assign global keybindings (triggers) to objects created with 'Compose "
+"Command'."
+msgstr ""
+"Globale Tastenkürzel (Auslöser) zu mit dem »Compose-Befehl« (Strg+Eingabe) "
+"erstellten Objekten hinzufügen"
 
 #: ../kupfer/plugin/triggers.py:161
 msgid "Add Trigger..."
@@ -1453,8 +1406,7 @@ msgstr "Auslöser hinzufügen …"
 msgid "Remove Trigger"
 msgstr "Auslöser entfernen …"
 
-#: ../kupfer/plugin/urlactions.py:1
-#: ../kupfer/plugin/urlactions.py:8
+#: ../kupfer/plugin/urlactions.py:1 ../kupfer/plugin/urlactions.py:8
 msgid "URL Actions"
 msgstr "URL-Aktionen"
 
@@ -1470,13 +1422,11 @@ msgstr "Herunterladen nach …"
 msgid "Download URL to a chosen location"
 msgstr "URL in einen ausgewählten Ort herunterladen"
 
-#: ../kupfer/plugin/volumes.py:1
-#: ../kupfer/plugin/volumes.py:91
+#: ../kupfer/plugin/volumes.py:1 ../kupfer/plugin/volumes.py:91
 msgid "Volumes and Disks"
 msgstr "Partitionen und Festplatten"
 
-#: ../kupfer/plugin/volumes.py:3
-#: ../kupfer/plugin/volumes.py:101
+#: ../kupfer/plugin/volumes.py:3 ../kupfer/plugin/volumes.py:101
 msgid "Mounted volumes and disks"
 msgstr "Eingebundene Partitionen und Festplatten"
 
@@ -1505,8 +1455,7 @@ msgstr "Aushängen und das Medium auswerfen"
 msgid "Search the Web"
 msgstr "Das Internet durchsuchen"
 
-#: ../kupfer/plugin/websearch.py:8
-#: ../kupfer/plugin/websearch.py:63
+#: ../kupfer/plugin/websearch.py:8 ../kupfer/plugin/websearch.py:63
 #: ../kupfer/plugin/websearch.py:90
 msgid "Search the web with OpenSearch search engines"
 msgstr "Das Internet mit den OpenSearch-Suchmaschinen durchsuchen"
@@ -1527,8 +1476,7 @@ msgstr "Suchmaschinen"
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: ../kupfer/plugin/wikipedia.py:8
-#: ../kupfer/plugin/wikipedia.py:31
+#: ../kupfer/plugin/wikipedia.py:8 ../kupfer/plugin/wikipedia.py:31
 msgid "Search in Wikipedia"
 msgstr "In Wikipedia suchen"
 
@@ -1546,13 +1494,11 @@ msgstr "de"
 msgid "Search for this term in %s.wikipedia.org"
 msgstr "Nach diesem Suchbegriff auf %s.wikipedia.org suchen"
 
-#: ../kupfer/plugin/windows.py:1
-#: ../kupfer/plugin/windows.py:210
+#: ../kupfer/plugin/windows.py:1 ../kupfer/plugin/windows.py:210
 msgid "Window List"
 msgstr "Fensterliste"
 
-#: ../kupfer/plugin/windows.py:3
-#: ../kupfer/plugin/windows.py:233
+#: ../kupfer/plugin/windows.py:3 ../kupfer/plugin/windows.py:233
 msgid "All windows on all workspaces"
 msgstr "Alle Fenster und Arbeitsflächen"
 
@@ -1633,8 +1579,7 @@ msgstr "Arbeitsflächen"
 msgid "Abiword"
 msgstr "Abiword"
 
-#: ../kupfer/plugin/abiword.py:3
-#: ../kupfer/plugin/abiword.py:88
+#: ../kupfer/plugin/abiword.py:3 ../kupfer/plugin/abiword.py:88
 msgid "Recently used documents in Abiword"
 msgstr "Kürzlich in Abiword verwendete Dokumente"
 
@@ -1654,8 +1599,7 @@ msgstr "Schnittstelle für die APT-Paketverwaltung"
 msgid "Installation method"
 msgstr "Installationsmethode"
 
-#: ../kupfer/plugin/apt_tools.py:61
-#: ../kupfer/plugin/apt_tools.py:66
+#: ../kupfer/plugin/apt_tools.py:61 ../kupfer/plugin/apt_tools.py:66
 msgid "Show Package Information"
 msgstr "Paketinformationen anzeigen"
 
@@ -1696,8 +1640,12 @@ msgid "Ascii & Unicode Icon Set"
 msgstr "ASCII- und Unicode-Symbolsatz"
 
 #: ../kupfer/plugin/asciiunicodeiconset.py:5
-msgid "Provides the Ascii and Unicode icon sets that use letters and symbols to produce icons for the objects found in Kupfer."
-msgstr "Stellt ASCII- und Unicode-Symbolsätze bereit, aus denen Buchstaben und Symbole für die in Kupfer gefundenen Objekte erstellt werden."
+msgid ""
+"Provides the Ascii and Unicode icon sets that use letters and symbols to "
+"produce icons for the objects found in Kupfer."
+msgstr ""
+"Stellt ASCII- und Unicode-Symbolsätze bereit, aus denen Buchstaben und "
+"Symbole für die in Kupfer gefundenen Objekte erstellt werden."
 
 #: ../kupfer/plugin/asciiunicodeiconset.py:21
 msgid "Ascii"
@@ -1707,8 +1655,7 @@ msgstr "ASCII"
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../kupfer/plugin/audacious.py:1
-#: ../kupfer/plugin/audacious.py:187
+#: ../kupfer/plugin/audacious.py:1 ../kupfer/plugin/audacious.py:187
 msgid "Audacious"
 msgstr "Audacious"
 
@@ -1772,13 +1719,11 @@ msgstr "Wiederholung in Audacious ein-/ausschalten"
 msgid "Playlist"
 msgstr "Wiedergabeliste"
 
-#: ../kupfer/plugin/chromium.py:1
-#: ../kupfer/plugin/chromium.py:16
+#: ../kupfer/plugin/chromium.py:1 ../kupfer/plugin/chromium.py:16
 msgid "Chromium Bookmarks"
 msgstr "Lesezeichen in Chromium"
 
-#: ../kupfer/plugin/chromium.py:3
-#: ../kupfer/plugin/chromium.py:43
+#: ../kupfer/plugin/chromium.py:3 ../kupfer/plugin/chromium.py:43
 msgid "Index of Chromium bookmarks"
 msgstr "Index der Chromium-Lesezeichen"
 
@@ -1791,10 +1736,8 @@ msgstr "Claws Mail"
 msgid "Claws Mail Contacts and Actions"
 msgstr "Kontakte und Aktionen in Claws Mail"
 
-#: ../kupfer/plugin/clawsmail.py:26
-#: ../kupfer/plugin/evolution.py:24
-#: ../kupfer/plugin/operamail.py:26
-#: ../kupfer/plugin/thunderbird.py:31
+#: ../kupfer/plugin/clawsmail.py:26 ../kupfer/plugin/evolution.py:24
+#: ../kupfer/plugin/operamail.py:26 ../kupfer/plugin/thunderbird.py:31
 msgid "Compose New Email"
 msgstr "Neue E-Mail verfassen"
 
@@ -1810,16 +1753,13 @@ msgstr "Alle E-Mails empfangen"
 msgid "Receive new messages from all accounts in ClawsMail"
 msgstr "Neue E-Mails für alle Konten in Claws Mail empfangen"
 
-#: ../kupfer/plugin/clawsmail.py:56
-#: ../kupfer/plugin/defaultmail.py:18
-#: ../kupfer/plugin/evolution.py:40
-#: ../kupfer/plugin/operamail.py:41
+#: ../kupfer/plugin/clawsmail.py:56 ../kupfer/plugin/defaultmail.py:18
+#: ../kupfer/plugin/evolution.py:40 ../kupfer/plugin/operamail.py:41
 #: ../kupfer/plugin/thunderbird.py:47
 msgid "Compose Email"
 msgstr "Neue E-Mail verfassen"
 
-#: ../kupfer/plugin/clawsmail.py:81
-#: ../kupfer/plugin/defaultmail.py:43
+#: ../kupfer/plugin/clawsmail.py:81 ../kupfer/plugin/defaultmail.py:43
 #: ../kupfer/plugin/evolution.py:65
 msgid "Send in Email To..."
 msgstr "In E-Mail senden an …"
@@ -1836,8 +1776,7 @@ msgstr "Adressbuch von Claws Mail"
 msgid "Contacts from Claws Mail Address Book"
 msgstr "Kontakte aus dem Adressbuch von Claws Mail"
 
-#: ../kupfer/plugin/custom_terminal.py:1
-#: ../kupfer/plugin/custom_terminal.py:39
+#: ../kupfer/plugin/custom_terminal.py:1 ../kupfer/plugin/custom_terminal.py:39
 msgid "Custom Terminal"
 msgstr "Benutzerdefiniertes Terminal"
 
@@ -1873,18 +1812,15 @@ msgstr "E-Mail mit dem »mailto:«-Handler des Systems verfassen"
 msgid "Devhelp"
 msgstr "Hilfe für Entwickler"
 
-#: ../kupfer/plugin/devhelp.py:3
-#: ../kupfer/plugin/devhelp.py:13
+#: ../kupfer/plugin/devhelp.py:3 ../kupfer/plugin/devhelp.py:13
 msgid "Search in Devhelp"
 msgstr "In der Hilfe für Entwickler suchen"
 
-#: ../kupfer/plugin/duckduckgo.py:5
-#: ../kupfer/plugin/duckduckgo.py:19
+#: ../kupfer/plugin/duckduckgo.py:5 ../kupfer/plugin/duckduckgo.py:19
 msgid "DuckDuckGo Search"
 msgstr "DuckDuckGo-Suche"
 
-#: ../kupfer/plugin/duckduckgo.py:8
-#: ../kupfer/plugin/duckduckgo.py:30
+#: ../kupfer/plugin/duckduckgo.py:8 ../kupfer/plugin/duckduckgo.py:30
 msgid "Search the web securely with DuckDuckGo"
 msgstr "Das Web sicher mit DuckDuckGo durchsuchen"
 
@@ -1898,67 +1834,55 @@ msgstr "Empathy"
 msgid "Access to Empathy Contacts"
 msgstr "Zugriff auf Empathy-Kontakte"
 
-#: ../kupfer/plugin/empathy.py:25
-#: ../kupfer/plugin/pidgin.py:29
+#: ../kupfer/plugin/empathy.py:26 ../kupfer/plugin/pidgin.py:29
 msgid "Show offline contacts"
 msgstr "Abgemeldete Kontakte anzeigen"
 
-#: ../kupfer/plugin/empathy.py:34
-#: ../kupfer/plugin/gajim.py:26
-#: ../kupfer/plugin/pidgin.py:158
-#: ../kupfer/plugin/skype.py:30
+#: ../kupfer/plugin/empathy.py:35 ../kupfer/plugin/gajim.py:26
+#: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:30
 msgid "Available"
 msgstr "Verfügbar"
 
-#: ../kupfer/plugin/empathy.py:35
-#: ../kupfer/plugin/gajim.py:28
-#: ../kupfer/plugin/pidgin.py:158
-#: ../kupfer/plugin/skype.py:32
+#: ../kupfer/plugin/empathy.py:36 ../kupfer/plugin/gajim.py:28
+#: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:32
 msgid "Away"
 msgstr "Abwesend"
 
-#: ../kupfer/plugin/empathy.py:36
-#: ../kupfer/plugin/gajim.py:30
+#: ../kupfer/plugin/empathy.py:37 ../kupfer/plugin/gajim.py:30
 #: ../kupfer/plugin/skype.py:34
 msgid "Busy"
 msgstr "Beschäftigt"
 
-#: ../kupfer/plugin/empathy.py:37
-#: ../kupfer/plugin/gajim.py:29
+#: ../kupfer/plugin/empathy.py:38 ../kupfer/plugin/gajim.py:29
 #: ../kupfer/plugin/skype.py:33
 msgid "Not Available"
 msgstr "Nicht verfügbar"
 
-#: ../kupfer/plugin/empathy.py:38
-#: ../kupfer/plugin/gajim.py:31
+#: ../kupfer/plugin/empathy.py:39 ../kupfer/plugin/gajim.py:31
 #: ../kupfer/plugin/skype.py:35
 msgid "Invisible"
 msgstr "Verborgen"
 
-#: ../kupfer/plugin/empathy.py:39
-#: ../kupfer/plugin/gajim.py:32
+#: ../kupfer/plugin/empathy.py:40 ../kupfer/plugin/gajim.py:32
 #: ../kupfer/plugin/skype.py:36
 msgid "Offline"
 msgstr "Abgemeldet"
 
-#: ../kupfer/plugin/empathy.py:96
-#: ../kupfer/plugin/gajim.py:93
-#: ../kupfer/plugin/pidgin.py:97
-#: ../kupfer/plugin/skype.py:197
+#: ../kupfer/plugin/empathy.py:100 ../kupfer/plugin/gajim.py:93
+#: ../kupfer/plugin/pidgin.py:97 ../kupfer/plugin/skype.py:197
 msgid "Open Chat"
 msgstr "Unterhaltung öffnen"
 
-#: ../kupfer/plugin/empathy.py:129
-#: ../kupfer/plugin/gajim.py:121
+#: ../kupfer/plugin/empathy.py:133 ../kupfer/plugin/gajim.py:121
 #: ../kupfer/plugin/skype.py:243
 msgid "Change Global Status To..."
 msgstr "Globalen Status ändern in …"
 
-#: ../kupfer/plugin/empathy.py:171
+#: ../kupfer/plugin/empathy.py:175
 msgid "Empathy Contacts"
 msgstr "Empathy-Kontakte"
 
-#: ../kupfer/plugin/empathy.py:237
+#: ../kupfer/plugin/empathy.py:249
 msgid "Empathy Account Status"
 msgstr "Kontenstatus von Empathy"
 
@@ -1966,8 +1890,7 @@ msgstr "Kontenstatus von Empathy"
 msgid "Evolution"
 msgstr "Evolution"
 
-#: ../kupfer/plugin/evolution.py:7
-#: ../kupfer/plugin/evolution.py:119
+#: ../kupfer/plugin/evolution.py:7 ../kupfer/plugin/evolution.py:119
 msgid "Evolution contacts"
 msgstr "Evolution-Kontakte"
 
@@ -2026,14 +1949,12 @@ msgid "Gajim Account Status"
 msgstr "Kontenstatus von Gajim"
 
 #. TRANS: "Glob" is the matching files like a shell with "*.py" etc.
-#: ../kupfer/plugin/glob.py:3
-#: ../kupfer/plugin/glob.py:17
+#: ../kupfer/plugin/glob.py:3 ../kupfer/plugin/glob.py:17
 msgid "Glob"
 msgstr "Glob"
 
 #. -*- coding: UTF-8 -*-
-#: ../kupfer/plugin/gmail/__init__.py:2
-#: ../kupfer/plugin/gmail/__init__.py:234
+#: ../kupfer/plugin/gmail/__init__.py:2 ../kupfer/plugin/gmail/__init__.py:234
 msgid "Gmail"
 msgstr "Gmail"
 
@@ -2133,8 +2054,7 @@ msgstr "Webbrowser öffnen und den Kontakt in GMail bearbeiten"
 msgid "Contacts from Google services (Gmail)"
 msgstr "Kontakte aus Google-Diensten (Google Mail)"
 
-#: ../kupfer/plugin/gnome_terminal.py:1
-#: ../kupfer/plugin/gnome_terminal.py:56
+#: ../kupfer/plugin/gnome_terminal.py:1 ../kupfer/plugin/gnome_terminal.py:56
 msgid "GNOME Terminal Profiles"
 msgstr "GNOME-Terminal-Profile"
 
@@ -2218,8 +2138,7 @@ msgstr "Picasa-Alben"
 msgid "User albums in Picasa"
 msgstr "Benutzeralben in Picasa"
 
-#: ../kupfer/plugin/google_search.py:1
-#: ../kupfer/plugin/google_search.py:30
+#: ../kupfer/plugin/google_search.py:1 ../kupfer/plugin/google_search.py:30
 msgid "Google Search"
 msgstr "Google-Suche"
 
@@ -2227,12 +2146,8 @@ msgstr "Google-Suche"
 msgid "Search Google with results shown directly"
 msgstr "Mit Google suchen und Ergebnisse direkt anzeigen"
 
-#: ../kupfer/plugin/google_search.py:58
-#: ../kupfer/plugin/locate.py:46
-#: ../kupfer/plugin/tracker1.py:168
-#: ../kupfer/plugin/tracker1.py:179
-#: ../kupfer/plugin/tracker.py:72
-#: ../kupfer/plugin/tracker.py:113
+#: ../kupfer/plugin/google_search.py:58 ../kupfer/plugin/locate.py:46
+#: ../kupfer/plugin/tracker1.py:168 ../kupfer/plugin/tracker1.py:179
 #, python-format
 msgid "Results for \"%s\""
 msgstr "Ergebnisse für »%s«"
@@ -2256,54 +2171,54 @@ msgstr "Getting Things GNOME"
 msgid "Browse and create new tasks in GTG"
 msgstr "GTG durchsuchen und neue Aufgaben erstellen"
 
-#: ../kupfer/plugin/gtg.py:87
+#: ../kupfer/plugin/gtg.py:114
 #, python-format
 msgid "due: %s"
 msgstr "Fällig: %s"
 
-#: ../kupfer/plugin/gtg.py:89
+#: ../kupfer/plugin/gtg.py:116
 #, python-format
 msgid "start: %s"
 msgstr "Beginn: %s"
 
-#: ../kupfer/plugin/gtg.py:91
+#: ../kupfer/plugin/gtg.py:118
 #, python-format
 msgid "tags: %s"
 msgstr "Schlagworte: %s"
 
-#: ../kupfer/plugin/gtg.py:118
+#: ../kupfer/plugin/gtg.py:148
 msgid "Open task in Getting Things GNOME!"
 msgstr "Aufgabe in Getting Things GNOME! öffnen"
 
-#: ../kupfer/plugin/gtg.py:125
+#: ../kupfer/plugin/gtg.py:155
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../kupfer/plugin/gtg.py:135
+#: ../kupfer/plugin/gtg.py:168
 msgid "Permanently remove this task"
 msgstr "Diese Aufgabe dauerhaft entfernen"
 
-#: ../kupfer/plugin/gtg.py:140
+#: ../kupfer/plugin/gtg.py:173
 msgid "Mark Done"
 msgstr "Erledigt"
 
-#: ../kupfer/plugin/gtg.py:149
+#: ../kupfer/plugin/gtg.py:182
 msgid "Mark this task as done"
 msgstr "Diese Aufgabe als erledigt markieren"
 
-#: ../kupfer/plugin/gtg.py:154
+#: ../kupfer/plugin/gtg.py:187
 msgid "Dismiss"
 msgstr "Verwerfen"
 
-#: ../kupfer/plugin/gtg.py:163
+#: ../kupfer/plugin/gtg.py:196
 msgid "Mark this task as not to be done anymore"
 msgstr "Diese Aufgabe als nicht mehr zu erledigen markieren"
 
-#: ../kupfer/plugin/gtg.py:168
+#: ../kupfer/plugin/gtg.py:201
 msgid "Create Task"
 msgstr "Aufgabe anlegen"
 
-#: ../kupfer/plugin/gtg.py:182
+#: ../kupfer/plugin/gtg.py:218
 msgid "Create new task in Getting Things GNOME"
 msgstr "Neue Aufgabe in Getting Things GNOME! anlegen"
 
@@ -2312,8 +2227,13 @@ msgid "Gwibber"
 msgstr "Gwibber"
 
 #: ../kupfer/plugin/gwibber.py:6
-msgid "Microblogging with Gwibber. Allows sending and receiving messages from social networks like Twitter, Identi.ca etc. Requires the package 'gwibber-service'."
-msgstr "Microblogging mit Gwibber. Erlaubt das Senden und Empfangen von Nachrichten in sozialen Netzwerken wie Twitter, Identi.ca usw. Dafür wird das Paket »gwibber-service« benötigt."
+msgid ""
+"Microblogging with Gwibber. Allows sending and receiving messages from social "
+"networks like Twitter, Identi.ca etc. Requires the package 'gwibber-service'."
+msgstr ""
+"Microblogging mit Gwibber. Erlaubt das Senden und Empfangen von Nachrichten "
+"in sozialen Netzwerken wie Twitter, Identi.ca usw. Dafür wird das Paket "
+"»gwibber-service« benötigt."
 
 #: ../kupfer/plugin/gwibber.py:45
 msgid "Maximum number of messages to show"
@@ -2349,8 +2269,7 @@ msgstr "Nachricht senden an …"
 msgid "Send message to a Gwibber account"
 msgstr "Nachricht an ein Gwibber-Konto senden"
 
-#: ../kupfer/plugin/gwibber.py:243
-#: ../kupfer/plugin/pidgin.py:120
+#: ../kupfer/plugin/gwibber.py:243 ../kupfer/plugin/pidgin.py:120
 msgid "Send Message..."
 msgstr "Nachricht senden …"
 
@@ -2398,8 +2317,7 @@ msgstr "Im Browser öffnen"
 msgid "Open message in default web browser"
 msgstr "Nachricht im vorgegebenen Webbrowser öffnen"
 
-#: ../kupfer/plugin/gwibber.py:425
-#: ../kupfer/plugin/gwibber.py:463
+#: ../kupfer/plugin/gwibber.py:425 ../kupfer/plugin/gwibber.py:463
 msgid "Gwibber Accounts"
 msgstr "Gwibber-Konten"
 
@@ -2512,8 +2430,7 @@ msgstr "Automatisch drehen"
 msgid "Rotate JPEG (in-place) according to its EXIF metadata"
 msgstr "JPEG anhand der EXIF-Metadaten drehen"
 
-#: ../kupfer/plugin/kupfer_plugins.py:1
-#: ../kupfer/plugin/kupfer_plugins.py:86
+#: ../kupfer/plugin/kupfer_plugins.py:1 ../kupfer/plugin/kupfer_plugins.py:86
 msgid "Kupfer Plugins"
 msgstr "Kupfer-Plugins"
 
@@ -2533,13 +2450,11 @@ msgstr "Quellcode anzeigen"
 msgid "enabled"
 msgstr "aktiviert"
 
-#: ../kupfer/plugin/locate.py:1
-#: ../kupfer/plugin/locate.py:28
+#: ../kupfer/plugin/locate.py:1 ../kupfer/plugin/locate.py:28
 msgid "Locate Files"
 msgstr "Datei finden"
 
-#: ../kupfer/plugin/locate.py:5
-#: ../kupfer/plugin/locate.py:38
+#: ../kupfer/plugin/locate.py:5 ../kupfer/plugin/locate.py:38
 msgid "Search filesystem using locate"
 msgstr "Das Dateisystem mit locate durchsuchen"
 
@@ -2552,8 +2467,7 @@ msgstr "Groß-/Kleinschreibung während der Suche ignorieren"
 msgid "OpenOffice / LibreOffice"
 msgstr "OpenOffice / LibreOffice"
 
-#: ../kupfer/plugin/openoffice.py:5
-#: ../kupfer/plugin/openoffice.py:136
+#: ../kupfer/plugin/openoffice.py:5 ../kupfer/plugin/openoffice.py:136
 msgid "Recently used documents in OpenOffice/LibreOffice"
 msgstr "Kürzlich in OpenOffice/LibreOffice verwendete Dokumente"
 
@@ -2582,13 +2496,11 @@ msgstr "Opera-Mail-Kontakte"
 msgid "Contacts from Opera Mail"
 msgstr "Kontakte aus Opera Mail"
 
-#: ../kupfer/plugin/opera.py:4
-#: ../kupfer/plugin/opera.py:22
+#: ../kupfer/plugin/opera.py:4 ../kupfer/plugin/opera.py:22
 msgid "Opera Bookmarks"
 msgstr "Lesezeichen in Opera"
 
-#: ../kupfer/plugin/opera.py:6
-#: ../kupfer/plugin/opera.py:54
+#: ../kupfer/plugin/opera.py:6 ../kupfer/plugin/opera.py:54
 msgid "Index of Opera bookmarks"
 msgstr "Index der Lesezeichen in Opera"
 
@@ -2611,8 +2523,7 @@ msgstr[1] "%s (%d Zeichen)"
 msgid "Pidgin Contacts"
 msgstr "Pidgin-Kontakte"
 
-#: ../kupfer/plugin/putty.py:5
-#: ../kupfer/plugin/putty.py:80
+#: ../kupfer/plugin/putty.py:5 ../kupfer/plugin/putty.py:80
 msgid "PuTTY Sessions"
 msgstr "PuTTY-Sitzungen"
 
@@ -2620,8 +2531,7 @@ msgstr "PuTTY-Sitzungen"
 msgid "Quick access to PuTTY Sessions"
 msgstr "Schneller Zugriff auf PuTTY-Sitzungen"
 
-#: ../kupfer/plugin/putty.py:46
-#: ../kupfer/plugin/tsclient.py:50
+#: ../kupfer/plugin/putty.py:46 ../kupfer/plugin/tsclient.py:50
 msgid "Start Session"
 msgstr "Sitzung starten"
 
@@ -2653,8 +2563,7 @@ msgstr "Als HTML-Dokument betrachten"
 msgid "GNU Screen"
 msgstr "GNU Screen"
 
-#: ../kupfer/plugin/screen.py:3
-#: ../kupfer/plugin/screen.py:89
+#: ../kupfer/plugin/screen.py:3 ../kupfer/plugin/screen.py:89
 msgid "Active GNU Screen sessions"
 msgstr "Aktive GNU Screen-Sitzungen"
 
@@ -2679,8 +2588,7 @@ msgstr "Screen-Sitzungen"
 msgid "Attach"
 msgstr "Verbinden"
 
-#: ../kupfer/plugin/sendkeys.py:2
-#: ../kupfer/plugin/sendkeys.py:52
+#: ../kupfer/plugin/sendkeys.py:2 ../kupfer/plugin/sendkeys.py:52
 msgid "Send Keys"
 msgstr "Tastatursignale senden"
 
@@ -2709,8 +2617,7 @@ msgid "Type the text to foreground window"
 msgstr "Text in das aktive Fenster eingeben"
 
 #. -*- coding: UTF-8 -*-
-#: ../kupfer/plugin/services.py:2
-#: ../kupfer/plugin/services.py:96
+#: ../kupfer/plugin/services.py:2 ../kupfer/plugin/services.py:96
 msgid "System Services"
 msgstr "Systemdienste"
 
@@ -2760,13 +2667,11 @@ msgstr "Abkürzen als …"
 msgid "Services"
 msgstr "Dienste"
 
-#: ../kupfer/plugin/show_qrcode.py:5
-#: ../kupfer/plugin/show_qrcode.py:25
+#: ../kupfer/plugin/show_qrcode.py:5 ../kupfer/plugin/show_qrcode.py:25
 msgid "Show QRCode"
 msgstr "QRCode anzeigen"
 
-#: ../kupfer/plugin/show_qrcode.py:9
-#: ../kupfer/plugin/show_qrcode.py:60
+#: ../kupfer/plugin/show_qrcode.py:9 ../kupfer/plugin/show_qrcode.py:60
 msgid "Display text as QRCode in a window"
 msgstr "Text als QRCode in einem Fenster anzeigen"
 
@@ -2804,8 +2709,7 @@ msgid "Skype Statuses"
 msgstr "Skype-Status"
 
 #. -*- coding: UTF-8 -*-
-#: ../kupfer/plugin/ssh_hosts.py:2
-#: ../kupfer/plugin/ssh_hosts.py:70
+#: ../kupfer/plugin/ssh_hosts.py:2 ../kupfer/plugin/ssh_hosts.py:70
 msgid "SSH Hosts"
 msgstr "SSH-Rechner"
 
@@ -2845,8 +2749,7 @@ msgstr "KWallet"
 msgid "Unencrypted File"
 msgstr "Unverschlüsselte Datei"
 
-#: ../kupfer/plugin/templates.py:1
-#: ../kupfer/plugin/templates.py:107
+#: ../kupfer/plugin/templates.py:1 ../kupfer/plugin/templates.py:107
 msgid "Document Templates"
 msgstr "Dokumentvorlagen"
 
@@ -2859,8 +2762,7 @@ msgstr "Neue Dokumente aus Ihren Vorlagen erstellen"
 msgid "%s template"
 msgstr "Vorlage %s"
 
-#: ../kupfer/plugin/templates.py:37
-#: ../kupfer/plugin/textfiles.py:86
+#: ../kupfer/plugin/templates.py:37 ../kupfer/plugin/textfiles.py:86
 msgid "Empty File"
 msgstr "Leere Datei"
 
@@ -2900,10 +2802,8 @@ msgstr "Schreiben an …"
 msgid "Get Text Contents"
 msgstr "Textinhalte holen"
 
-#: ../kupfer/plugin/thunar.py:1
-#: ../kupfer/plugin/thunar.py:185
-#: ../kupfer/plugin/thunar.py:225
-#: ../kupfer/plugin/thunar.py:278
+#: ../kupfer/plugin/thunar.py:1 ../kupfer/plugin/thunar.py:185
+#: ../kupfer/plugin/thunar.py:225 ../kupfer/plugin/thunar.py:278
 #: ../kupfer/plugin/thunar.py:329
 msgid "Thunar"
 msgstr "Thunar"
@@ -2938,7 +2838,7 @@ msgstr "Verknüpfung zur Datei am gewählten Ort erstellen"
 
 #: ../kupfer/plugin/thunar.py:304
 msgid "Empty Trash"
-msgstr "Müll ist leer"
+msgstr "Papierkorb leeren"
 
 #: ../kupfer/plugin/thunar.py:344
 msgid "Thunar Send To Objects"
@@ -2976,8 +2876,7 @@ msgstr "Anzeigen aktiver Prozesse und Senden von Signalen"
 msgid "Sort Order"
 msgstr "Sortierreihenfolge"
 
-#: ../kupfer/plugin/top.py:25
-#: ../kupfer/plugin/top.py:26
+#: ../kupfer/plugin/top.py:25 ../kupfer/plugin/top.py:26
 #: ../kupfer/plugin/top.py:115
 msgid "Commandline"
 msgstr "Befehlszeile"
@@ -2987,8 +2886,7 @@ msgid "CPU usage (descending)"
 msgstr "Prozessorlast (absteigend)"
 
 #. sort processes (top don't allow to sort via cmd line)
-#: ../kupfer/plugin/top.py:27
-#: ../kupfer/plugin/top.py:112
+#: ../kupfer/plugin/top.py:27 ../kupfer/plugin/top.py:112
 msgid "Memory usage (descending)"
 msgstr "Speichernutzung (absteigend)"
 
@@ -3019,81 +2917,34 @@ msgid "Tracker"
 msgstr "Tracker"
 
 #: ../kupfer/plugin/tracker1.py:18
-#: ../kupfer/plugin/tracker.py:15
 msgid "Tracker desktop search integration"
 msgstr "Einbindung der Tracker Desktop-Suche"
 
 #: ../kupfer/plugin/tracker1.py:49
-#: ../kupfer/plugin/tracker.py:41
 msgid "Search in Tracker"
 msgstr "Mit Tracker suchen"
 
 #: ../kupfer/plugin/tracker1.py:54
-#: ../kupfer/plugin/tracker.py:46
 msgid "Open Tracker Search Tool and search for this term"
 msgstr "Tracker Suchwerkzeug öffnen und nach diesem Begriff suchen"
 
 #: ../kupfer/plugin/tracker1.py:62
-#: ../kupfer/plugin/tracker.py:55
 msgid "Get Tracker Results..."
 msgstr "Tracker-Ergebnisse einholen …"
 
 #: ../kupfer/plugin/tracker1.py:71
-#: ../kupfer/plugin/tracker.py:64
 msgid "Show Tracker results for query"
 msgstr "Tracker Ergebnisse für den Suchbegriff anzeigen"
 
-#: ../kupfer/plugin/tracker.py:5
-msgid "Tracker 0.6"
-msgstr "Tracker 0.6"
-
-#: ../kupfer/plugin/tracker.py:165
-#: ../kupfer/plugin/tracker.py:171
-msgid "Tracker tags"
-msgstr "Tracker-Schlagworte"
-
-#: ../kupfer/plugin/tracker.py:180
-msgid "Tracker Tags"
-msgstr "Tracker-Schlagworte"
-
-#: ../kupfer/plugin/tracker.py:186
-msgid "Browse Tracker's tags"
-msgstr "Tracker-Schlagworte anzeigen"
-
-#: ../kupfer/plugin/tracker.py:197
-#: ../kupfer/plugin/tracker.py:204
-#, python-format
-msgid "Tag %s"
-msgstr "Schlagwort %s"
-
-#: ../kupfer/plugin/tracker.py:211
-#, python-format
-msgid "Objects tagged %s with Tracker"
-msgstr "Objekte mit dem Schlagwort %s in Tracker"
-
-#: ../kupfer/plugin/tracker.py:223
-msgid "Add Tag..."
-msgstr "Schlagwort hinzufügen …"
-
-#: ../kupfer/plugin/tracker.py:249
-msgid "Add tracker tag to file"
-msgstr "Tracker-Schlagwort zur Datei hinzufügen"
-
-#: ../kupfer/plugin/tracker.py:255
-msgid "Remove Tag..."
-msgstr "Schlagwort entfernen …"
-
-#: ../kupfer/plugin/tracker.py:274
-msgid "Remove tracker tag from file"
-msgstr "Tracker-Schlagwort von der Datei entfernen"
-
+#. FIXME: Port tracker tag sources and actions
+#. to the new, much more powerful sparql + dbus API
+#. (using tracker-tag as in 0.6 is a plain hack and a dead end)
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/truecrypt.py:3
 msgid "TrueCrypt"
 msgstr "TrueCrypt"
 
-#: ../kupfer/plugin/truecrypt.py:6
-#: ../kupfer/plugin/truecrypt.py:140
+#: ../kupfer/plugin/truecrypt.py:6 ../kupfer/plugin/truecrypt.py:140
 msgid "Volumes from TrueCrypt history"
 msgstr "Datenträger der TrueCrypt-Chronik"
 
@@ -3197,8 +3048,12 @@ msgid "VirtualBox"
 msgstr "VirtualBox"
 
 #: ../kupfer/plugin/virtualbox/__init__.py:5
-msgid "Control VirtualBox Virtual Machines. Supports both Sun VirtualBox and Open Source Edition."
-msgstr "Steuerung von VirtualBox-Maschinen. Unterstützt sowohl VirtualBox von Sun als auch die Open Source Edition."
+msgid ""
+"Control VirtualBox Virtual Machines. Supports both Sun VirtualBox and Open "
+"Source Edition."
+msgstr ""
+"Steuerung von VirtualBox-Maschinen. Unterstützt sowohl VirtualBox von Sun als "
+"auch die Open Source Edition."
 
 #: ../kupfer/plugin/virtualbox/__init__.py:22
 msgid "Force use CLI interface"
@@ -3316,6 +3171,51 @@ msgstr "Zim-Seiten"
 msgid "Pages stored in Zim Notebooks"
 msgstr "In Zim-Notizbüchern gespeicherte Seiten"
 
+#~ msgid "Selected File"
+#~ msgstr "Ausgewählte Datei"
+
+#~ msgid ""
+#~ "Provides current nautilus selection, using Kupfer's Nautilus Extension"
+#~ msgstr ""
+#~ "Gibt aktuelle Nautilus-Auswahl aus, indem es Kupfers Nautilus-Erweiterung "
+#~ "verwendet"
+
+#~ msgid "Selected File \"%s\""
+#~ msgstr "Ausgewählte Datei »%s«"
+
+#~ msgid "Selected Files"
+#~ msgstr "Ausgewählte Dateien"
+
+#~ msgid "Tracker 0.6"
+#~ msgstr "Tracker 0.6"
+
+#~ msgid "Tracker tags"
+#~ msgstr "Tracker-Schlagworte"
+
+#~ msgid "Tracker Tags"
+#~ msgstr "Tracker-Schlagworte"
+
+#~ msgid "Browse Tracker's tags"
+#~ msgstr "Tracker-Schlagworte anzeigen"
+
+#~ msgid "Tag %s"
+#~ msgstr "Schlagwort %s"
+
+#~ msgid "Objects tagged %s with Tracker"
+#~ msgstr "Objekte mit dem Schlagwort %s in Tracker"
+
+#~ msgid "Add Tag..."
+#~ msgstr "Schlagwort hinzufügen …"
+
+#~ msgid "Add tracker tag to file"
+#~ msgstr "Tracker-Schlagwort zur Datei hinzufügen"
+
+#~ msgid "Remove Tag..."
+#~ msgstr "Schlagwort entfernen …"
+
+#~ msgid "Remove tracker tag from file"
+#~ msgstr "Tracker-Schlagwort von der Datei entfernen"
+
 #~ msgid "Translate text with Google Translate"
 #~ msgstr "Text mit Google Translate übersetzen"
 
@@ -3394,9 +3294,9 @@ msgstr "In Zim-Notizbüchern gespeicherte Seiten"
 #~ "the terminal (e.g. '-x' for gnome-terminal and terminal, '-e' for konsole "
 #~ "and urxvt)."
 #~ msgstr ""
-#~ "Das Argument, welches das Terminal anweist, alles Nachfolgende im "
-#~ "Terminal auszuführen (z.B. »-x« für gnome-terminal und terminal, »-e« für "
-#~ "konsole und urxvt)."
+#~ "Das Argument, welches das Terminal anweist, alles Nachfolgende im Terminal "
+#~ "auszuführen (z.B. »-x« für gnome-terminal und terminal, »-e« für konsole "
+#~ "und urxvt)."
 
 #~ msgid "Tracker 0.8"
 #~ msgstr "Tracker 0.8"

--- a/po/el.po
+++ b/po/el.po
@@ -1,0 +1,3175 @@
+# Greek translation for kupfer.
+# Copyright (C) 2013 kupfer's COPYRIGHT HOLDER
+# This file is distributed under the same license as the kupfer package.
+# Dimitris Spingos <dmtrs32@gmail.com>, 2013.
+# keratea <dmtrs32@gmail.com>, 2013.
+# Dimitris Spingos (Δημήτρης Σπίγγος) <dmtrs32@gmail.com>, 2013.
+msgid ""
+msgstr ""
+"Project-Id-Version: kupfer master\n"
+"Report-Msgid-Bugs-To: http://bugs.launchpad.net/kupfer\n"
+"POT-Creation-Date: 2013-01-15 15:13+0000\n"
+"PO-Revision-Date: 2013-07-05 09:52+0300\n"
+"Last-Translator: Dimitris Spingos (Δημήτρης Σπίγγος) <dmtrs32@gmail.com>\n"
+"Language-Team: team@gnome.gr\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Virtaal 0.7.1\n"
+
+#: ../auxdata/kupfer.desktop.in.h:1 ../kupfer/version.py:15
+#: ../kupfer/plugin/core/contents.py:91
+msgid "Kupfer"
+msgstr "Kupfer"
+
+#: ../auxdata/kupfer.desktop.in.h:2
+msgid "Application Launcher"
+msgstr "Εκκινητής εφαρμογής"
+
+#: ../auxdata/kupfer.desktop.in.h:3
+msgid "Convenient command and access tool for applications and documents"
+msgstr "Βολικό εργαλείο εντολών και πρόσβασης για εφαρμογές και έγγραφα"
+
+#: ../auxdata/kupfer-exec.desktop.in.h:1
+msgid "Execute in Kupfer"
+msgstr "Εκτέλεση στο Kupfer"
+
+#: ../auxdata/kupfer-mimetypes.xml.in.h:1
+msgid "Saved Kupfer Command"
+msgstr "Αποθηκευμένη εντολή Kupfer"
+
+#: ../data/credentials_dialog.ui.h:1
+msgid "User credentials"
+msgstr "Διαπιστευτήρια χρήστη"
+
+#: ../data/credentials_dialog.ui.h:2
+msgid "_User:"
+msgstr "_Χρήστης:"
+
+#: ../data/credentials_dialog.ui.h:3
+msgid "_Password:"
+msgstr "_Κωδικός πρόσβασης:"
+
+#: ../data/credentials_dialog.ui.h:4
+msgid "_Change"
+msgstr "Α_λλαγή"
+
+#: ../data/getkey_dialog.ui.h:1
+msgid "Set Keyboard Shortcut"
+msgstr "Ορισμός συντόμευσης πληκτρολογίου"
+
+#: ../data/getkey_dialog.ui.h:2
+msgid "Please press desired key combination"
+msgstr "Παρακαλούμε, πατήστε τον επιθυμητό συνδυασμό πλήκτρων"
+
+#: ../data/getkey_dialog.ui.h:3
+msgid "Keybinding could not be bound"
+msgstr "Ο συνδυασμός πλήκτρων δεν μπόρεσε να προσαρτηθεί"
+
+#: ../data/preferences.ui.h:1 ../kupfer/plugin/core/contents.py:78
+msgid "Kupfer Preferences"
+msgstr "Προτιμήσεις Kupfer"
+
+#: ../data/preferences.ui.h:2
+msgid "Start automatically on login"
+msgstr "Αυτόματη έναρξη στη σύνδεση"
+
+#: ../data/preferences.ui.h:3
+msgid "<b>Start</b>"
+msgstr "<b>Έναρξη</b>"
+
+#: ../data/preferences.ui.h:4
+msgid "Show icon in notification area"
+msgstr "Εμφάνιση εικονιδίου στην περιοχή ειδοποίησης"
+
+#: ../data/preferences.ui.h:5
+msgid "Icon set:"
+msgstr "Ομάδα εικονιδίων:"
+
+#: ../data/preferences.ui.h:6
+msgid "Terminal emulator:"
+msgstr "Προσομοιωτής τερματικού:"
+
+#: ../data/preferences.ui.h:7
+msgid "Desktop Environment"
+msgstr "Περιβάλλον επιφάνειας εργασίας"
+
+#: ../data/preferences.ui.h:8 ../kupfer/plugin/gmail/__init__.py:60
+msgid "General"
+msgstr "Γενικά"
+
+#: ../data/preferences.ui.h:9
+msgid "<b>Global Keyboard Shortcuts</b>"
+msgstr "<b>Γενικές συντομεύσεις πληκτρολογίου</b>"
+
+#: ../data/preferences.ui.h:10 ../kupfer/ui/preferences.py:849
+msgid "Reset"
+msgstr "Επαναφορά"
+
+#: ../data/preferences.ui.h:11
+msgid "<b>Browser Keyboard Shortcuts</b>"
+msgstr "<b>Συντομεύσεις πληκτρολογίου περιηγητή</b>"
+
+#: ../data/preferences.ui.h:12
+msgid "Use single keystroke commands (Space, /, period, comma etc.)"
+msgstr "Χρήση μονών εντολών πληκτρολόγησης (διάστημα, /, περίοδος, κόμμα κλπ.)"
+
+#: ../data/preferences.ui.h:13
+msgid "Keyboard"
+msgstr "Πληκτρολόγιο"
+
+#: ../data/preferences.ui.h:14
+msgid "Plugins"
+msgstr "Πρόσθετα"
+
+#: ../data/preferences.ui.h:15
+msgid "Inclusion in Top Level Searches"
+msgstr "Συμπερίληψη στις αναζητήσεις κορυφαίου επιπέδου"
+
+#: ../data/preferences.ui.h:16
+msgid ""
+"Marked sources have their objects included in top level searches.\n"
+"An unmarked source's contents are only available by locating its subcatalog."
+msgstr ""
+"Οι σημειωμένες πηγές έχουν τα αντικείμενά τους να συμπεριλαμβάνονται στις "
+"αναζητήσεις κορυφαίου επιπέδου.\n"
+"Τα περιεχόμενα μιας ασημείωτης πηγής είναι διαθέσιμα μόνο με εντοπισμό του "
+"υποκαταλόγου της."
+
+#: ../data/preferences.ui.h:18
+msgid "Indexed Folders"
+msgstr "Φάκελοι από ευρετήριο"
+
+#: ../data/preferences.ui.h:19
+msgid "Folders whose files are always available in the catalog."
+msgstr "Φάκελοι των οποίων τα αρχεία είναι πάντα διαθέσιμα στον κατάλογο."
+
+#: ../data/preferences.ui.h:20 ../kupfer/obj/sources.py:157
+msgid "Catalog"
+msgstr "Κατάλογος"
+
+#: ../kupfer/core/commandexec.py:239
+#, python-format
+msgid "Could not to carry out '%s'"
+msgstr "Αδύνατη η εκτέλεση του '%s'"
+
+#: ../kupfer/core/commandexec.py:268
+#, python-format
+msgid "\"%s\" produced a result"
+msgstr "το \"%s\" παρήγαγε ένα αποτέλεσμα"
+
+#: ../kupfer/core/execfile.py:30
+#, python-format
+msgid "No permission to run \"%s\" (not executable)"
+msgstr "Χωρίς δικαίωμα εκτέλεσης του \"%s\" (μη εκτελέσιμο)"
+
+#: ../kupfer/core/execfile.py:47
+#, python-format
+msgid "Command in \"%s\" is not available"
+msgstr "Η εντολή στο \"%s\" δεν είναι διαθέσιμη"
+
+#: ../kupfer/keyrelay.py:62
+#, python-format
+msgid "Keyboard relay is active for display %s"
+msgstr "Η μεταγωγή πληκτρολογίου είναι ενεργή για εμφάνιση του %s"
+
+#: ../kupfer/main.py:43
+msgid "do not present main interface on launch"
+msgstr "να μην εμφανίζεται η κύρια διεπαφή στην έναρξη"
+
+#: ../kupfer/main.py:44
+msgid "list available plugins"
+msgstr "λίστα διαθέσιμων προσθέτων"
+
+#: ../kupfer/main.py:45
+msgid "enable debug info"
+msgstr "ενεργοποίηση πληροφοριών αποσφαλμάτωσης"
+
+#. TRANS: --exec-helper=HELPER is an internal command
+#. TRANS: that executes a helper program that is part of kupfer
+#: ../kupfer/main.py:49
+msgid "run plugin helper"
+msgstr "εκτέλεση βοηθού προσθέτου"
+
+#: ../kupfer/main.py:52
+msgid "show usage help"
+msgstr "εμφάνιση βοήθειας χρήσης"
+
+#: ../kupfer/main.py:53
+msgid "show version information"
+msgstr "εμφάνιση πληροφοριών έκδοσης"
+
+#: ../kupfer/main.py:59
+msgid "Usage: kupfer [ OPTIONS | FILE ... ]"
+msgstr "Χρήση: kupfer [ ΕΠΙΛΟΓΕΣ | ΑΡΧΕΙΟ ... ]"
+
+#: ../kupfer/main.py:70
+msgid "Available plugins:"
+msgstr "Διαθέσιμα πρόσθετα:"
+
+#: ../kupfer/main.py:121
+#, python-format
+msgid ""
+"%(PROGRAM_NAME)s: %(SHORT_DESCRIPTION)s\n"
+"\t%(COPYRIGHT)s\n"
+"\t%(WEBSITE)s\n"
+msgstr ""
+"%(PROGRAM_NAME)s: %(SHORT_DESCRIPTION)s\n"
+"\t%(COPYRIGHT)s\n"
+"\t%(WEBSITE)s\n"
+
+#. TRANS: Names of accelerators in the interface
+#: ../kupfer/ui/accelerators.py:4
+msgid "Alternate Activate"
+msgstr "Εναλλακτική ενεργοποίηση"
+
+#. TRANS: The "Comma Trick"/"Put Selection on Stack" allows the
+#. TRANS: user to select many objects to be used for one action
+#: ../kupfer/ui/accelerators.py:7
+msgid "Comma Trick"
+msgstr "Τέχνασμα κόμμα (πολλά αντικείμενα)"
+
+#. TRANS: "Compose Command" makes one object out of the selected
+#. TRANS: object + action (+iobject)
+#: ../kupfer/ui/accelerators.py:10
+msgid "Compose Command"
+msgstr "Εντολή σύνθεσης"
+
+#: ../kupfer/ui/accelerators.py:11
+msgid "Mark Default Action"
+msgstr "Σημείωση προεπιλεγμένης ενέργειας"
+
+#: ../kupfer/ui/accelerators.py:12
+msgid "Forget Object"
+msgstr "Παράλειψη αντικειμένου"
+
+#: ../kupfer/ui/accelerators.py:13
+msgid "Reset All"
+msgstr "Επαναφορά όλων"
+
+#: ../kupfer/ui/accelerators.py:14
+msgid "Select Quit"
+msgstr "Επιλογή εξόδου"
+
+#: ../kupfer/ui/accelerators.py:15
+msgid "Select Selected File"
+msgstr "Επιλογή του επιλεγμένου αρχείου"
+
+#: ../kupfer/ui/accelerators.py:16
+msgid "Select Selected Text"
+msgstr "Επιλογή του επιλεγμένου κειμένου"
+
+#: ../kupfer/ui/accelerators.py:17
+msgid "Show Help"
+msgstr "Εμφάνιση βοήθειας"
+
+#: ../kupfer/ui/accelerators.py:18
+msgid "Show Preferences"
+msgstr "Εμφάνιση προτιμήσεων"
+
+#: ../kupfer/ui/accelerators.py:19
+msgid "Switch to First Pane"
+msgstr "Εναλλαγή σε πρώτο παράθυρο"
+
+#: ../kupfer/ui/accelerators.py:20
+msgid "Toggle Text Mode"
+msgstr "Εναλλαγή σε κατάσταση κειμένου"
+
+#: ../kupfer/ui/browser.py:888
+#, python-format
+msgid "%s is empty"
+msgstr "το %s είναι κενό"
+
+#: ../kupfer/ui/browser.py:892
+#, python-format
+msgid "No matches in %(src)s for \"%(query)s\""
+msgstr "Δεν υπάρχει συμφωνία στο %(src)s για το \"%(query)s\""
+
+#: ../kupfer/ui/browser.py:898
+msgid "No matches"
+msgstr "Καμία συμφωνία"
+
+#: ../kupfer/ui/browser.py:903
+msgid "Type to search"
+msgstr "Πληκτρολογήστε για αναζήτηση"
+
+#: ../kupfer/ui/browser.py:909
+#, python-format
+msgid "Type to search %s"
+msgstr "Πληκτρολογήστε για αναζήτηση του %s"
+
+#: ../kupfer/ui/browser.py:924
+msgid "No action"
+msgstr "Καμία ενέργεια"
+
+#: ../kupfer/ui/browser.py:1513
+#, python-format
+msgid "Make \"%(action)s\" Default for \"%(object)s\""
+msgstr "Κάντε το \"%(action)s\" προεπιλογή για \"%(object)s\""
+
+#. TRANS: Removing learned and/or configured bonus search score
+#: ../kupfer/ui/browser.py:1523
+#, python-format
+msgid "Forget About \"%s\""
+msgstr "Παράλειψη σχετικά με το \"%s\""
+
+#. TRANS: Names of global keyboard shortcuts
+#: ../kupfer/ui/browser.py:1960 ../kupfer/ui/preferences.py:58
+msgid "Show Main Interface"
+msgstr "Εμφάνιση κύριας διεπαφής"
+
+#: ../kupfer/ui/preferences.py:59
+msgid "Show with Selection"
+msgstr "Εμφάνιση με επιλογή"
+
+#. TRANS: Plugin info fields
+#: ../kupfer/ui/preferences.py:416
+msgid "Description"
+msgstr "Περιγραφή"
+
+#: ../kupfer/ui/preferences.py:416
+msgid "Author"
+msgstr "Δημιουργός"
+
+#: ../kupfer/ui/preferences.py:433
+msgid "Version"
+msgstr "Έκδοση"
+
+#. TRANS: Error message when Plugin needs a Python module to load
+#: ../kupfer/ui/preferences.py:443
+#, python-format
+msgid "Python module '%s' is needed"
+msgstr "Χρειάζεται η ενότητα Python '%s'"
+
+#: ../kupfer/ui/preferences.py:457
+msgid "Plugin could not be read due to an error:"
+msgstr "Το πρόσθετο δεν μπόρεσε να διαβαστεί λόγω ενός σφάλματος:"
+
+#: ../kupfer/ui/preferences.py:465 ../kupfer/plugin/kupfer_plugins.py:80
+msgid "disabled"
+msgstr "ανενεργό"
+
+#: ../kupfer/ui/preferences.py:539
+msgid "Content of"
+msgstr "Περιεχόμενο του"
+
+#. TRANS: Plugin contents header
+#: ../kupfer/ui/preferences.py:548
+msgid "Sources"
+msgstr "Πηγές"
+
+#. TRANS: Plugin contents header
+#: ../kupfer/ui/preferences.py:552
+msgid "Actions"
+msgstr "Ενέργειες"
+
+#: ../kupfer/ui/preferences.py:575
+#, python-format
+msgid "Using encrypted password storage: %s"
+msgstr "Χρήση κρυπτογραφημένης αποθήκευσης κωδικού πρόσβασης: %s"
+
+#: ../kupfer/ui/preferences.py:577
+#, python-format
+msgid "Using password storage: %s"
+msgstr "Χρήση αποθήκευσης κωδικού πρόσβασης: %s"
+
+#. TRANS: Plugin-specific configuration (header)
+#: ../kupfer/ui/preferences.py:594
+msgid "Configuration"
+msgstr "Διαμόρφωση"
+
+#: ../kupfer/ui/preferences.py:614
+msgid "Set username and password"
+msgstr "Εισάγετε το όνομα χρήστη και κωδικό πρόσβασης."
+
+#. TRANS: File Chooser Title
+#: ../kupfer/ui/preferences.py:668
+msgid "Choose a Directory"
+msgstr "Επιλέξτε έναν κατάλογο"
+
+#: ../kupfer/ui/preferences.py:847
+msgid "Reset all shortcuts to default values?"
+msgstr "Επαναφορά όλων των συντομεύσεων στις προεπιλεγμένες τιμές;"
+
+#: ../kupfer/ui/preferences.py:855 ../kupfer/plugin/custom_terminal.py:12
+msgid "Command"
+msgstr "Εντολή"
+
+#: ../kupfer/ui/preferences.py:856
+msgid "Shortcut"
+msgstr "Συντόμευση"
+
+#. TRANS: Don't translate literally!
+#. TRANS: This should be a list of all translators of this language
+#: ../kupfer/version.py:73
+msgid "translator-credits"
+msgstr ""
+"Ελληνική μεταφραστική ομάδα του GNOME\n"
+" Δημήτρης Σπίγγος <dmtrs32@gmail.com>\n"
+"Για περισσότερα δείτε: http://gnome.gr"
+
+#: ../kupfer/version.py:78
+msgid "A free software (GPLv3+) launcher"
+msgstr "Ένας εκκινητής ελεύθερου λογισμικού (GPLv3+)"
+
+#: ../kupfer/version.py:81
+msgid ""
+"\n"
+"This program is free software: you can redistribute it and/or modify\n"
+"it under the terms of the GNU General Public License as published by\n"
+"the Free Software Foundation, either version 3 of the License, or\n"
+"(at your option) any later version.\n"
+"\n"
+"This program is distributed in the hope that it will be useful,\n"
+"but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
+"GNU General Public License for more details.\n"
+"\n"
+"You should have received a copy of the GNU General Public License\n"
+"along with this program.  If not, see <http://www.gnu.org/licenses/>.\n"
+msgstr ""
+"\n"
+"Αυτό το πρόγραμμα είναι ελεύθερο λογισμικό: Επιτρέπεται η αναδιανομή ή/και "
+"τροποποίησή του υπό τους όρους της Γενικής Άδειας Δημόσιας Χρήσης\n"
+"GNU, όπως αυτή έχει δημοσιευτεί από το Ίδρυμα Ελεύθερου Λογισμικού,\n"
+"είτε της έκδοσης 3 της Άδειας, είτε (κατ' επιλογήν) οποιασδήποτε\n"
+"μεταγενέστερης έκδοσης.\n"
+"\n"
+"Το πρόγραμμα αυτό διανέμεται με την ελπίδα ότι θα αποδειχθεί χρήσιμο,\n"
+"παρόλα αυτά ΧΩΡΙΣ ΚΑΜΙΑ ΕΓΓΥΗΣΗ – χωρίς ούτε και την σιωπηρή εγγύηση\n"
+"ΕΜΠΟΡΕΥΣΙΜΟΤΗΤΑΣ ή ΚΑΤΑΛΛΗΛΟΤΗΤΑΣ ΓΙΑ ΣΥΓΚΕΚΡΙΜΕΝΗ ΧΡΗΣΗ. Για\n"
+"περισσότερες λεπτομέρειες ανατρέξτε στη Γενική Άδεια Δημόσιας Χρήσης\n"
+"GNU.\n"
+"\n"
+"Θα πρέπει να έχετε λάβει ένα αντίγραφο της Γενικής Άδειας Δημόσιας\n"
+"Χρήσης GNU μαζί με αυτό το πρόγραμμα. Εάν όχι, δείτε εδώ: "
+"<http://www.gnu.org/licenses/>.\n"
+
+#. follows strings used elsewhere
+#: ../kupfer/version.py:98
+msgid "Could not find running Kupfer"
+msgstr "Αδύνατη η εύρεση εκτελούμενου Kupfer"
+
+#: ../kupfer/obj/base.py:457 ../kupfer/plugin/core/text.py:22
+msgid "Text"
+msgstr "Κείμενο"
+
+#: ../kupfer/obj/compose.py:15
+msgid "Run after Delay..."
+msgstr "Εκτέλεση μετά από καθυστέρηση..."
+
+#: ../kupfer/obj/compose.py:36
+msgid "Perform command after a specified time interval"
+msgstr "Εκτέλεση της εντολής μετά από έναν καθορισμένο χρονικό διάστημα"
+
+#: ../kupfer/obj/compose.py:95
+msgid "Multiple Objects"
+msgstr "Πολλαπλά αντικείμενα"
+
+#: ../kupfer/obj/compose.py:126
+#, python-format
+msgid "%s object"
+msgid_plural "%s objects"
+msgstr[0] "%s αντικείμενο"
+msgstr[1] "%s αντικείμενα"
+
+#: ../kupfer/obj/contacts.py:129 ../kupfer/plugin/pidgin.py:156
+#, python-format
+msgid "[%(status)s] %(userid)s/%(service)s"
+msgstr "[%(status)s] %(userid)s/%(service)s"
+
+#: ../kupfer/obj/contacts.py:131
+msgid "unknown"
+msgstr "άγνωστο"
+
+#: ../kupfer/obj/contacts.py:144
+msgid "Aim"
+msgstr "Aim"
+
+#: ../kupfer/obj/contacts.py:151
+msgid "Google Talk"
+msgstr "Google Talk"
+
+#: ../kupfer/obj/contacts.py:159
+msgid "ICQ"
+msgstr "ICQ"
+
+#: ../kupfer/obj/contacts.py:166
+msgid "MSN"
+msgstr "MSN"
+
+#: ../kupfer/obj/contacts.py:173
+msgid "QQ"
+msgstr "QQ"
+
+#: ../kupfer/obj/contacts.py:180
+msgid "Yahoo"
+msgstr "Yahoo"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/obj/contacts.py:187 ../kupfer/plugin/skype.py:2
+msgid "Skype"
+msgstr "Skype"
+
+#: ../kupfer/obj/exceptions.py:19
+#, python-format
+msgid "%s does not support this operation"
+msgstr "το %s δεν υποστηρίζει αυτή τη λειτουργία"
+
+#: ../kupfer/obj/exceptions.py:24
+msgid "Can not be used with multiple objects"
+msgstr "Αδύνατη η χρήση του με πολλαπλά αντικείμενα"
+
+#: ../kupfer/obj/fileactions.py:30 ../kupfer/plugin/notes.py:89
+#: ../kupfer/plugin/gnome_terminal.py:36 ../kupfer/plugin/gtg.py:135
+#: ../kupfer/plugin/zim.py:176
+msgid "Open"
+msgstr "Άνοιγμα"
+
+#: ../kupfer/obj/fileactions.py:43
+#, python-format
+msgid "No default application for %(file)s (%(type)s)"
+msgstr "Χωρίς προεπιλεγμένη εφαρμογή για %(file)s (%(type)s)"
+
+#: ../kupfer/obj/fileactions.py:45
+#, python-format
+msgid "Please use \"%s\""
+msgstr "Παρακαλούμε χρησιμοποιήστε το \"%s\""
+
+#: ../kupfer/obj/fileactions.py:45 ../kupfer/plugin/applications.py:109
+msgid "Set Default Application..."
+msgstr "Ορισμός προεπιλεγμένης εφαρμογής..."
+
+#: ../kupfer/obj/fileactions.py:71
+msgid "Open with default application"
+msgstr "Άνοιγμα με την προεπιλεγμένη εφαρμογή"
+
+#: ../kupfer/obj/fileactions.py:74
+msgid "Reveal"
+msgstr "Αποκάλυψη"
+
+#: ../kupfer/obj/fileactions.py:83
+msgid "Open parent folder"
+msgstr "Άνοιγμα γονικού φακέλου"
+
+#: ../kupfer/obj/fileactions.py:89
+msgid "Open Terminal Here"
+msgstr "Άνοιγμα τερματικού εδώ"
+
+#: ../kupfer/obj/fileactions.py:102
+msgid "Open this location in a terminal"
+msgstr "Άνοιγμα αυτής της τοποθεσίας σε τερματικό"
+
+#: ../kupfer/obj/fileactions.py:110
+msgid "Run in Terminal"
+msgstr "Εκτέλεση σε τερματικό"
+
+#: ../kupfer/obj/fileactions.py:110
+msgid "Run (Execute)"
+msgstr "Τρέξιμο (εκτέλεση)"
+
+#: ../kupfer/obj/fileactions.py:130
+msgid "Run this program in a Terminal"
+msgstr "Εκτέλεση αυτού του προγράμματος σε τερματικό"
+
+#: ../kupfer/obj/fileactions.py:132
+msgid "Run this program"
+msgstr "Εκτέλεση αυτού του προγράμματος"
+
+#: ../kupfer/obj/objects.py:252 ../kupfer/plugin/windows.py:105
+#: ../kupfer/plugin/windows.py:264 ../kupfer/plugin/vim/plugin.py:172
+msgid "Go To"
+msgstr "Μετάβαση σε"
+
+#: ../kupfer/obj/objects.py:278
+msgid "Open URL"
+msgstr "Άνοιγμα URL"
+
+#: ../kupfer/obj/objects.py:289
+msgid "Open URL with default viewer"
+msgstr "Άνοιγμα URL με προεπιλεγμένη προβολή"
+
+#: ../kupfer/obj/objects.py:303
+msgid "Launch"
+msgstr "Έναρξη"
+
+#: ../kupfer/obj/objects.py:316
+msgid "Show application window"
+msgstr "Εμφάνιση παραθύρου εφαρμογής"
+
+#: ../kupfer/obj/objects.py:317
+msgid "Launch application"
+msgstr "Έναρξη εφαρμογής"
+
+#: ../kupfer/obj/objects.py:328
+msgid "Launch Again"
+msgstr "Έναρξη πάλι"
+
+#: ../kupfer/obj/objects.py:335
+msgid "Launch another instance of this application"
+msgstr "Έναρξη ενός άλλου στιγμιότυπου αυτής της εφαρμογής"
+
+#: ../kupfer/obj/objects.py:341 ../kupfer/plugin/windows.py:37
+msgid "Close"
+msgstr "Κλείσιμο"
+
+#: ../kupfer/obj/objects.py:349
+msgid "Attempt to close all application windows"
+msgstr "Προσπάθεια για κλείσιμο όλων των παραθύρων εφαρμογής"
+
+#. TRANS: 'Run' as in Perform a (saved) command
+#: ../kupfer/obj/objects.py:398
+msgid "Run"
+msgstr "Εκτέλεση"
+
+#: ../kupfer/obj/objects.py:408
+msgid "Perform command"
+msgstr "Εντολή εκτέλεσης"
+
+#: ../kupfer/obj/objects.py:421
+msgid "(Empty Text)"
+msgstr "(κενό κείμενο)"
+
+#. TRANS: This is description for a TextLeaf, a free-text search
+#. TRANS: The plural parameter is the number of lines %(num)d
+#: ../kupfer/obj/objects.py:451
+#, python-format
+msgid "\"%(text)s\""
+msgid_plural "(%(num)d lines) \"%(text)s\""
+msgstr[0] "\"%(text)s\""
+msgstr[1] "(%(num)d γραμμές) \"%(text)s\""
+
+#. TRANS: Multiple artist description "Artist1 et. al. "
+#: ../kupfer/obj/sources.py:24 ../kupfer/plugin/rhythmbox.py:247
+#, python-format
+msgid "%s et. al."
+msgstr "%s κ.α."
+
+#: ../kupfer/obj/sources.py:54
+#, python-format
+msgid "Recursive source of %(dir)s, (%(levels)d levels)"
+msgstr "Αναδρομική πηγή των %(dir)s, (%(levels)d επιπέδων)"
+
+#: ../kupfer/obj/sources.py:108
+#, python-format
+msgid "Directory source %s"
+msgstr "Προέλευση καταλόγου %s"
+
+#: ../kupfer/obj/sources.py:119
+msgid "Home Folder"
+msgstr "Προσωπικός φάκελος"
+
+#: ../kupfer/obj/sources.py:130
+msgid "Catalog Index"
+msgstr "Ευρετήριο καταλόγου"
+
+#: ../kupfer/obj/sources.py:145
+msgid "An index of all available sources"
+msgstr "Ένα ευρετήριο όλων των διαθέσιμων πηγών"
+
+#: ../kupfer/obj/sources.py:177
+msgid "Root catalog"
+msgstr "Πηγαίος κατάλογος"
+
+#: ../kupfer/obj/special.py:10
+msgid "Please Configure Plugin"
+msgstr "Παρακαλούμε, ρυθμίστε το πρόσθετο"
+
+#: ../kupfer/obj/special.py:11
+#, python-format
+msgid "Plugin %s is not configured"
+msgstr "Το πρόσθετο %s δεν ρυθμίστηκε"
+
+#: ../kupfer/obj/special.py:32
+#, python-format
+msgid "Invalid user credentials for %s"
+msgstr "Άκυρα διαπιστευτήρια χρήστη για το %s"
+
+#: ../kupfer/plugin/applications.py:2 ../kupfer/plugin/applications.py:38
+msgid "Applications"
+msgstr "Εφαρμογές"
+
+#: ../kupfer/plugin/applications.py:8 ../kupfer/plugin/applications.py:74
+msgid "All applications and preferences"
+msgstr "Όλες οι εφαρμογές και προτιμήσεις"
+
+#: ../kupfer/plugin/applications.py:23
+msgid "Applications for Desktop Environment"
+msgstr "Εφαρμογές για το περιβάλλον επιφάνειας εργασίας"
+
+#: ../kupfer/plugin/applications.py:83
+msgid "Open With..."
+msgstr "Άνοιγμα με..."
+
+#: ../kupfer/plugin/applications.py:105
+msgid "Open with any application"
+msgstr "Άνοιγμα με οποιαδήποτε εφαρμογή"
+
+#: ../kupfer/plugin/applications.py:124
+msgid "Set default application to open this file type"
+msgstr "Ορισμός προεπιλεγμένης εφαρμογής για άνοιγμα με αυτόν τον τύπο αρχείου"
+
+#: ../kupfer/plugin/archivemanager.py:1
+msgid "Archive Manager"
+msgstr "Διαχειριστής αρχειοθήκης"
+
+#: ../kupfer/plugin/archivemanager.py:9
+msgid "Use Archive Manager actions"
+msgstr "Χρήση ενεργειών διαχειριστή αρχειοθήκης"
+
+#: ../kupfer/plugin/archivemanager.py:27
+msgid "Compressed archive type for 'Create Archive In'"
+msgstr "Τύπος συμπιεσμένης αρχειοθήκης για 'Δημιουργία αρχειοθήκης σε'"
+
+#: ../kupfer/plugin/archivemanager.py:44
+msgid "Extract Here"
+msgstr "Αποσυμπίεση εδώ"
+
+#: ../kupfer/plugin/archivemanager.py:64
+msgid "Extract compressed archive"
+msgstr "Εξαγωγή συμπιεσμένης αρχειοθήκης"
+
+#: ../kupfer/plugin/archivemanager.py:70
+msgid "Create Archive"
+msgstr "Δημιουργία αρχειοθήκης"
+
+#: ../kupfer/plugin/archivemanager.py:86
+#: ../kupfer/plugin/archivemanager.py:129
+msgid "Create a compressed archive from folder"
+msgstr "Δημιουργία συμπιεσμένης αρχειοθήκης από φάκελο"
+
+#: ../kupfer/plugin/archivemanager.py:92
+msgid "Create Archive In..."
+msgstr "Δημιουργία αρχειοθήκης σε..."
+
+#. TRANS: Default filename (no extension) for 'Create Archive In...'
+#: ../kupfer/plugin/archivemanager.py:115
+msgid "Archive"
+msgstr "Αρχειοθήκη"
+
+#: ../kupfer/plugin/calculator.py:2 ../kupfer/plugin/calculator.py:69
+msgid "Calculator"
+msgstr "Αριθμομηχανή"
+
+#: ../kupfer/plugin/calculator.py:4
+msgid "Calculate expressions starting with '='"
+msgstr "Υπολογισμός εκφράσεων που ξεκινούν με '='"
+
+#: ../kupfer/plugin/calculator.py:101
+msgid "Calculate"
+msgstr "Υπολογισμός"
+
+#: ../kupfer/plugin/clipboard.py:1 ../kupfer/plugin/clipboard.py:112
+msgid "Clipboards"
+msgstr "Πρόχειρα"
+
+#: ../kupfer/plugin/clipboard.py:4
+msgid "Recent clipboards and clipboard proxy objects"
+msgstr "Πρόσφατα πρόχειρα και αντικείμενα μεσολαβητή προχείρων"
+
+#: ../kupfer/plugin/clipboard.py:24
+msgid "Number of recent clipboards to remember"
+msgstr "Αριθμός πρόσφατων προχείρων για απομνημόνευση"
+
+#: ../kupfer/plugin/clipboard.py:30
+msgid "Include selected text in clipboard history"
+msgstr "Να συμπεριλαμβάνεται το επιλεγμένο κείμενο στο ιστορικό προχείρου"
+
+#: ../kupfer/plugin/clipboard.py:36
+msgid "Copy selected text to primary clipboard"
+msgstr "Αντιγραφή επιλεγμένου κειμένου στο κύριο πρόχειρο"
+
+#: ../kupfer/plugin/clipboard.py:47
+msgid "Selected Text"
+msgstr "Επιλεγμένο κείμενο"
+
+#: ../kupfer/plugin/clipboard.py:57
+#, python-format
+msgid "Clipboard \"%(desc)s\""
+msgid_plural "Clipboard with %(num)d lines \"%(desc)s\""
+msgstr[0] "Πρόχειρο \"%(desc)s\""
+msgstr[1] "Πρόχειρο με %(num)d γραμμές \"%(desc)s\""
+
+#: ../kupfer/plugin/clipboard.py:64
+msgid "Clipboard Text"
+msgstr "Κείμενο προχείρου"
+
+#: ../kupfer/plugin/clipboard.py:74
+msgid "Clipboard File"
+msgstr "Αρχείο προχείρου"
+
+#: ../kupfer/plugin/clipboard.py:84
+msgid "Clipboard Files"
+msgstr "Αρχεία προχείρου"
+
+#: ../kupfer/plugin/clipboard.py:92
+msgid "Clear"
+msgstr "Καθαρισμός"
+
+#: ../kupfer/plugin/clipboard.py:104
+msgid "Remove all recent clipboards"
+msgstr "Αφαίρεση όλων των πρόσφατων προχείρων"
+
+#: ../kupfer/plugin/commands.py:1 ../kupfer/plugin/commands.py:187
+msgid "Shell Commands"
+msgstr "Εντολές φλοιού"
+
+#: ../kupfer/plugin/commands.py:9
+#, python-format
+msgid ""
+"Run command-line programs. Actions marked with the symbol %s run in a "
+"subshell."
+msgstr ""
+"Εκτέλεση προγραμμάτων γραμμής εντολών. Οι ενέργειες που σημειώθηκαν με το "
+"σύμβολο %s εκτελούνται σε έναν υποφλοιό."
+
+#: ../kupfer/plugin/commands.py:41
+msgid "Run (Get Output)"
+msgstr "Εκτέλεση (λήψη εξόδου)"
+
+#: ../kupfer/plugin/commands.py:59
+msgid "Run program and return its output"
+msgstr "Εκτέλεση προγράμματος και επιστροφή της εξόδου του"
+
+#. TRANS: The user starts a program (command) and the text
+#. TRANS: is an argument to the command
+#: ../kupfer/plugin/commands.py:65
+msgid "Pass to Command..."
+msgstr "Πέρασμα στην εντολή..."
+
+#: ../kupfer/plugin/commands.py:107
+msgid "Run program with object as an additional parameter"
+msgstr "Εκτέλεση προγράμματος με αντικείμενο ως μία πρόσθετη παράμετρος"
+
+#. TRANS: The user starts a program (command) and
+#. TRANS: the text is written on stdin
+#: ../kupfer/plugin/commands.py:115
+msgid "Write to Command..."
+msgstr "Εγγραφή στην εντολή..."
+
+#: ../kupfer/plugin/commands.py:149 ../kupfer/plugin/commands.py:161
+msgid "Run program and supply text on the standard input"
+msgstr "Εκτέλεση προγράμματος και τροφοδοσία κειμένου στην τυπική είσοδο"
+
+#. TRANS: The user starts a program (command) and
+#. TRANS: the text is written on stdin, and we
+#. TRANS: present the output (stdout) to the user.
+#: ../kupfer/plugin/commands.py:157
+msgid "Filter through Command..."
+msgstr "Φιλτράρισμα μέσα από την εντολή..."
+
+#: ../kupfer/plugin/commands.py:215
+msgid "Run command-line programs"
+msgstr "Εκτέλεση προγραμμάτων γραμμής εντολών"
+
+#: ../kupfer/plugin/core/alternatives.py:7
+msgid "GTK+"
+msgstr "GTK+"
+
+#: ../kupfer/plugin/core/alternatives.py:13
+msgid "GNOME Terminal"
+msgstr "Τερματικό GNOME"
+
+#: ../kupfer/plugin/core/alternatives.py:22
+msgid "XFCE Terminal"
+msgstr "Τερματικό XFCE"
+
+#: ../kupfer/plugin/core/alternatives.py:31
+msgid "LXTerminal"
+msgstr "Τερματικό LX"
+
+#: ../kupfer/plugin/core/alternatives.py:40
+msgid "X Terminal"
+msgstr "Τερματικό Χ"
+
+#: ../kupfer/plugin/core/alternatives.py:49
+msgid "Urxvt"
+msgstr "Urxvt"
+
+#: ../kupfer/plugin/core/alternatives.py:58
+msgid "Konsole"
+msgstr "Κονσόλα"
+
+#: ../kupfer/plugin/core/commands.py:13 ../kupfer/plugin/core/commands.py:32
+msgid "Save As..."
+msgstr "Αποθήκευση ως..."
+
+#: ../kupfer/plugin/core/contents.py:41
+msgid "Quit"
+msgstr "Έξοδος"
+
+#: ../kupfer/plugin/core/contents.py:46
+msgid "Quit Kupfer"
+msgstr "Έξοδος από το Kupfer"
+
+#: ../kupfer/plugin/core/contents.py:52
+msgid "About Kupfer"
+msgstr "Σχετικά με το Kupfer"
+
+#: ../kupfer/plugin/core/contents.py:59
+msgid "Show information about Kupfer authors and license"
+msgstr "Εμφάνιση πληροφοριών για τους συγγραφείς του Kupfer και την άδεια"
+
+#: ../kupfer/plugin/core/contents.py:65
+msgid "Kupfer Help"
+msgstr "Βοήθεια Kupfer"
+
+#: ../kupfer/plugin/core/contents.py:72
+msgid "Get help with Kupfer"
+msgstr "Λήψη βοήθειας με το Kupfer"
+
+#: ../kupfer/plugin/core/contents.py:85
+msgid "Show preferences window for Kupfer"
+msgstr "Εμφάνιση παραθύρου προτιμήσεων για το Kupfer"
+
+#: ../kupfer/plugin/core/__init__.py:64
+msgid "Search Contents"
+msgstr "Αναζήτηση περιεχομένων"
+
+#: ../kupfer/plugin/core/__init__.py:82
+msgid "Search inside this catalog"
+msgstr "Αναζήτηση μέσα σε αυτόν τον κατάλογο"
+
+#: ../kupfer/plugin/core/__init__.py:90
+msgid "Copy"
+msgstr "Αντιγραφή"
+
+#: ../kupfer/plugin/core/__init__.py:105
+msgid "Copy to clipboard"
+msgstr "Αντιγραφή στο πρόχειρο"
+
+#: ../kupfer/plugin/core/__init__.py:127
+msgid "Rescan"
+msgstr "Επανασάρωση"
+
+#: ../kupfer/plugin/core/__init__.py:142
+msgid "Force reindex of this source"
+msgstr "Αναγκαστική επαναευρετηριοποίηση αυτής της πηγής"
+
+#: ../kupfer/plugin/core/internal.py:13
+msgid "Last Command"
+msgstr "Τελευταία εντολή"
+
+#: ../kupfer/plugin/core/internal.py:24
+msgid "Internal Kupfer Objects"
+msgstr "Εσωτερικά αντικείμενα Kupfer"
+
+#: ../kupfer/plugin/core/internal.py:46 ../kupfer/plugin/core/internal.py:48
+msgid "Last Result"
+msgstr "Τελευταίο αποτέλεσμα"
+
+#: ../kupfer/plugin/core/internal.py:66
+msgid "Command Results"
+msgstr "Αποτελέσματα εντολής"
+
+#: ../kupfer/plugin/dictionary.py:1 ../kupfer/plugin/dictionary.py:21
+msgid "Dictionary"
+msgstr "Λεξικό"
+
+#: ../kupfer/plugin/dictionary.py:3 ../kupfer/plugin/dictionary.py:47
+msgid "Look up word in dictionary"
+msgstr "Αναζήτηση λέξης σε λεξικό"
+
+#: ../kupfer/plugin/dictionary.py:30
+msgid "Look Up"
+msgstr "Αναζήτηση"
+
+#: ../kupfer/plugin/documents.py:1
+msgid "Documents"
+msgstr "Έγγραφα"
+
+#: ../kupfer/plugin/documents.py:4
+msgid "Recently used documents and bookmarked folders"
+msgstr "Πρόσφατα χρησιμοποιημένα έγγραφα και φάκελοι με σελιδοδείκτες"
+
+#: ../kupfer/plugin/documents.py:22
+msgid "Max recent document days"
+msgstr "Μέγιστος αριθμός ημερών για πρόσφατα έγγραφα"
+
+#: ../kupfer/plugin/documents.py:32
+msgid "Recent Items"
+msgstr "Πρόσφατα στοιχεία"
+
+#: ../kupfer/plugin/documents.py:78
+msgid "Recently used documents"
+msgstr "Πρόσφατα χρησιμοποιημένα αρχεία"
+
+#: ../kupfer/plugin/documents.py:88
+#, python-format
+msgid "%s Documents"
+msgstr "%s Έγγραφα"
+
+#: ../kupfer/plugin/documents.py:113
+#, python-format
+msgid "Recently used documents for %s"
+msgstr "Πρόσφατα χρησιμοποιημένα έγγραφα για %s"
+
+#: ../kupfer/plugin/documents.py:132
+msgid "Places"
+msgstr "Τοποθεσίες"
+
+#: ../kupfer/plugin/documents.py:164
+msgid "Bookmarked folders"
+msgstr "Φάκελοι με σελιδοδείκτες"
+
+#: ../kupfer/plugin/epiphany.py:1 ../kupfer/plugin/epiphany.py:18
+msgid "Epiphany Bookmarks"
+msgstr "Σελιδοδείκτες Epiphany"
+
+#: ../kupfer/plugin/epiphany.py:3 ../kupfer/plugin/epiphany.py:35
+msgid "Index of Epiphany bookmarks"
+msgstr "Ευρετήριο σελιδοδεικτών του Epiphany"
+
+#: ../kupfer/plugin/favorites.py:1 ../kupfer/plugin/favorites.py:21
+msgid "Favorites"
+msgstr "Αγαπημένα"
+
+#: ../kupfer/plugin/favorites.py:4
+msgid "Mark commonly used items and store objects for later use"
+msgstr ""
+"Σημείωση κοινών χρησιμοποιούμενων στοιχείων και αποθήκευση αντικειμένων για "
+"μεταγενέστερη χρήση"
+
+#: ../kupfer/plugin/favorites.py:127
+msgid "Shelf of \"Favorite\" items"
+msgstr "Ράφι των στοιχείων \"Αγαπημένα\""
+
+#: ../kupfer/plugin/favorites.py:140
+msgid "Add to Favorites"
+msgstr "Προσθήκη στα αγαπημένα"
+
+#: ../kupfer/plugin/favorites.py:148
+msgid "Add item to favorites shelf"
+msgstr "Προσθήκη στοιχείου στο ράφι αγαπημένων"
+
+#: ../kupfer/plugin/favorites.py:155
+msgid "Remove from Favorites"
+msgstr "Απομάκρυνση από τα αγαπημένα"
+
+#: ../kupfer/plugin/favorites.py:163
+msgid "Remove item from favorites shelf"
+msgstr "Αφαίρεση στοιχείου από το ράφι αγαπημένων"
+
+#: ../kupfer/plugin/fileactions.py:1
+msgid "File Actions"
+msgstr "Ενέργειες αρχείου"
+
+#: ../kupfer/plugin/fileactions.py:9
+msgid "More file actions"
+msgstr "Περισσότερες ενέργειες αρχείου"
+
+#: ../kupfer/plugin/fileactions.py:40 ../kupfer/plugin/windows.py:122
+#: ../kupfer/plugin/thunar.py:211
+msgid "Move To..."
+msgstr "Μετακίνηση σε..."
+
+#: ../kupfer/plugin/fileactions.py:67 ../kupfer/plugin/thunar.py:253
+msgid "Move file to new location"
+msgstr "Μετακίνηση αρχείου σε νέα τοποθεσία"
+
+#: ../kupfer/plugin/fileactions.py:80 ../kupfer/plugin/fileactions.py:103
+msgid "Rename To..."
+msgstr "Μετονομασία σε..."
+
+#: ../kupfer/plugin/fileactions.py:145 ../kupfer/plugin/thunar.py:166
+msgid "Copy To..."
+msgstr "Αντιγραφή σε..."
+
+#: ../kupfer/plugin/fileactions.py:186 ../kupfer/plugin/thunar.py:207
+msgid "Copy file to a chosen location"
+msgstr "Αντιγραφή αρχείου σε επιλεγμένη θέση"
+
+#: ../kupfer/plugin/firefox.py:4 ../kupfer/plugin/firefox.py:61
+msgid "Firefox Bookmarks"
+msgstr "Σελιδοδείκτες Firefox"
+
+#: ../kupfer/plugin/firefox.py:6 ../kupfer/plugin/firefox.py:147
+msgid "Index of Firefox bookmarks"
+msgstr "Ευρετήριο σελιδοδεικτών του Firefox"
+
+#: ../kupfer/plugin/firefox.py:26
+msgid "Include visited sites"
+msgstr "Να συμπεριλαμβάνονται οι τόποι που επισκέφτηκαν"
+
+#: ../kupfer/plugin/firefox.py:44
+msgid "Firefox tag"
+msgstr "Ετικέτα Firefox"
+
+#. TRANS: Multihead refers to support for multiple computer displays
+#. TRANS: In this case, it only concerns the special configuration
+#. TRANS: with multiple X "screens"
+#: ../kupfer/plugin/multihead.py:4
+msgid "Multihead Support"
+msgstr "Υποστήριξη πολλαπλής κεφαλής"
+
+#: ../kupfer/plugin/notes.py:6 ../kupfer/plugin/notes.py:178
+#: ../kupfer/plugin/notes.py:230
+msgid "Notes"
+msgstr "Σημειώσεις"
+
+#: ../kupfer/plugin/notes.py:13
+msgid "Gnote or Tomboy notes"
+msgstr "Σημειώσεις Gnote ή Tomboy"
+
+#: ../kupfer/plugin/notes.py:35
+msgid "Work with application"
+msgstr "Εργασία με την εφαρμογή"
+
+#: ../kupfer/plugin/notes.py:95
+msgid "Open with notes application"
+msgstr "Άνοιγμα με εφαρμογή σημειώσεων"
+
+#: ../kupfer/plugin/notes.py:102
+msgid "Append to Note..."
+msgstr "Προσάρτηση στη σημείωση..."
+
+#: ../kupfer/plugin/notes.py:125
+msgid "Add text to existing note"
+msgstr "Προσθήκη κειμένου στην υπάρχουσα σημείωση"
+
+#: ../kupfer/plugin/notes.py:140
+msgid "Create Note"
+msgstr "Δημιουργία σημείωσης"
+
+#: ../kupfer/plugin/notes.py:154
+msgid "Create a new note from this text"
+msgstr "Δημιουργία νέας σημείωσης από αυτό το κείμενο"
+
+#: ../kupfer/plugin/notes.py:160
+msgid "Get Note Search Results..."
+msgstr "Λήψη αποτελεσμάτων αναζήτησης σημείωσης..."
+
+#: ../kupfer/plugin/notes.py:173
+msgid "Show search results for this query"
+msgstr "Εμφάνιση αποτελεσμάτων αναζήτησης για αυτό το ερώτημα"
+
+#: ../kupfer/plugin/notes.py:213
+#, python-format
+msgid "today, %s"
+msgstr "σήμερα, %s"
+
+#: ../kupfer/plugin/notes.py:215
+#, python-format
+msgid "yesterday, %s"
+msgstr "χτες, %s"
+
+#. TRANS: Note description, %s is last changed time in locale format
+#: ../kupfer/plugin/notes.py:219
+#, python-format
+msgid "Last updated %s"
+msgstr "Τελευταία ενημέρωση του %s"
+
+#: ../kupfer/plugin/rhythmbox.py:1 ../kupfer/plugin/rhythmbox.py:399
+msgid "Rhythmbox"
+msgstr "Rhythmbox"
+
+#: ../kupfer/plugin/rhythmbox.py:3 ../kupfer/plugin/rhythmbox.py:433
+msgid "Play and enqueue tracks and browse the music library"
+msgstr ""
+"Αναπαραγωγή, τοποθέτηση κομματιών σε αναμονή και περιήγηση της μουσικής "
+"βιβλιοθήκης"
+
+#: ../kupfer/plugin/rhythmbox.py:22
+msgid "Include artists in top level"
+msgstr "Να συμπεριλαμβάνονται οι καλλιτέχνες στο κορυφαίο επίπεδο"
+
+#: ../kupfer/plugin/rhythmbox.py:28
+msgid "Include albums in top level"
+msgstr "Να συμπεριλαμβάνονται οι δίσκοι στο κορυφαίο επίπεδο"
+
+#: ../kupfer/plugin/rhythmbox.py:34 ../kupfer/plugin/audacious.py:20
+msgid "Include songs in top level"
+msgstr "Να συμπεριλαμβάνονται τα τραγούδια στο κορυφαίο επίπεδο"
+
+#: ../kupfer/plugin/rhythmbox.py:63 ../kupfer/plugin/rhythmbox.py:131
+#: ../kupfer/plugin/audacious.py:82 ../kupfer/plugin/audacious.py:92
+msgid "Play"
+msgstr "Αναπαραγωγή"
+
+#: ../kupfer/plugin/rhythmbox.py:67
+msgid "Resume playback in Rhythmbox"
+msgstr "Συνέχιση αναπαραγωγής στο Rhythmbox"
+
+#: ../kupfer/plugin/rhythmbox.py:73 ../kupfer/plugin/audacious.py:102
+#: ../kupfer/plugin/virtualbox/__init__.py:93
+msgid "Pause"
+msgstr "Παύση"
+
+#: ../kupfer/plugin/rhythmbox.py:77
+msgid "Pause playback in Rhythmbox"
+msgstr "Παύση αναπαραγωγής στο Rhythmbox"
+
+#: ../kupfer/plugin/rhythmbox.py:83 ../kupfer/plugin/audacious.py:112
+msgid "Next"
+msgstr "Επόμενο"
+
+#: ../kupfer/plugin/rhythmbox.py:87
+msgid "Jump to next track in Rhythmbox"
+msgstr "Μετάβαση στο επόμενο κομμάτι στο Rhythmbox"
+
+#: ../kupfer/plugin/rhythmbox.py:93 ../kupfer/plugin/audacious.py:122
+msgid "Previous"
+msgstr "Προηγούμενο"
+
+#: ../kupfer/plugin/rhythmbox.py:97
+msgid "Jump to previous track in Rhythmbox"
+msgstr "Μετάβαση στο προηγούμενο κομμάτι στο Rhythmbox"
+
+#: ../kupfer/plugin/rhythmbox.py:103
+msgid "Show Playing"
+msgstr "Εμφάνιση αναπαραγωγής"
+
+#: ../kupfer/plugin/rhythmbox.py:107
+msgid "Tell which song is currently playing"
+msgstr "Να λέει ποιο τραγούδι αναπαράγεται τώρα"
+
+#: ../kupfer/plugin/rhythmbox.py:115 ../kupfer/plugin/audacious.py:132
+msgid "Clear Queue"
+msgstr "Καθαρισμός αναμονής"
+
+#: ../kupfer/plugin/rhythmbox.py:155
+msgid "Play tracks in Rhythmbox"
+msgstr "Αναπαραγωγή κομματιών στο Rhythmbox"
+
+#: ../kupfer/plugin/rhythmbox.py:161 ../kupfer/plugin/audacious.py:58
+msgid "Enqueue"
+msgstr "Σε αναμονή"
+
+#: ../kupfer/plugin/rhythmbox.py:172
+msgid "Add tracks to the play queue"
+msgstr "Προσθήκη κομματιών στη σειρά αναπαραγωγής"
+
+#. TRANS: Song description
+#: ../kupfer/plugin/rhythmbox.py:195
+#, python-format
+msgid "by %(artist)s from %(album)s"
+msgstr "κατά %(artist)s από %(album)s"
+
+#. TRANS: Album description "by Artist"
+#: ../kupfer/plugin/rhythmbox.py:250
+#, python-format
+msgid "by %s"
+msgstr "κατά %s"
+
+#. TRANS: Artist songs collection description
+#: ../kupfer/plugin/rhythmbox.py:311
+#, python-format
+msgid "Tracks by %s"
+msgstr "Κομμάτια κατά %s"
+
+#: ../kupfer/plugin/rhythmbox.py:321
+#: ../kupfer/plugin/google_picasa/__init__.py:444
+msgid "Albums"
+msgstr "Δίσκοι"
+
+#: ../kupfer/plugin/rhythmbox.py:331
+msgid "Music albums in Rhythmbox Library"
+msgstr "Μουσικοί δίσκοι στη βιβλιοθήκη Rhythmbox"
+
+#: ../kupfer/plugin/rhythmbox.py:342
+msgid "Artists"
+msgstr "Καλλιτέχνες"
+
+#: ../kupfer/plugin/rhythmbox.py:352
+msgid "Music artists in Rhythmbox Library"
+msgstr "Μουσικοί καλλιτέχνες στη βιβλιοθήκη Rhythmbox"
+
+#: ../kupfer/plugin/rhythmbox.py:379
+msgid "Songs"
+msgstr "Τραγούδια"
+
+#: ../kupfer/plugin/rhythmbox.py:389
+msgid "Songs in Rhythmbox library"
+msgstr "Τραγούδια στη βιβλιοθήκη Rhythmbox"
+
+#: ../kupfer/plugin/session_gnome.py:1 ../kupfer/plugin/session_gnome.py:20
+msgid "GNOME Session Management"
+msgstr "Διαχείριση συνεδρίας GNOME"
+
+#: ../kupfer/plugin/session_gnome.py:3
+msgid "Special items and actions for GNOME environment"
+msgstr "Ειδικά στοιχεία και ενέργειες για περιβάλλον GNOME"
+
+#: ../kupfer/plugin/session_support.py:31
+msgid "Log Out..."
+msgstr "Αποσύνδεση..."
+
+#: ../kupfer/plugin/session_support.py:34
+msgid "Log out or change user"
+msgstr "Αποσύνδεση ή αλλαγή χρήστη"
+
+#: ../kupfer/plugin/session_support.py:41
+msgid "Shut Down..."
+msgstr "Τερματισμός..."
+
+#: ../kupfer/plugin/session_support.py:44
+msgid "Shut down, restart or suspend computer"
+msgstr "Τερματισμός, επανεκκίνηση ή αναστολή υπολογιστή"
+
+#: ../kupfer/plugin/session_support.py:51
+msgid "Lock Screen"
+msgstr "Κλείδωμα οθόνης"
+
+#: ../kupfer/plugin/session_support.py:54
+msgid "Enable screensaver and lock"
+msgstr "Ενεργοποίηση προφύλαξης οθόνης και κλείδωμα"
+
+#. -*- coding: utf-8 -*
+#: ../kupfer/plugin/session_xfce.py:3 ../kupfer/plugin/session_xfce.py:20
+msgid "XFCE Session Management"
+msgstr "Διαχείριση συνεδρίας XFCE"
+
+#: ../kupfer/plugin/session_xfce.py:5
+msgid "Special items and actions for XFCE environment"
+msgstr "Ειδικά στοιχεία και ενέργειες για περιβάλλον XFCE"
+
+#: ../kupfer/plugin/show_text.py:1 ../kupfer/plugin/show_text.py:18
+#: ../kupfer/plugin/show_text.py:25
+msgid "Show Text"
+msgstr "Εμφάνιση κειμένου"
+
+#: ../kupfer/plugin/show_text.py:7 ../kupfer/plugin/show_text.py:31
+#: ../kupfer/plugin/show_text.py:58
+msgid "Display text in a window"
+msgstr "Εμφάνιση κειμένου σε παράθυρο"
+
+#: ../kupfer/plugin/show_text.py:37
+msgid "Large Type"
+msgstr "Μεγάλος τύπος"
+
+#: ../kupfer/plugin/show_text.py:66
+msgid "Show Notification"
+msgstr "Εμφάνιση ειδοποίησης"
+
+#: ../kupfer/plugin/trash.py:1 ../kupfer/plugin/trash.py:173
+msgid "Trash"
+msgstr "Απορρίμματα"
+
+#: ../kupfer/plugin/trash.py:4
+msgid "Access trash contents"
+msgstr "Πρόσβαση στα περιεχόμενα απορριμμάτων"
+
+#: ../kupfer/plugin/trash.py:23
+msgid "Move to Trash"
+msgstr "Μετακίνηση στα απορρίμματα"
+
+#: ../kupfer/plugin/trash.py:39
+msgid "Move this file to trash"
+msgstr "Μεταφορά αυτού του αρχείου στα απορρίμματα"
+
+#: ../kupfer/plugin/trash.py:48
+msgid "Restore"
+msgstr "Επαναφορά"
+
+#: ../kupfer/plugin/trash.py:67
+msgid "Move file back to original location"
+msgstr "Μετακίνηση αρχείου πίσω στην αρχική θέση"
+
+#: ../kupfer/plugin/trash.py:161
+msgid "Trash is empty"
+msgstr "Τα απορρίμματα είναι άδεια"
+
+#. proper translation of plural
+#: ../kupfer/plugin/trash.py:163
+#, python-format
+msgid "Trash contains one file"
+msgid_plural "Trash contains %(num)s files"
+msgstr[0] "Τα απορρίμματα περιέχουν ένα αρχείο"
+msgstr[1] "Τα απορρίμματα περιέχουν %(num)s αρχεία"
+
+#: ../kupfer/plugin/triggers.py:1 ../kupfer/plugin/triggers.py:50
+msgid "Triggers"
+msgstr "Εναύσματα"
+
+#: ../kupfer/plugin/triggers.py:6
+msgid ""
+"Assign global keybindings (triggers) to objects created with 'Compose "
+"Command'."
+msgstr ""
+"Απόδοση γενικών συνδυασμών πλήκτρων (εναύσματα) σε αντικείμενα που "
+"δημιουργήθηκαν με την 'εντολή σύνθεση'."
+
+#: ../kupfer/plugin/triggers.py:161
+msgid "Add Trigger..."
+msgstr "Προσθήκη εναύσματος..."
+
+#: ../kupfer/plugin/triggers.py:180
+msgid "Remove Trigger"
+msgstr "Αφαίρεση εναύσματος"
+
+#: ../kupfer/plugin/urlactions.py:1 ../kupfer/plugin/urlactions.py:8
+msgid "URL Actions"
+msgstr "Ενέργειες URL"
+
+#: ../kupfer/plugin/urlactions.py:63
+msgid "Download and Open"
+msgstr "Μεταφόρτωση και άνοιγμα"
+
+#: ../kupfer/plugin/urlactions.py:83
+msgid "Download To..."
+msgstr "Μεταφόρτωση σε..."
+
+#: ../kupfer/plugin/urlactions.py:104
+msgid "Download URL to a chosen location"
+msgstr "Μεταφόρτωση URL σε μια επιλεγμένη θέση"
+
+#: ../kupfer/plugin/volumes.py:1 ../kupfer/plugin/volumes.py:91
+msgid "Volumes and Disks"
+msgstr "Τόμοι και δίσκοι"
+
+#: ../kupfer/plugin/volumes.py:3 ../kupfer/plugin/volumes.py:101
+msgid "Mounted volumes and disks"
+msgstr "Προσαρτημένοι τόμοι και δίσκοι"
+
+#: ../kupfer/plugin/volumes.py:42
+#, python-format
+msgid "Volume mounted at %s"
+msgstr "Τόμος προσαρτημένος στο %s"
+
+#: ../kupfer/plugin/volumes.py:51
+msgid "Unmount"
+msgstr "Αποπροσάρτηση"
+
+#: ../kupfer/plugin/volumes.py:78
+msgid "Unmount this volume"
+msgstr "Προσάρτηση αυτού του τόμου"
+
+#: ../kupfer/plugin/volumes.py:85
+msgid "Eject"
+msgstr "Εξαγωγή"
+
+#: ../kupfer/plugin/volumes.py:88
+msgid "Unmount and eject this media"
+msgstr "Αποπροσάρτηση και εξαγωγή αυτού του μέσου"
+
+#: ../kupfer/plugin/websearch.py:1
+msgid "Search the Web"
+msgstr "Αναζήτηση στον ιστό"
+
+#: ../kupfer/plugin/websearch.py:8 ../kupfer/plugin/websearch.py:63
+#: ../kupfer/plugin/websearch.py:90
+msgid "Search the web with OpenSearch search engines"
+msgstr "Αναζήτηση στον ιστό με μηχανές αναζήτησης OpenSearch"
+
+#: ../kupfer/plugin/websearch.py:44
+msgid "Search With..."
+msgstr "Αναζήτηση με..."
+
+#: ../kupfer/plugin/websearch.py:73
+msgid "Search For..."
+msgstr "Αναζήτηση για..."
+
+#: ../kupfer/plugin/websearch.py:114
+msgid "Search Engines"
+msgstr "Μηχανές αναζήτησης"
+
+#: ../kupfer/plugin/wikipedia.py:5
+msgid "Wikipedia"
+msgstr "Βικιπαίδεια"
+
+#: ../kupfer/plugin/wikipedia.py:8 ../kupfer/plugin/wikipedia.py:31
+msgid "Search in Wikipedia"
+msgstr "Αναζήτηση στη βικιπαίδεια"
+
+#: ../kupfer/plugin/wikipedia.py:21
+msgid "Wikipedia language"
+msgstr "Γλώσσα βικιπαίδειας"
+
+#. TRANS: Default wikipedia language code
+#: ../kupfer/plugin/wikipedia.py:24
+msgid "en"
+msgstr "el"
+
+#: ../kupfer/plugin/wikipedia.py:44
+#, python-format
+msgid "Search for this term in %s.wikipedia.org"
+msgstr "Αναζήτηση για αυτόν τον όρο στο %s.wikipedia.org"
+
+#: ../kupfer/plugin/windows.py:1 ../kupfer/plugin/windows.py:210
+msgid "Window List"
+msgstr "Λίστα παραθύρων"
+
+#: ../kupfer/plugin/windows.py:3 ../kupfer/plugin/windows.py:233
+msgid "All windows on all workspaces"
+msgstr "Όλα τα παράθυρα σε όλους τους χώρους εργασίας"
+
+#: ../kupfer/plugin/windows.py:18
+msgid "Activate"
+msgstr "Ενεργοποίηση"
+
+#: ../kupfer/plugin/windows.py:22
+msgid "Shade"
+msgstr "Σκίαση"
+
+#: ../kupfer/plugin/windows.py:22
+msgid "Unshade"
+msgstr "Αποσκίαση"
+
+#: ../kupfer/plugin/windows.py:25
+msgid "Minimize"
+msgstr "Ελαχιστοποίηση"
+
+#: ../kupfer/plugin/windows.py:25
+msgid "Unminimize"
+msgstr "Απελαχιστοποίηση"
+
+#: ../kupfer/plugin/windows.py:29
+msgid "Maximize"
+msgstr "Μεγιστοποίηση"
+
+#: ../kupfer/plugin/windows.py:29
+msgid "Unmaximize"
+msgstr "Aπομεγιστοποίηση"
+
+#: ../kupfer/plugin/windows.py:33
+msgid "Maximize Vertically"
+msgstr "Κάθετη μεγιστοποίηση"
+
+#: ../kupfer/plugin/windows.py:33
+msgid "Unmaximize Vertically"
+msgstr "Κάθετη απομεγιστοποίηση"
+
+#. TRANS: Window on (Workspace name), window description
+#: ../kupfer/plugin/windows.py:48
+#, python-format
+msgid "Window on %(wkspc)s"
+msgstr "Παράθυρο στο %(wkspc)s"
+
+#: ../kupfer/plugin/windows.py:56
+msgid "Frontmost Window"
+msgstr "Το πιο μπροστινό παράθυρο"
+
+#: ../kupfer/plugin/windows.py:85
+msgid "Next Window"
+msgstr "Επόμενο παράθυρο"
+
+#: ../kupfer/plugin/windows.py:116
+msgid "Jump to this window's workspace and focus"
+msgstr "Μετάβαση σε αυτό τον χώρο εργασίας του παραθύρου και εστίαση"
+
+#: ../kupfer/plugin/windows.py:252
+#, python-format
+msgid "%d window"
+msgid_plural "%d windows"
+msgstr[0] "%d παράθυρο"
+msgstr[1] "%d παράθυρα"
+
+#: ../kupfer/plugin/windows.py:256
+msgid "Active workspace"
+msgstr "Ενεργός χώρος εργασίας"
+
+#: ../kupfer/plugin/windows.py:274
+msgid "Jump to this workspace"
+msgstr "Μετάβαση σε αυτόν τον χώρο εργασίας"
+
+#: ../kupfer/plugin/windows.py:281
+msgid "Workspaces"
+msgstr "Χώροι εργασίας"
+
+#: ../kupfer/plugin/abiword.py:1
+msgid "Abiword"
+msgstr "Abiword"
+
+#: ../kupfer/plugin/abiword.py:3 ../kupfer/plugin/abiword.py:88
+msgid "Recently used documents in Abiword"
+msgstr "Πρόσφατα χρησιμοποιημένα έγγραφα στο Abiword"
+
+#: ../kupfer/plugin/abiword.py:34
+msgid "Abiword Recent Items"
+msgstr "Πρόσφατα στοιχεία Abiword"
+
+#: ../kupfer/plugin/apt_tools.py:1
+msgid "APT"
+msgstr "APT"
+
+#: ../kupfer/plugin/apt_tools.py:9
+msgid "Interface with the package manager APT"
+msgstr "Διεπαφή με τον διαχειριστή πακέτου APT"
+
+#: ../kupfer/plugin/apt_tools.py:25
+msgid "Installation method"
+msgstr "Μέθοδος εγκατάστασης"
+
+#: ../kupfer/plugin/apt_tools.py:61 ../kupfer/plugin/apt_tools.py:66
+msgid "Show Package Information"
+msgstr "Εμφάνιση πληροφοριών πακέτου"
+
+#: ../kupfer/plugin/apt_tools.py:87
+msgid "Install"
+msgstr "Εγκατάσταση"
+
+#: ../kupfer/plugin/apt_tools.py:103
+msgid "Install package using the configured method"
+msgstr "Εγκατάσταση πακέτου χρησιμοποιώντας τη ρυθμισμένη μέθοδο"
+
+#: ../kupfer/plugin/apt_tools.py:122
+#, python-format
+msgid "Packages matching \"%s\""
+msgstr "Πακέτα που ταιριάζουν στο \"%s\""
+
+#: ../kupfer/plugin/apt_tools.py:154
+msgid "Search Package Name..."
+msgstr "Όνομα πακέτου αναζήτησης..."
+
+#: ../kupfer/plugin/archiveinside.py:8
+msgid "Deep Archives"
+msgstr "Βαθιές αρχειοθήκες"
+
+#: ../kupfer/plugin/archiveinside.py:10
+msgid "Allow browsing inside compressed archive files"
+msgstr "Να επιτρέπεται η περιήγηση μέσα σε συμπιεσμένα αρχεία αρχειοθήκης"
+
+#: ../kupfer/plugin/archiveinside.py:49
+#, python-format
+msgid "Content of %s"
+msgstr "Περιεχόμενα του %s"
+
+#. encoding: utf-8
+#. don't panic! This is just because it's crazy and fun! ツ
+#: ../kupfer/plugin/asciiunicodeiconset.py:3
+msgid "Ascii & Unicode Icon Set"
+msgstr "Ομάδα εικονιδίων Ascii & Unicode"
+
+#: ../kupfer/plugin/asciiunicodeiconset.py:5
+msgid ""
+"Provides the Ascii and Unicode icon sets that use letters and symbols to "
+"produce icons for the objects found in Kupfer."
+msgstr ""
+"Παρέχει τις ομάδες εικονιδίων Ascii και Unicode που χρησιμοποιούν γράμματα "
+"και σύμβολα για να παράξουν εικονίδια για αντικείμενα που βρέθηκαν στο "
+"Kupfer."
+
+#: ../kupfer/plugin/asciiunicodeiconset.py:21
+msgid "Ascii"
+msgstr "Ascii"
+
+#: ../kupfer/plugin/asciiunicodeiconset.py:23
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../kupfer/plugin/audacious.py:1 ../kupfer/plugin/audacious.py:187
+msgid "Audacious"
+msgstr "Audacious"
+
+#: ../kupfer/plugin/audacious.py:3
+msgid "Control Audacious playback and playlist"
+msgstr "Έλεγχος αναπαραγωγής Audacious και λίστας αναπαραγωγής"
+
+#: ../kupfer/plugin/audacious.py:62
+msgid "Add track to the Audacious play queue"
+msgstr "Προσθήκη κομματιού στην σειρά αναπαραγωγής του Audacious"
+
+#: ../kupfer/plugin/audacious.py:70
+msgid "Dequeue"
+msgstr "Αφαίρεση από την αναμονή"
+
+#: ../kupfer/plugin/audacious.py:74
+msgid "Remove track from the Audacious play queue"
+msgstr "Αφαίρεση κομματιού από τη σειρά αναπαραγωγής του Audacious"
+
+#: ../kupfer/plugin/audacious.py:86
+msgid "Jump to track in Audacious"
+msgstr "Μετάβαση σε κομμάτι στο Audacious"
+
+#: ../kupfer/plugin/audacious.py:96
+msgid "Resume playback in Audacious"
+msgstr "Συνέχιση αναπαραγωγής στο Audacious"
+
+#: ../kupfer/plugin/audacious.py:106
+msgid "Pause playback in Audacious"
+msgstr "Παύση αναπαραγωγής στο Audacious"
+
+#: ../kupfer/plugin/audacious.py:116
+msgid "Jump to next track in Audacious"
+msgstr "Μετάβαση στο επόμενο κομμάτι στο Audacious"
+
+#: ../kupfer/plugin/audacious.py:126
+msgid "Jump to previous track in Audacious"
+msgstr "Μετάβαση στο προηγούμενο κομμάτι στο Audacious"
+
+#: ../kupfer/plugin/audacious.py:136
+msgid "Clear the Audacious play queue"
+msgstr "Καθαρισμός της σειρά αναπαραγωγής του Audacious"
+
+#: ../kupfer/plugin/audacious.py:142
+msgid "Shuffle"
+msgstr "Ανακάτεμα"
+
+#: ../kupfer/plugin/audacious.py:146
+msgid "Toggle shuffle in Audacious"
+msgstr "Εναλλαγή ανακατέματος στο Audacious"
+
+#: ../kupfer/plugin/audacious.py:152
+msgid "Repeat"
+msgstr "Επανάληψη"
+
+#: ../kupfer/plugin/audacious.py:156
+msgid "Toggle repeat in Audacious"
+msgstr "Εναλλαγή επανάληψης στο Audacious"
+
+#: ../kupfer/plugin/audacious.py:171
+msgid "Playlist"
+msgstr "Λίστα αναπαραγωγής"
+
+#: ../kupfer/plugin/chromium.py:1 ../kupfer/plugin/chromium.py:16
+msgid "Chromium Bookmarks"
+msgstr "Σελιδοδείκτες Chromium"
+
+#: ../kupfer/plugin/chromium.py:3 ../kupfer/plugin/chromium.py:43
+msgid "Index of Chromium bookmarks"
+msgstr "Ευρετήριο σελιδοδεικτών του Chromium"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/clawsmail.py:2
+msgid "Claws Mail"
+msgstr "Claws Mail"
+
+#: ../kupfer/plugin/clawsmail.py:5
+msgid "Claws Mail Contacts and Actions"
+msgstr "Επαφές και ενέργειες Claws Mail"
+
+#: ../kupfer/plugin/clawsmail.py:26 ../kupfer/plugin/evolution.py:24
+#: ../kupfer/plugin/operamail.py:26 ../kupfer/plugin/thunderbird.py:31
+msgid "Compose New Email"
+msgstr "Σύνταξη νέας αλληλογραφίας"
+
+#: ../kupfer/plugin/clawsmail.py:32
+msgid "Compose a new message in Claws Mail"
+msgstr "Σύνταξη νέου μηνύματος στο Claws Mail"
+
+#: ../kupfer/plugin/clawsmail.py:41
+msgid "Receive All Email"
+msgstr "Λήψη όλων των μηνυμάτων"
+
+#: ../kupfer/plugin/clawsmail.py:47
+msgid "Receive new messages from all accounts in ClawsMail"
+msgstr "Λήψη νέων μηνυμάτων από όλους τους λογαριασμούς στο ClawsMail"
+
+#: ../kupfer/plugin/clawsmail.py:56 ../kupfer/plugin/defaultmail.py:18
+#: ../kupfer/plugin/evolution.py:40 ../kupfer/plugin/operamail.py:41
+#: ../kupfer/plugin/thunderbird.py:47
+msgid "Compose Email"
+msgstr "Σύνταξη αλληλογραφίας"
+
+#: ../kupfer/plugin/clawsmail.py:81 ../kupfer/plugin/defaultmail.py:43
+#: ../kupfer/plugin/evolution.py:65
+msgid "Send in Email To..."
+msgstr "Αποστολή με αλληλογραφία σε..."
+
+#: ../kupfer/plugin/clawsmail.py:107
+msgid "Compose new message in Claws Mail and attach file"
+msgstr "Σύνταξη νέου μηνύματος στο Claws Mail και επισύναψη αρχείου"
+
+#: ../kupfer/plugin/clawsmail.py:116
+msgid "Claws Mail Address Book"
+msgstr "Το βιβλίο διευθύνσεων του Claws Mail"
+
+#: ../kupfer/plugin/clawsmail.py:164
+msgid "Contacts from Claws Mail Address Book"
+msgstr "Επαφές από το βιβλίο διευθύνσεων του Claws Mail"
+
+#: ../kupfer/plugin/custom_terminal.py:1
+#: ../kupfer/plugin/custom_terminal.py:39
+msgid "Custom Terminal"
+msgstr "Προσαρμοσμένο τερματικό"
+
+#: ../kupfer/plugin/custom_terminal.py:2
+msgid "Configure a custom terminal emulator"
+msgstr "Ρύθμιση προσαρμοσμένου εξομοιωτή τερματικού"
+
+#: ../kupfer/plugin/custom_terminal.py:18
+msgid "Execute flag"
+msgstr "Εκτέλεση σημαίας"
+
+#: ../kupfer/plugin/customtheme.py:1
+msgid "Custom Theme"
+msgstr "Προσαρμοσμένο θέμα"
+
+#: ../kupfer/plugin/customtheme.py:3
+msgid "Use a custom color theme"
+msgstr "Χρήση προσαρμοσμένου χρωματικού θέματος"
+
+#: ../kupfer/plugin/customtheme.py:110
+msgid "Theme:"
+msgstr "Θέμα:"
+
+#: ../kupfer/plugin/defaultmail.py:1
+msgid "Default Email Client"
+msgstr "Προεπιλεγμένος πελάτης αλληλογραφίας"
+
+#: ../kupfer/plugin/defaultmail.py:6
+msgid "Compose email using the system's default mailto: handler"
+msgstr ""
+"Σύνταξη αλληλογραφίας χρησιμοποιώντας τον προεπιλεγμένο χειριστή mailto: του "
+"συστήματος"
+
+#: ../kupfer/plugin/devhelp.py:1
+msgid "Devhelp"
+msgstr "Βοήθεια ανάπτυξης"
+
+#: ../kupfer/plugin/devhelp.py:3 ../kupfer/plugin/devhelp.py:13
+msgid "Search in Devhelp"
+msgstr "Αναζήτηση στη βοήθεια ανάπτυξης"
+
+#: ../kupfer/plugin/duckduckgo.py:5 ../kupfer/plugin/duckduckgo.py:19
+msgid "DuckDuckGo Search"
+msgstr "Αναζήτηση DuckDuckGo"
+
+#: ../kupfer/plugin/duckduckgo.py:8 ../kupfer/plugin/duckduckgo.py:30
+msgid "Search the web securely with DuckDuckGo"
+msgstr "Αναζήτηση του ιστού με ασφάλεια με το DuckDuckGo"
+
+#. -*- coding: UTF-8 -*-
+#. vim: set noexpandtab ts=8 sw=8:
+#: ../kupfer/plugin/empathy.py:3
+msgid "Empathy"
+msgstr "Empathy"
+
+#: ../kupfer/plugin/empathy.py:6
+msgid "Access to Empathy Contacts"
+msgstr "Πρόσβαση στις επαφές του Empathy"
+
+#: ../kupfer/plugin/empathy.py:26 ../kupfer/plugin/pidgin.py:29
+msgid "Show offline contacts"
+msgstr "Εμφάνιση επαφών εκτός σύνδεσης"
+
+#: ../kupfer/plugin/empathy.py:35 ../kupfer/plugin/gajim.py:26
+#: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:30
+msgid "Available"
+msgstr "Διαθέσιμες"
+
+#: ../kupfer/plugin/empathy.py:36 ../kupfer/plugin/gajim.py:28
+#: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:32
+msgid "Away"
+msgstr "Απουσιάζει"
+
+#: ../kupfer/plugin/empathy.py:37 ../kupfer/plugin/gajim.py:30
+#: ../kupfer/plugin/skype.py:34
+msgid "Busy"
+msgstr "Απασχολημένος"
+
+#: ../kupfer/plugin/empathy.py:38 ../kupfer/plugin/gajim.py:29
+#: ../kupfer/plugin/skype.py:33
+msgid "Not Available"
+msgstr "Μη διαθέσιμος"
+
+#: ../kupfer/plugin/empathy.py:39 ../kupfer/plugin/gajim.py:31
+#: ../kupfer/plugin/skype.py:35
+msgid "Invisible"
+msgstr "Αόρατος"
+
+#: ../kupfer/plugin/empathy.py:40 ../kupfer/plugin/gajim.py:32
+#: ../kupfer/plugin/skype.py:36
+msgid "Offline"
+msgstr "Αποσυνδεδεμένος"
+
+#: ../kupfer/plugin/empathy.py:100 ../kupfer/plugin/gajim.py:93
+#: ../kupfer/plugin/pidgin.py:97 ../kupfer/plugin/skype.py:197
+msgid "Open Chat"
+msgstr "Ανοικτή συνομιλία"
+
+#: ../kupfer/plugin/empathy.py:133 ../kupfer/plugin/gajim.py:121
+#: ../kupfer/plugin/skype.py:243
+msgid "Change Global Status To..."
+msgstr "Αλλαγή της γενικής κατάστασης σε..."
+
+#: ../kupfer/plugin/empathy.py:175
+msgid "Empathy Contacts"
+msgstr "Επαφές του Empathy"
+
+#: ../kupfer/plugin/empathy.py:249
+msgid "Empathy Account Status"
+msgstr "Κατάσταση λογαριασμού του Empathy"
+
+#: ../kupfer/plugin/evolution.py:4
+msgid "Evolution"
+msgstr "Evolution"
+
+#: ../kupfer/plugin/evolution.py:7 ../kupfer/plugin/evolution.py:119
+msgid "Evolution contacts"
+msgstr "Επαφές Evolution"
+
+#: ../kupfer/plugin/evolution.py:31
+msgid "Compose a new message in Evolution"
+msgstr "Σύνταξη νέου μηνύματος στο Evolution"
+
+#: ../kupfer/plugin/evolution.py:92
+msgid "Compose new message in Evolution and attach file"
+msgstr "Σύνταξη νέου μηνύματος στο Evolution και επισύναψη αρχείου"
+
+#: ../kupfer/plugin/evolution.py:100
+msgid "Evolution Address Book"
+msgstr "Βιβλίο διευθύνσεων Evolution"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/filezilla.py:3
+msgid "Filezilla"
+msgstr "FileZilla"
+
+#: ../kupfer/plugin/filezilla.py:6
+msgid "Show sites and handle ftp addresses by Filezilla"
+msgstr "Εμφάνιση τόπων και χειρισμός διευθύνσεων ftp από το Filezilla"
+
+#: ../kupfer/plugin/filezilla.py:42
+msgid "Open Site with Filezilla"
+msgstr "Άνοιγμα τόπου με Filezilla"
+
+#: ../kupfer/plugin/filezilla.py:87
+msgid "Filezilla Sites"
+msgstr "Τόποι Filezilla"
+
+#: ../kupfer/plugin/filezilla.py:122
+msgid "Sites from Filezilla"
+msgstr "Τόποι από Filezilla"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/gajim.py:2
+msgid "Gajim"
+msgstr "Gajim"
+
+#: ../kupfer/plugin/gajim.py:5
+msgid "Access to Gajim Contacts"
+msgstr "Πρόσβαση στις επαφές του Gajim"
+
+#: ../kupfer/plugin/gajim.py:27
+msgid "Free for Chat"
+msgstr "Ελεύθερος για συνομιλία"
+
+#: ../kupfer/plugin/gajim.py:149
+msgid "Gajim Contacts"
+msgstr "Επαφές του Gajim"
+
+#: ../kupfer/plugin/gajim.py:213
+msgid "Gajim Account Status"
+msgstr "Κατάσταση λογαριασμού Gajim"
+
+#. TRANS: "Glob" is the matching files like a shell with "*.py" etc.
+#: ../kupfer/plugin/glob.py:3 ../kupfer/plugin/glob.py:17
+msgid "Glob"
+msgstr "Glob"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/gmail/__init__.py:2 ../kupfer/plugin/gmail/__init__.py:234
+msgid "Gmail"
+msgstr "Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:5
+msgid "Load contacts and compose new email in Gmail"
+msgstr "Φόρτωση επαφών και σύνταξη νέου μηνύματος σε Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:33
+msgid "Load contacts' pictures"
+msgstr "Φόρτωση εικόνων επαφών"
+
+#: ../kupfer/plugin/gmail/__init__.py:39
+msgid "Load additional information"
+msgstr "Φόρτωση πρόσθετων πληροφοριών"
+
+#: ../kupfer/plugin/gmail/__init__.py:50
+msgid "Work email"
+msgstr "Ηλεκτρονικό ταχυδρομείο εργασίας"
+
+#: ../kupfer/plugin/gmail/__init__.py:51
+msgid "Home email"
+msgstr "Ηλεκτρονικό ταχυδρομείο οικίας"
+
+#: ../kupfer/plugin/gmail/__init__.py:52
+msgid "Other email"
+msgstr "Άλλα ηλεκτρονικά ταχυδρομεία"
+
+#: ../kupfer/plugin/gmail/__init__.py:54
+msgid "Work address"
+msgstr "Διεύθυνση εργασίας"
+
+#: ../kupfer/plugin/gmail/__init__.py:55
+msgid "Home address"
+msgstr "Διεύθυνση οικίας"
+
+#: ../kupfer/plugin/gmail/__init__.py:56
+msgid "Other address"
+msgstr "Άλλες διευθύνσεις"
+
+#: ../kupfer/plugin/gmail/__init__.py:58
+msgid "Car phone"
+msgstr "Τηλέφωνο αυτοκινήτου"
+
+#: ../kupfer/plugin/gmail/__init__.py:59
+msgid "Fax"
+msgstr "Φαξ"
+
+#: ../kupfer/plugin/gmail/__init__.py:61
+msgid "Home phone"
+msgstr "Τηλέφωνο οικίας"
+
+#: ../kupfer/plugin/gmail/__init__.py:62
+msgid "Home fax"
+msgstr "Φαξ οικίας"
+
+#: ../kupfer/plugin/gmail/__init__.py:63
+msgid "Internal phone"
+msgstr "Εσωτερικό τηλέφωνο"
+
+#: ../kupfer/plugin/gmail/__init__.py:64
+msgid "Mobile"
+msgstr "Κινητό τηλέφωνο"
+
+#: ../kupfer/plugin/gmail/__init__.py:65
+msgid "Other"
+msgstr "Άλλο"
+
+#: ../kupfer/plugin/gmail/__init__.py:66
+msgid "VOIP"
+msgstr "VOIP"
+
+#: ../kupfer/plugin/gmail/__init__.py:67
+msgid "Work phone"
+msgstr "Τηλέφωνο εργασίας"
+
+#: ../kupfer/plugin/gmail/__init__.py:68
+msgid "Work fax"
+msgstr "Φαξ εργασίας"
+
+#: ../kupfer/plugin/gmail/__init__.py:93
+msgid "Compose Email in Gmail"
+msgstr "Σύνταξη μηνύματος σε Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:117
+msgid "Open web browser and compose new email in Gmail"
+msgstr "Άνοιγμα περιηγητή ιστού και σύνταξη νέου μηνύματος σε Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:123
+msgid "Edit Contact in Gmail"
+msgstr "Επεξεργασία επαφής σε Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:133
+msgid "Open web browser and edit contact in Gmail"
+msgstr "Άνοιγμα περιηγητή ιστού και επεξεργασία επαφής σε Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:263
+msgid "Contacts from Google services (Gmail)"
+msgstr "Επαφές από υπηρεσίες Google (Gmail)"
+
+#: ../kupfer/plugin/gnome_terminal.py:1 ../kupfer/plugin/gnome_terminal.py:56
+msgid "GNOME Terminal Profiles"
+msgstr "Κατατομές τερματικού GNOME"
+
+#: ../kupfer/plugin/gnome_terminal.py:3
+msgid "Launch GNOME Terminal profiles"
+msgstr "Έναρξη κατατομών τερματικού GNOME"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/google_picasa/__init__.py:2
+msgid "Google Picasa"
+msgstr "Google Picasa"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:5
+msgid "Show albums and upload files to Picasa"
+msgstr "Εμφάνιση συλλογών και ανέβασμα αρχείων στο Picasa"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:35
+msgid "Users to show: (,-separated)"
+msgstr "Εμφανιζόμενοι χρήστες: (διαχωρισμός με ,)"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:41
+msgid "Load user and album icons"
+msgstr "Φόρτωση εικονιδίων χρήστη και δίσκου"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:92
+msgid "Uploading Pictures"
+msgstr "Ανέβασμα εικόνων"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:93
+msgid "Uploading pictures to Picasa Web Album"
+msgstr "Ανέβασμα εικόνων στη συλλογή ιστού Picasa"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:102
+msgid "Creating album:"
+msgstr "Δημιουργία συλλογής:"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:105
+msgid "Album created by Kupfer"
+msgstr "Η συλλογή δημιουργήθηκε από το Kupfer"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:112
+msgid "File:"
+msgstr "Αρχείο:"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:252
+#, python-format
+msgid "One album"
+msgid_plural "%(num)d albums"
+msgstr[0] "Μία συλλογή"
+msgstr[1] "%(num)d συλλογές"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:279
+#, python-format
+msgid "one photo"
+msgid_plural "%(num)s photos"
+msgstr[0] "μία φωτογραφία"
+msgstr[1] "%(num)s φωτογραφίες"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:299
+msgid "Upload to Picasa Album..."
+msgstr "Ανέβασμα στη συλλογή του Picasa..."
+
+#: ../kupfer/plugin/google_picasa/__init__.py:343
+msgid "Upload files to Picasa album"
+msgstr "Ανέβασμα αρχείων στη συλλογή του Picasa"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:349
+msgid "Upload to Picasa as New Album"
+msgstr "Ανέβασμα στο Picasa ως νέα συλλογή"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:377
+msgid "Create album from selected local directory"
+msgstr "Δημιουργία συλλογής από επιλεγμένο τοπικό κατάλογο"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:381
+#: ../kupfer/plugin/google_picasa/__init__.py:404
+msgid "Picasa Albums"
+msgstr "Συλλογές Picasa"
+
+#: ../kupfer/plugin/google_picasa/__init__.py:436
+msgid "User albums in Picasa"
+msgstr "Συλλογές χρήστη στο Picasa"
+
+#: ../kupfer/plugin/google_search.py:1 ../kupfer/plugin/google_search.py:30
+msgid "Google Search"
+msgstr "Αναζήτηση Google"
+
+#: ../kupfer/plugin/google_search.py:3
+msgid "Search Google with results shown directly"
+msgstr "Αναζήτηση Google με άμεσα εμφανιζόμενα αποτελέσματα"
+
+#: ../kupfer/plugin/google_search.py:58 ../kupfer/plugin/locate.py:46
+#: ../kupfer/plugin/tracker1.py:168 ../kupfer/plugin/tracker1.py:179
+#, python-format
+msgid "Results for \"%s\""
+msgstr "Αποτελέσματα για \"%s\""
+
+#: ../kupfer/plugin/google_search.py:91
+#, python-format
+msgid "Show More Results For \"%s\""
+msgstr "Εμφάνιση περισσότερων αποτελεσμάτων για \"%s\""
+
+#: ../kupfer/plugin/google_search.py:92
+#, python-format
+msgid "%s total found"
+msgstr "βρέθηκαν συνολικά %s"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/gtg.py:2
+msgid "Getting Things GNOME"
+msgstr "Getting Things GNOME"
+
+#: ../kupfer/plugin/gtg.py:5
+msgid "Browse and create new tasks in GTG"
+msgstr "Περιήγηση και δημιουργία νέων εργασιών στο GTG"
+
+#: ../kupfer/plugin/gtg.py:114
+#, python-format
+msgid "due: %s"
+msgstr "λήξη: %s"
+
+#: ../kupfer/plugin/gtg.py:116
+#, python-format
+msgid "start: %s"
+msgstr "έναρξη: %s"
+
+#: ../kupfer/plugin/gtg.py:118
+#, python-format
+msgid "tags: %s"
+msgstr "ετικέτες: %s"
+
+#: ../kupfer/plugin/gtg.py:148
+msgid "Open task in Getting Things GNOME!"
+msgstr "Άνοιγμα εργασίας στο Getting Things GNOME!"
+
+#: ../kupfer/plugin/gtg.py:155
+msgid "Delete"
+msgstr "Διαγραφή"
+
+#: ../kupfer/plugin/gtg.py:168
+msgid "Permanently remove this task"
+msgstr "Μόνιμη απομάκρυνση αυτής της εργασίας"
+
+#: ../kupfer/plugin/gtg.py:173
+msgid "Mark Done"
+msgstr "Έτοιμο"
+
+#: ../kupfer/plugin/gtg.py:182
+msgid "Mark this task as done"
+msgstr "Σημείωση αυτής της εργασίας ως έτοιμης"
+
+#: ../kupfer/plugin/gtg.py:187
+msgid "Dismiss"
+msgstr "Αποδέσμευση"
+
+#: ../kupfer/plugin/gtg.py:196
+msgid "Mark this task as not to be done anymore"
+msgstr "Σημείωση αυτής της εργασίας να μην γίνει πια"
+
+#: ../kupfer/plugin/gtg.py:201
+msgid "Create Task"
+msgstr "Δημιουργία εργασίας"
+
+#: ../kupfer/plugin/gtg.py:218
+msgid "Create new task in Getting Things GNOME"
+msgstr "Δημιουργία νέας εργασίας στο Getting Things GNOME"
+
+#: ../kupfer/plugin/gwibber.py:3
+msgid "Gwibber"
+msgstr "Gwibber"
+
+#: ../kupfer/plugin/gwibber.py:6
+msgid ""
+"Microblogging with Gwibber. Allows sending and receiving messages from "
+"social networks like Twitter, Identi.ca etc. Requires the package 'gwibber-"
+"service'."
+msgstr ""
+"Μικροϊστολόγιο με το Gwibber. Επιτρέπει την αποστολή και λήψη μηνυμάτων από "
+"τα κοινωνικά δίκτυα όπως Twitter, Identi.ca κλπ. Απαιτεί το πακέτο 'gwibber-"
+"service'."
+
+#: ../kupfer/plugin/gwibber.py:45
+msgid "Maximum number of messages to show"
+msgstr "Μέγιστος αριθμός εμφανιζόμενων μηνυμάτων"
+
+#. TRANS: Account description, similar to "John on Identi.ca"
+#: ../kupfer/plugin/gwibber.py:98
+#, python-format
+msgid "%(user)s on %(service)s"
+msgstr "%(user)s στο %(service)s"
+
+#. TRANS: Gwibber Message description
+#. TRANS: Similar to "John  May 5 2011 11:40 on Identi.ca"
+#. TRANS: the %(user)s and similar tokens must be unchanged
+#: ../kupfer/plugin/gwibber.py:153
+#, python-format
+msgid "%(user)s %(when)s on %(where)s"
+msgstr "%(user)s %(when)s στο %(where)s"
+
+#: ../kupfer/plugin/gwibber.py:187
+msgid "Send Message"
+msgstr "Αποστολή μηνύματος"
+
+#: ../kupfer/plugin/gwibber.py:205
+msgid "Send message to all Gwibber accounts"
+msgstr "Αποστολή μηνύματος σε όλους τους λογαριασμούς Gwibber"
+
+#: ../kupfer/plugin/gwibber.py:210
+msgid "Send Message To..."
+msgstr "Αποστολή μηνύματος προς..."
+
+#: ../kupfer/plugin/gwibber.py:238
+msgid "Send message to a Gwibber account"
+msgstr "Αποστολή μηνύματος σε έναν λογαριασμό Gwibber"
+
+#: ../kupfer/plugin/gwibber.py:243 ../kupfer/plugin/pidgin.py:120
+msgid "Send Message..."
+msgstr "Αποστολή μηνύματος..."
+
+#: ../kupfer/plugin/gwibber.py:273
+msgid "Send message to selected Gwibber account"
+msgstr "Αποστολή μηνύματος σε επιλεγμένο λογαριασμό Gwibber"
+
+#: ../kupfer/plugin/gwibber.py:278
+msgid "Reply..."
+msgstr "Απάντηση..."
+
+#: ../kupfer/plugin/gwibber.py:314
+msgid "Delete Message"
+msgstr "Διαγραφή μηνύματος"
+
+#: ../kupfer/plugin/gwibber.py:337
+msgid "Send Private Message..."
+msgstr "Αποστολή ιδιωτικού μηνύματος..."
+
+#: ../kupfer/plugin/gwibber.py:370
+msgid "Send direct message to user"
+msgstr "Αποστολή άμεσου μηνύματος στον χρήστη"
+
+#: ../kupfer/plugin/gwibber.py:376
+msgid "Retweet"
+msgstr "Απάντηση"
+
+#: ../kupfer/plugin/gwibber.py:376
+msgid "Retweet To..."
+msgstr "Απάντηση προς..."
+
+#: ../kupfer/plugin/gwibber.py:407
+msgid "Retweet message to all Gwibber accounts"
+msgstr "Απάντηση μηνύματος σε όλους τους λογαριασμούς Gwibber"
+
+#: ../kupfer/plugin/gwibber.py:408
+msgid "Retweet message to a Gwibber account"
+msgstr "Απάντηση μηνύματος σε λογαριασμό Gwibber"
+
+#: ../kupfer/plugin/gwibber.py:413
+msgid "Open in Browser"
+msgstr "Άνοιγμα στον περιηγητή"
+
+#: ../kupfer/plugin/gwibber.py:419
+msgid "Open message in default web browser"
+msgstr "Άνοιγμα μηνύματος σε προεπιλεγμένο περιηγητή ιστού"
+
+#: ../kupfer/plugin/gwibber.py:425 ../kupfer/plugin/gwibber.py:463
+msgid "Gwibber Accounts"
+msgstr "Λογαριασμοί Gwibber"
+
+#: ../kupfer/plugin/gwibber.py:456
+msgid "Accounts configured in Gwibber"
+msgstr "Ρυθμισμένοι λογαριασμοί στο Gwibber"
+
+#: ../kupfer/plugin/gwibber.py:495
+msgid "Gwibber Messages"
+msgstr "Μηνύματα Gwibber"
+
+#: ../kupfer/plugin/gwibber.py:518
+msgid "Recent messages received by Gwibber"
+msgstr "Τα πρόσφατα μηνύματα ελήφθησαν από το Gwibber"
+
+#. TRANS:  %s is a service name
+#: ../kupfer/plugin/gwibber.py:527
+#, python-format
+msgid "Gwibber Messages for %s"
+msgstr "Μηνύματα Gwibber για %s"
+
+#: ../kupfer/plugin/gwibber.py:543
+msgid "Gwibber Streams"
+msgstr "Ροές Gwibber"
+
+#: ../kupfer/plugin/gwibber.py:566
+msgid "Streams configured in Gwibber"
+msgstr "Ρυθμισμένες ροές στο Gwibber"
+
+#. TRANS: Gwibber messages in %s :: %s is a Stream name
+#: ../kupfer/plugin/gwibber.py:574
+#, python-format
+msgid "Gwibber Messages in %s"
+msgstr "Μηνύματα Gwibber στο %s"
+
+#: ../kupfer/plugin/gwibber_simple.py:3
+msgid "Gwibber (Simple)"
+msgstr "Gwibber (Απλό)"
+
+#: ../kupfer/plugin/gwibber_simple.py:7
+msgid "Send updates via the microblogging client Gwibber"
+msgstr "Αποστολή ενημερώσεων μέσα από πελάτη μικροϊστολογίου Gwibber"
+
+#: ../kupfer/plugin/gwibber_simple.py:45
+msgid "Send Update"
+msgstr "Αποστολή ενημέρωσης"
+
+#: ../kupfer/plugin/gwibber_simple.py:65
+msgid "Unable to activate Gwibber service"
+msgstr "Αδύνατη η ενεργοποίηση υπηρεσίας Gwibber"
+
+#: ../kupfer/plugin/higherorder.py:1
+msgid "Higher-order Actions"
+msgstr "Ενέργειες μεγαλύτερης τάξης"
+
+#: ../kupfer/plugin/higherorder.py:7
+msgid "Tools to work with commands as objects"
+msgstr "Εργαλεία για εργασία με εντολές όπως αντικείμενα"
+
+#: ../kupfer/plugin/higherorder.py:20
+msgid "Select in Kupfer"
+msgstr "Επιλογή στο Kupfer"
+
+#: ../kupfer/plugin/higherorder.py:59
+#, python-format
+msgid "Result of %s (%s)"
+msgstr "Αποτέλεσμα του %s (%s)"
+
+#: ../kupfer/plugin/higherorder.py:75
+msgid "Run (Take Result)"
+msgstr "Εκτέλεση (λήψη αποτελέσματος)"
+
+#: ../kupfer/plugin/higherorder.py:90
+msgid "Take the command result as a proxy object"
+msgstr "Λήψη του αποτελέσματος εντολής ως αντικειμένου μεσολαβητή"
+
+#: ../kupfer/plugin/higherorder.py:95
+msgid "Run (Discard Result)"
+msgstr "Εκτέλεση (απόρριψη αποτελέσματος)"
+
+#: ../kupfer/plugin/image.py:1
+msgid "Image Tools"
+msgstr "Εργαλεία εικόνας"
+
+#: ../kupfer/plugin/image.py:10
+msgid "Image transformation tools"
+msgstr "Εργαλεία μετασχηματισμού εικόνας"
+
+#: ../kupfer/plugin/image.py:25
+msgid "Scale..."
+msgstr "Κλιμάκωση..."
+
+#: ../kupfer/plugin/image.py:77
+msgid "Scale image to fit inside given pixel measure(s)"
+msgstr ""
+"Κλιμάκωση εικόνας για προσαρμογή μέσα στις δοσμένες μετρήσεις "
+"εικονοστοιχείου"
+
+#: ../kupfer/plugin/image.py:112
+msgid "Rotate Clockwise"
+msgstr "Δεξιόστροφη περιστροφή"
+
+#: ../kupfer/plugin/image.py:119
+msgid "Rotate Counter-Clockwise"
+msgstr "Αριστερόστροφη περιστροφή"
+
+#: ../kupfer/plugin/image.py:126
+msgid "Autorotate"
+msgstr "Αυτόματη περιστροφή"
+
+#: ../kupfer/plugin/image.py:155
+msgid "Rotate JPEG (in-place) according to its EXIF metadata"
+msgstr "Περιστροφή JPEG (επί τόπου) σύμφωνα με τα μεταδεδομένα του EXIF"
+
+#: ../kupfer/plugin/kupfer_plugins.py:1 ../kupfer/plugin/kupfer_plugins.py:86
+msgid "Kupfer Plugins"
+msgstr "Πρόσθετα Kupfer"
+
+#: ../kupfer/plugin/kupfer_plugins.py:3
+msgid "Access Kupfer's plugin list in Kupfer"
+msgstr "Πρόσβαση λίστας προσθέτων του Kupfer στο Kupfer"
+
+#: ../kupfer/plugin/kupfer_plugins.py:19
+msgid "Show Information"
+msgstr "Εμφάνιση πληροφοριών"
+
+#: ../kupfer/plugin/kupfer_plugins.py:35
+msgid "Show Source Code"
+msgstr "Εμφάνιση πηγαίου κώδικα"
+
+#: ../kupfer/plugin/kupfer_plugins.py:80
+msgid "enabled"
+msgstr "ενεργό"
+
+#: ../kupfer/plugin/locate.py:1 ../kupfer/plugin/locate.py:28
+msgid "Locate Files"
+msgstr "Εντοπισμός αρχείων"
+
+#: ../kupfer/plugin/locate.py:5 ../kupfer/plugin/locate.py:38
+msgid "Search filesystem using locate"
+msgstr "Αναζήτηση συστήματος αρχείων χρησιμοποιώντας εντοπισμό"
+
+#: ../kupfer/plugin/locate.py:20
+msgid "Ignore case distinctions when searching files"
+msgstr "Παράβλεψη διακρίσεων πεζών-κεφαλαίων κατά την αναζήτηση αρχείων"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/openoffice.py:3
+msgid "OpenOffice / LibreOffice"
+msgstr "OpenOffice / LibreOffice"
+
+#: ../kupfer/plugin/openoffice.py:5 ../kupfer/plugin/openoffice.py:136
+msgid "Recently used documents in OpenOffice/LibreOffice"
+msgstr "Πρόσφατα χρησιμοποιημένα έγγραφα στο OpenOffice/LibreOffice"
+
+#: ../kupfer/plugin/openoffice.py:84
+msgid "OpenOffice/LibreOffice Recent Items"
+msgstr "Πρόσφατα στοιχεία OpenOffice/LibreOffice"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/operamail.py:2
+msgid "Opera Mail"
+msgstr "Opera Mail"
+
+#: ../kupfer/plugin/operamail.py:5
+msgid "Opera Mail contacts and actions"
+msgstr "Επαφές και ενέργειες Opera Mail"
+
+#: ../kupfer/plugin/operamail.py:32
+msgid "Compose a new message in Opera Mail"
+msgstr "Σύνταξη νέου μηνύματος στο Opera Mail"
+
+#: ../kupfer/plugin/operamail.py:64
+msgid "Opera Mail Contacts"
+msgstr "Επαφές Opera Mail"
+
+#: ../kupfer/plugin/operamail.py:120
+msgid "Contacts from Opera Mail"
+msgstr "Επαφές από Opera Mail"
+
+#: ../kupfer/plugin/opera.py:4 ../kupfer/plugin/opera.py:22
+msgid "Opera Bookmarks"
+msgstr "Σελιδοδείκτες Opera"
+
+#: ../kupfer/plugin/opera.py:6 ../kupfer/plugin/opera.py:54
+msgid "Index of Opera bookmarks"
+msgstr "Ευρετήριο σελιδοδεικτών του Opera"
+
+#: ../kupfer/plugin/pidgin.py:3
+msgid "Pidgin"
+msgstr "Pidgin"
+
+#: ../kupfer/plugin/pidgin.py:9
+msgid "Access to Pidgin Contacts"
+msgstr "Πρόσβαση στις επαφές του Pidgin"
+
+#: ../kupfer/plugin/pidgin.py:111
+#, python-format
+msgid "%s (%d character)"
+msgid_plural "%s (%d characters)"
+msgstr[0] "%s (%d χαρακτήρας)"
+msgstr[1] "%s (%d χαρακτήρες)"
+
+#: ../kupfer/plugin/pidgin.py:192
+msgid "Pidgin Contacts"
+msgstr "Επαφές Pidgin"
+
+#: ../kupfer/plugin/putty.py:5 ../kupfer/plugin/putty.py:80
+msgid "PuTTY Sessions"
+msgstr "Συνεδρίες PuTTY"
+
+#: ../kupfer/plugin/putty.py:8
+msgid "Quick access to PuTTY Sessions"
+msgstr "Γρήγορη πρόσβαση σε συνεδρίες PuTTY"
+
+#: ../kupfer/plugin/putty.py:46 ../kupfer/plugin/tsclient.py:50
+msgid "Start Session"
+msgstr "Έναρξη συνεδρίας"
+
+#: ../kupfer/plugin/qsicons/__init__.py:24
+msgid "Quicksilver Icons"
+msgstr "Εικονίδια Quicksilver"
+
+#: ../kupfer/plugin/quickview.py:1
+msgid "Quick Image Viewer"
+msgstr "Γρήγορη προβολή εικόνων"
+
+#: ../kupfer/plugin/quickview.py:53
+msgid "View Image"
+msgstr "Προβολή εικόνας"
+
+#: ../kupfer/plugin/rst.py:1
+msgid "reStructuredText"
+msgstr "reStructuredText"
+
+#: ../kupfer/plugin/rst.py:3
+msgid "Render reStructuredText and show the result"
+msgstr "Απόδοση reStructuredText και εμφάνιση του αποτελέσματος"
+
+#: ../kupfer/plugin/rst.py:18
+msgid "View as HTML Document"
+msgstr "Προβολή ως εγγράφου HTML"
+
+#: ../kupfer/plugin/screen.py:1
+msgid "GNU Screen"
+msgstr "Οθόνη GNU"
+
+#: ../kupfer/plugin/screen.py:3 ../kupfer/plugin/screen.py:89
+msgid "Active GNU Screen sessions"
+msgstr "Ενεργές συνεδρίες οθόνης GNU"
+
+#: ../kupfer/plugin/screen.py:57
+msgid "Attached"
+msgstr "Επισύναψη"
+
+#: ../kupfer/plugin/screen.py:58
+msgid "Detached"
+msgstr "Απόσπαση"
+
+#: ../kupfer/plugin/screen.py:61
+#, python-format
+msgid "%(status)s session (%(pid)s) created %(time)s"
+msgstr "συνεδρία %(status)s (%(pid)s) δημιουργήθηκε στις %(time)s"
+
+#: ../kupfer/plugin/screen.py:70
+msgid "Screen Sessions"
+msgstr "Συνεδρίες οθόνης"
+
+#: ../kupfer/plugin/screen.py:99
+msgid "Attach"
+msgstr "Επισύναψη"
+
+#: ../kupfer/plugin/sendkeys.py:2 ../kupfer/plugin/sendkeys.py:52
+msgid "Send Keys"
+msgstr "Αποστολή πλήκτρων"
+
+#: ../kupfer/plugin/sendkeys.py:8
+msgid "Send synthetic keyboard events using xautomation"
+msgstr "Αποστολή τεχνητών συμβάντων πληκτρολογίου χρησιμοποιώντας xautomation"
+
+#: ../kupfer/plugin/sendkeys.py:28
+msgid "Paste to Foreground Window"
+msgstr "Επικόλληση στο παράθυρο προσκηνίου"
+
+#: ../kupfer/plugin/sendkeys.py:46
+msgid "Copy to clipboard and send Ctrl+V to foreground window"
+msgstr "Αντιγραφή στο πρόχειρο και αποστολή Ctrl+V στο παράθυρο προσκηνίου"
+
+#: ../kupfer/plugin/sendkeys.py:101
+msgid "Send keys to foreground window"
+msgstr "Αποστολή πλήκτρων στο παράθυρο προσκηνίου"
+
+#: ../kupfer/plugin/sendkeys.py:106
+msgid "Type Text"
+msgstr "Πληκτρολόγηση κειμένου"
+
+#: ../kupfer/plugin/sendkeys.py:127
+msgid "Type the text to foreground window"
+msgstr "Πληκτρολογήστε το κείμενο στο παράθυρο προσκηνίου"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/services.py:2 ../kupfer/plugin/services.py:96
+msgid "System Services"
+msgstr "Υπηρεσίες συστήματος"
+
+#: ../kupfer/plugin/services.py:4
+msgid "Start, stop or restart system services via init scripts"
+msgstr ""
+"Έναρξη, διακοπή ή επανεκκίνηση υπηρεσιών συστήματος μέσα από σενάρια init"
+
+#: ../kupfer/plugin/services.py:18
+msgid "Sudo-like Command"
+msgstr "Εντολή μορφής Sudo"
+
+#: ../kupfer/plugin/services.py:78
+msgid "Start Service"
+msgstr "Έναρξη υπηρεσίας"
+
+#: ../kupfer/plugin/services.py:84
+msgid "Restart Service"
+msgstr "Επανεκκίνηση υπηρεσίας"
+
+#: ../kupfer/plugin/services.py:90
+msgid "Stop Service"
+msgstr "Διακοπή υπηρεσίας"
+
+#: ../kupfer/plugin/services.py:126
+#, python-format
+msgid "%s Service"
+msgstr "%s υπηρεσία"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/shorten_links.py:2
+msgid "Shorten Links"
+msgstr "Συντόμευση συνδέσμων"
+
+#: ../kupfer/plugin/shorten_links.py:4
+msgid "Create short aliases of long URLs"
+msgstr "Δημιουργία σύντομων ψευδωνύμων μεγάλων URLs"
+
+#: ../kupfer/plugin/shorten_links.py:48
+msgid "Error"
+msgstr "Σφάλμα"
+
+#: ../kupfer/plugin/shorten_links.py:121
+msgid "Shorten With..."
+msgstr "Συντόμευση με..."
+
+#: ../kupfer/plugin/shorten_links.py:151
+msgid "Services"
+msgstr "Υπηρεσίες"
+
+#: ../kupfer/plugin/show_qrcode.py:5 ../kupfer/plugin/show_qrcode.py:25
+msgid "Show QRCode"
+msgstr "Εμφάνιση QRCode"
+
+#: ../kupfer/plugin/show_qrcode.py:9 ../kupfer/plugin/show_qrcode.py:60
+msgid "Display text as QRCode in a window"
+msgstr "Εμφάνιση κειμένου σε παράθυρο ως QRCode"
+
+#: ../kupfer/plugin/skype.py:5
+msgid "Access to Skype contacts"
+msgstr "Πρόσβαση σε επαφές του Skype"
+
+#: ../kupfer/plugin/skype.py:31
+msgid "Skype Me"
+msgstr "Καλέστε με"
+
+#: ../kupfer/plugin/skype.py:37
+msgid "Logged Out"
+msgstr "Αποσύνδεση"
+
+#: ../kupfer/plugin/skype.py:179
+#, python-format
+msgid "[%(status)s] %(userid)s"
+msgstr "[%(status)s] %(userid)s"
+
+#: ../kupfer/plugin/skype.py:218
+msgid "Call"
+msgstr "Κλήση"
+
+#: ../kupfer/plugin/skype.py:232
+msgid "Place a call to contact"
+msgstr "Κλήση στην επαφή"
+
+#: ../kupfer/plugin/skype.py:267
+msgid "Skype Contacts"
+msgstr "Επαφές Skype"
+
+#: ../kupfer/plugin/skype.py:287
+msgid "Skype Statuses"
+msgstr "Καταστάσεις Skype"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/ssh_hosts.py:2 ../kupfer/plugin/ssh_hosts.py:70
+msgid "SSH Hosts"
+msgstr "Οικοδεσπότες SSH"
+
+#: ../kupfer/plugin/ssh_hosts.py:3
+msgid "Adds the SSH hosts found in ~/.ssh/config."
+msgstr "Προσθέτει τους οικοδεσπότες SSH που βρέθηκαν στο ~/.ssh/config."
+
+#: ../kupfer/plugin/ssh_hosts.py:32
+msgid "SSH host"
+msgstr "Οικοδεσπότης SSH"
+
+#: ../kupfer/plugin/ssh_hosts.py:43
+msgid "Connect"
+msgstr "Σύνδεση"
+
+#: ../kupfer/plugin/ssh_hosts.py:49
+msgid "Connect to SSH host"
+msgstr "Σύνδεση με οικοδεσπότη SSH"
+
+#: ../kupfer/plugin/ssh_hosts.py:102
+msgid "SSH hosts as specified in ~/.ssh/config"
+msgstr "Οικοδεσπότες SSH όπως ορίστηκαν στο ~/.ssh/config"
+
+#: ../kupfer/plugin_support.py:144
+msgid "No D-Bus connection to desktop session"
+msgstr "Χωρίς σύνδεση διαύλου δεδομένων στη συνεδρία επιφάνειας εργασίας"
+
+#: ../kupfer/plugin_support.py:171
+msgid "GNOME Keyring"
+msgstr "Κλειδοθήκη GNOME"
+
+#: ../kupfer/plugin_support.py:172
+msgid "KWallet"
+msgstr "KWallet"
+
+#: ../kupfer/plugin_support.py:173
+msgid "Unencrypted File"
+msgstr "Ακρυπτογράφητο αρχείο"
+
+#: ../kupfer/plugin/templates.py:1 ../kupfer/plugin/templates.py:107
+msgid "Document Templates"
+msgstr "Πρότυπα εγγράφων"
+
+#: ../kupfer/plugin/templates.py:4
+msgid "Create new documents from your templates"
+msgstr "Δημιουργία νέων εγγράφων από τα πρότυπά σας"
+
+#: ../kupfer/plugin/templates.py:24
+#, python-format
+msgid "%s template"
+msgstr "πρότυπο %s"
+
+#: ../kupfer/plugin/templates.py:37 ../kupfer/plugin/textfiles.py:86
+msgid "Empty File"
+msgstr "Κενό αρχείο"
+
+#: ../kupfer/plugin/templates.py:47
+msgid "New Folder"
+msgstr "Νέος φάκελος"
+
+#: ../kupfer/plugin/templates.py:57
+msgid "Create New Document..."
+msgstr "Δημιουργία νέου εγγράφου..."
+
+#: ../kupfer/plugin/templates.py:96
+msgid "Create a new document from template"
+msgstr "Δημιουργία νέου εγγράφου από πρότυπο"
+
+#: ../kupfer/plugin/templates.py:103
+msgid "Create Document In..."
+msgstr "Δημιουργία εγγράφου σε..."
+
+#: ../kupfer/plugin/textfiles.py:13
+msgid "Textfiles"
+msgstr "Αρχεία κειμένου"
+
+#: ../kupfer/plugin/textfiles.py:51
+msgid "Append To..."
+msgstr "Προσάρτηση σε..."
+
+#: ../kupfer/plugin/textfiles.py:75
+msgid "Append..."
+msgstr "Προσάρτηση..."
+
+#: ../kupfer/plugin/textfiles.py:79
+msgid "Write To..."
+msgstr "Εγγραφή σε..."
+
+#: ../kupfer/plugin/textfiles.py:111
+msgid "Get Text Contents"
+msgstr "Λήψη περιεχομένων κειμένου"
+
+#: ../kupfer/plugin/thunar.py:1 ../kupfer/plugin/thunar.py:185
+#: ../kupfer/plugin/thunar.py:225 ../kupfer/plugin/thunar.py:278
+#: ../kupfer/plugin/thunar.py:329
+msgid "Thunar"
+msgstr "Thunar"
+
+#: ../kupfer/plugin/thunar.py:11
+msgid "File manager Thunar actions"
+msgstr "Ενέργειες του διαχειριστή αρχείων Thunar"
+
+#: ../kupfer/plugin/thunar.py:67
+msgid "Select in File Manager"
+msgstr "Επιλογή στον διαχειριστή αρχείων"
+
+#: ../kupfer/plugin/thunar.py:95
+msgid "Show Properties"
+msgstr "Εμφάνιση ιδιοτήτων"
+
+#: ../kupfer/plugin/thunar.py:118
+msgid "Show information about file in file manager"
+msgstr "Εμφάνιση πληροφοριών για το αρχείο στον διαχειριστή αρχείων"
+
+#: ../kupfer/plugin/thunar.py:127
+msgid "Send To..."
+msgstr "Αποστολή σε..."
+
+#: ../kupfer/plugin/thunar.py:259
+msgid "Symlink In..."
+msgstr "Συμβολικός δεσμός σε..."
+
+#: ../kupfer/plugin/thunar.py:300
+msgid "Create a symlink to file in a chosen location"
+msgstr "Δημιουργία συμβολικού δεσμού σε αρχείο σε επιλεγμένη θέση"
+
+#: ../kupfer/plugin/thunar.py:304
+msgid "Empty Trash"
+msgstr "Άδειασμα απορριμμάτων"
+
+#: ../kupfer/plugin/thunar.py:344
+msgid "Thunar Send To Objects"
+msgstr "Αποστολή αντικειμένων από το Thunar"
+
+#: ../kupfer/plugin/thunderbird.py:4
+msgid "Thunderbird"
+msgstr "Thunderbird"
+
+#: ../kupfer/plugin/thunderbird.py:7
+msgid "Thunderbird/Icedove Contacts and Actions"
+msgstr "Επαφές και ενέργειες Thunderbird/Icedove"
+
+#: ../kupfer/plugin/thunderbird.py:38
+msgid "Compose a new message in Thunderbird"
+msgstr "Σύνταξη νέου μηνύματος στο Thunderbird"
+
+#: ../kupfer/plugin/thunderbird.py:74
+msgid "Thunderbird Address Book"
+msgstr "Βιβλίο διευθύνσεων Thunderbird"
+
+#: ../kupfer/plugin/thunderbird.py:99
+msgid "Contacts from Thunderbird Address Book"
+msgstr "Επαφές από το βιβλίο διευθύνσεων από το Thunderbird"
+
+#: ../kupfer/plugin/top.py:4
+msgid "Top"
+msgstr "Κορυφή"
+
+#: ../kupfer/plugin/top.py:6
+msgid "Show running tasks and allow sending signals to them"
+msgstr ""
+"Εμφάνιση εκτελούμενων εργασιών και δυνατότητα αποστολής σημάτων σε αυτές"
+
+#: ../kupfer/plugin/top.py:23
+msgid "Sort Order"
+msgstr "Σειρά ταξινόμησης"
+
+#: ../kupfer/plugin/top.py:25 ../kupfer/plugin/top.py:26
+#: ../kupfer/plugin/top.py:115
+msgid "Commandline"
+msgstr "Γραμμή εντολών"
+
+#: ../kupfer/plugin/top.py:26
+msgid "CPU usage (descending)"
+msgstr "Xρήση CPU (φθίνουσα)"
+
+#. sort processes (top don't allow to sort via cmd line)
+#: ../kupfer/plugin/top.py:27 ../kupfer/plugin/top.py:112
+msgid "Memory usage (descending)"
+msgstr "Χρήση μνήμης (φθίνουσα)"
+
+#: ../kupfer/plugin/top.py:49
+msgid "Send Signal..."
+msgstr "Αποστολή σήματος..."
+
+#: ../kupfer/plugin/top.py:79
+msgid "Signals"
+msgstr "Σήματα"
+
+#: ../kupfer/plugin/top.py:91
+msgid "Running Tasks"
+msgstr "Εκτέλεση εργασιών"
+
+#. default: by cpu
+#: ../kupfer/plugin/top.py:119
+#, python-format
+msgid "pid: %(pid)s  cpu: %(cpu)g%%  mem: %(mem)g%%  time: %(time)s"
+msgstr "pid: %(pid)s  ΚΜΕ: %(cpu)g%%  μνήμη: %(mem)g%%  διάρκεια: %(time)s"
+
+#: ../kupfer/plugin/top.py:139
+msgid "Running tasks for current user"
+msgstr "Εκτελούμενες εργασίες για τον τρέχοντα χρήστη"
+
+#: ../kupfer/plugin/tracker1.py:10
+msgid "Tracker"
+msgstr "Tracker"
+
+#: ../kupfer/plugin/tracker1.py:18
+msgid "Tracker desktop search integration"
+msgstr "Ολοκλήρωση αναζήτησης επιφάνειας εργασίας Tracker"
+
+#: ../kupfer/plugin/tracker1.py:49
+msgid "Search in Tracker"
+msgstr "Αναζήτηση στο Tracker"
+
+#: ../kupfer/plugin/tracker1.py:54
+msgid "Open Tracker Search Tool and search for this term"
+msgstr "Άνοιγμα του εργαλείου αναζήτησης Tracker και αναζήτηση αυτού του όρου"
+
+#: ../kupfer/plugin/tracker1.py:62
+msgid "Get Tracker Results..."
+msgstr "Λήψη αποτελεσμάτων του Tracker..."
+
+#: ../kupfer/plugin/tracker1.py:71
+msgid "Show Tracker results for query"
+msgstr "Εμφάνιση αποτελεσμάτων του Tracker για ερώτημα"
+
+#. FIXME: Port tracker tag sources and actions
+#. to the new, much more powerful sparql + dbus API
+#. (using tracker-tag as in 0.6 is a plain hack and a dead end)
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/truecrypt.py:3
+msgid "TrueCrypt"
+msgstr "TrueCrypt"
+
+#: ../kupfer/plugin/truecrypt.py:6 ../kupfer/plugin/truecrypt.py:140
+msgid "Volumes from TrueCrypt history"
+msgstr "Τόμοι από το ιστορικό TrueCrypt"
+
+#: ../kupfer/plugin/truecrypt.py:44
+#, python-format
+msgid "TrueCrypt volume: %(file)s"
+msgstr "Τόμος TrueCrypt: %(file)s"
+
+#: ../kupfer/plugin/truecrypt.py:52
+msgid "Mount Volume"
+msgstr "Προσάρτηση τόμου"
+
+#: ../kupfer/plugin/truecrypt.py:63
+msgid "Mount in Truecrypt"
+msgstr "Προσάρτηση στο Truecrypt"
+
+#: ../kupfer/plugin/truecrypt.py:72
+msgid "Try to mount file as Truecrypt volume"
+msgstr "Προσπάθεια προσάρτησης αρχείου ως τόμο Truecrypt"
+
+#: ../kupfer/plugin/truecrypt.py:80
+msgid "Dismount All Volumes"
+msgstr "Αποπροσάρτηση όλων των τόμων"
+
+#: ../kupfer/plugin/truecrypt.py:98
+msgid "TrueCrypt Volumes"
+msgstr "Τόμοι TrueCrypt"
+
+#: ../kupfer/plugin/tsclient.py:4
+msgid "Terminal Server Client"
+msgstr "Πελάτης διακομιστή τερματικού"
+
+#: ../kupfer/plugin/tsclient.py:7
+msgid "Session saved in Terminal Server Client"
+msgstr "Αποθηκευμένη συνεδρία στον πελάτη διακομιστή τερματικού"
+
+#: ../kupfer/plugin/tsclient.py:72
+msgid "TSClient sessions"
+msgstr "Συνεδρίες TSClient"
+
+#: ../kupfer/plugin/tsclient.py:94
+msgid "Saved sessions in Terminal Server Client"
+msgstr "Αποθηκευμένες συνεδρίες στον πελάτη διακομιστή τερματικού"
+
+#: ../kupfer/plugin/vim/__init__.py:1
+msgid "Vim"
+msgstr "Vim"
+
+#: ../kupfer/plugin/vim/__init__.py:4
+msgid "Recently used documents in Vim"
+msgstr "Πρόσφατα χρησιμοποιημένα έγγραφα στο Vim"
+
+#: ../kupfer/plugin/vim/plugin.py:56
+msgid "Vim Recent Documents"
+msgstr "Πρόσφατα έγγραφα Vim"
+
+#: ../kupfer/plugin/vim/plugin.py:219
+msgid "Close (Save All)"
+msgstr "Κλείσιμο (Αποθήκευση όλων)"
+
+#: ../kupfer/plugin/vim/plugin.py:237
+msgid "Send..."
+msgstr "Αποστολή..."
+
+#: ../kupfer/plugin/vim/plugin.py:264
+msgid "Send ex command"
+msgstr "Αποστολή εντολής ex"
+
+#: ../kupfer/plugin/vim/plugin.py:272
+msgid "Insert in Vim..."
+msgstr "Εισαγωγή στο Vim..."
+
+#: ../kupfer/plugin/vim/plugin.py:309
+msgid "Active Vim Sessions"
+msgstr "Ενεργές συνεδρίες Vim"
+
+#: ../kupfer/plugin/vim/plugin.py:338
+#, python-format
+msgid "Vim Session %s"
+msgstr "Συνεδρία %s του Vim"
+
+#: ../kupfer/plugin/vinagre.py:4
+msgid "Vinagre"
+msgstr "Vinagre"
+
+#: ../kupfer/plugin/vinagre.py:7
+msgid "Vinagre bookmarks and actions"
+msgstr "Σελιδοδείκτες και ενέργειες Vinagre"
+
+#: ../kupfer/plugin/vinagre.py:34
+msgid "Start Vinagre Session"
+msgstr "Έναρξη συνεδρίας Vinagre"
+
+#: ../kupfer/plugin/vinagre.py:72
+msgid "Vinagre Bookmarks"
+msgstr "Σελιδοδείκτες Vinagre"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/virtualbox/__init__.py:3
+msgid "VirtualBox"
+msgstr "VirtualBox"
+
+#: ../kupfer/plugin/virtualbox/__init__.py:5
+msgid ""
+"Control VirtualBox Virtual Machines. Supports both Sun VirtualBox and Open "
+"Source Edition."
+msgstr ""
+"Έλεγχος εικονικών μηχανημάτων VirtualBox. Υποστηρίζει και το Sun VirtualBox "
+"και την έκδοση ανοικτού λογισμικού."
+
+#: ../kupfer/plugin/virtualbox/__init__.py:22
+msgid "Force use CLI interface"
+msgstr "Αναγκαστική χρήση διεπαφής CLI"
+
+#: ../kupfer/plugin/virtualbox/__init__.py:86
+#: ../kupfer/plugin/virtualbox/__init__.py:97
+msgid "Power On"
+msgstr "Ενεργοποίηση"
+
+#: ../kupfer/plugin/virtualbox/__init__.py:88
+#: ../kupfer/plugin/virtualbox/__init__.py:99
+msgid "Power On Headless"
+msgstr "Ακέφαλη ενεργοποίηση"
+
+#: ../kupfer/plugin/virtualbox/__init__.py:91
+msgid "Send Power Off Signal"
+msgstr "Αποστολή σήματος τερματισμού"
+
+#: ../kupfer/plugin/virtualbox/__init__.py:94
+msgid "Reboot"
+msgstr "Επανεκκίνηση"
+
+#. VM_STATE_PAUSED
+#: ../kupfer/plugin/virtualbox/__init__.py:102
+msgid "Resume"
+msgstr "Συνέχεια"
+
+#: ../kupfer/plugin/virtualbox/__init__.py:105
+msgid "Save State"
+msgstr "Αποθήκευση κατάστασης"
+
+#: ../kupfer/plugin/virtualbox/__init__.py:107
+msgid "Power Off"
+msgstr "Απενεργοποίηση"
+
+#: ../kupfer/plugin/virtualbox/__init__.py:131
+msgid "VirtualBox Machines"
+msgstr "Μηανήματα VirtualBox"
+
+#: ../kupfer/plugin/zim.py:4
+msgid "Zim"
+msgstr "Zim"
+
+#: ../kupfer/plugin/zim.py:11
+msgid "Access to Pages stored in Zim - A Desktop Wiki and Outliner"
+msgstr ""
+"Πρόσβαση σε σελίδες αποθηκευμένες στο Zim - Μια επιφάνεια εργασίας βίκι και "
+"περίγραμμα"
+
+#: ../kupfer/plugin/zim.py:30
+msgid "Page names start with :colon"
+msgstr "Τα ονόματα σελίδων ξεκινούν με: διπλή τελεία"
+
+#: ../kupfer/plugin/zim.py:36
+msgid "Default page name for quick notes"
+msgstr "Προεπιλεγμένο όνομα σελίδας για γρήγορες σημειώσεις"
+
+#: ../kupfer/plugin/zim.py:38
+#, python-format
+msgid "Note %x %X"
+msgstr "Σημείωση %x %X"
+
+#: ../kupfer/plugin/zim.py:39
+msgid ""
+"Strftime tags can be used: %H - hour, %M - minutes, etc\n"
+"Please check python documentation for details.\n"
+"NOTE: comma will be replaced by _"
+msgstr ""
+"Ετικέτες Strftime μπορούν να χρησιμοποιηθούν: %H - ώρες, %M - λεπτά, κλπ\n"
+"Παρακαλούμε, δείτε την τεκμηρίωση python για λεπτομέρειες.\n"
+"ΣΗΜΕΙΩΣΗ: το κόμμα θα αντικατασταθεί από _"
+
+#: ../kupfer/plugin/zim.py:45
+msgid "Default namespace for quick notes"
+msgstr "Προεπιλεγμένος χώρος ονόματος για γρήγορες σημειώσεις"
+
+#: ../kupfer/plugin/zim.py:80
+#, python-format
+msgid "Zim Page from Notebook \"%s\""
+msgstr "Σελίδα Zim από σημειωματάριο \"%s\""
+
+#: ../kupfer/plugin/zim.py:89
+msgid "Create Zim Page"
+msgstr "Δημιουργία σελίδας Zim"
+
+#: ../kupfer/plugin/zim.py:96
+msgid "Create page in default notebook"
+msgstr "Δημιουργία σελίδας σε προεπιλεγμένο σημειωματάριο"
+
+#: ../kupfer/plugin/zim.py:108
+msgid "Create Zim Page In..."
+msgstr "Δημιουργία σελίδας Zim σε..."
+
+#: ../kupfer/plugin/zim.py:132
+msgid "Insert QuickNote into Zim"
+msgstr "Εισαγωγή γρήγορης σημείωσης στο Zim"
+
+#: ../kupfer/plugin/zim.py:142
+msgid "Quick note selected text into Zim notebook"
+msgstr "Γρήγορη σημείωση επιλεγμένου κειμένου στο σημειωματάριο Zim"
+
+#: ../kupfer/plugin/zim.py:191
+msgid "Create Subpage..."
+msgstr "Δημιουργία υποσελίδας..."
+
+#: ../kupfer/plugin/zim.py:370
+msgid "Zim Notebooks"
+msgstr "Σημειωματάρια Zim"
+
+#: ../kupfer/plugin/zim.py:387
+msgid "Zim Pages"
+msgstr "Σελίδες Zim"
+
+#: ../kupfer/plugin/zim.py:415
+msgid "Pages stored in Zim Notebooks"
+msgstr "Αποθηκευμένες σελίδες σε σημειωματάρια Zim"

--- a/po/hu.po
+++ b/po/hu.po
@@ -3,184 +3,214 @@
 # Hungarian translation by SanskritFritz (gmail)
 # This file is distributed under the same license as the kupfer package. (GPLv3)
 #
+# Reviewed and fixed by Balázs Úr, 2013-04-01
+#
+# Balázs Úr <urbalazs at gmail dot com>, 2013.
 msgid ""
 msgstr ""
 "Project-Id-Version: kupfer\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-04-24 18:13+0200\n"
-"PO-Revision-Date: \n"
-"Last-Translator: SanskritFritz (gmail)\n"
-"Language-Team: \n"
+"Report-Msgid-Bugs-To: http://bugs.launchpad.net/kupfer\n"
+"POT-Creation-Date: 2012-07-05 12:49+0000\n"
+"PO-Revision-Date: 2013-04-01 22:49+0200\n"
+"Last-Translator: Balázs Úr <urbalazs at gmail dot com>\n"
+"Language-Team: Hungarian <kde-l10n-hu@kde.org>\n"
 "Language: Hungarian\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 1.2\n"
 
-#: ../auxdata/kupfer.desktop.in.h:1
-msgid "Application Launcher"
-msgstr "Alkalmazásindító"
-
-#: ../auxdata/kupfer.desktop.in.h:2
-msgid "Convenient command and access tool for applications and documents"
-msgstr "Ügyes kis kütyü alkalmazások indítására és dokumentumok elérésére"
-
-#: ../auxdata/kupfer.desktop.in.h:3 ../kupfer/version.py:15
+#: ../auxdata/kupfer.desktop.in.h:1 ../kupfer/version.py:15
 #: ../kupfer/plugin/core/contents.py:91
 msgid "Kupfer"
 msgstr "Kupfer"
 
+#: ../auxdata/kupfer.desktop.in.h:2
+msgid "Application Launcher"
+msgstr "Alkalmazásindító"
+
+#: ../auxdata/kupfer.desktop.in.h:3
+msgid "Convenient command and access tool for applications and documents"
+msgstr ""
+"Kényelmes parancs és hozzáférési eszköz az alkalmazásokhoz és dokumentumokhoz"
+
 #: ../auxdata/kupfer-exec.desktop.in.h:1
 msgid "Execute in Kupfer"
-msgstr "Végrehajtás Kupfer-ben"
+msgstr "Végrehajtás a Kupferben"
 
 #: ../auxdata/kupfer-mimetypes.xml.in.h:1
 msgid "Saved Kupfer Command"
-msgstr "Elmentett Kupfer parancs"
-
-#: ../data/preferences.ui.h:1
-msgid "<b>Browser Keyboard Shortcuts</b>"
-msgstr "<b>Böngésző gyorsbillentyűk</b>"
-
-#: ../data/preferences.ui.h:2
-msgid "<b>Global Keyboard Shortcuts</b>"
-msgstr "<b>Globális gyorsbillentyűk</b>"
-
-#: ../data/preferences.ui.h:3
-msgid "<b>Start</b>"
-msgstr "<b>Start</b>"
-
-#: ../data/preferences.ui.h:4 ../kupfer/obj/sources.py:150
-msgid "Catalog"
-msgstr "Katalógus"
-
-#: ../data/preferences.ui.h:5
-msgid "Desktop Environment"
-msgstr "Asztali környezet"
-
-#: ../data/preferences.ui.h:6
-msgid "Folders whose files are always available in the catalog."
-msgstr "Mappák, melyek fájljai mindig láthatók lesznek a katalógusban."
-
-#: ../data/preferences.ui.h:7
-msgid "General"
-msgstr "Általános"
-
-#: ../data/preferences.ui.h:8
-msgid "Icon set:"
-msgstr "Ikonkészlet:"
-
-#: ../data/preferences.ui.h:9
-msgid "Inclusion in Top Level Searches"
-msgstr "A legfelső szinten is kereshető elemek"
-
-#: ../data/preferences.ui.h:10
-msgid "Indexed Folders"
-msgstr "Indexelt mappák"
-
-#: ../data/preferences.ui.h:11
-msgid "Keyboard"
-msgstr "Billentyűzet"
-
-#: ../data/preferences.ui.h:12 ../kupfer/plugin/core/contents.py:78
-msgid "Kupfer Preferences"
-msgstr "Kupfer beállítások"
-
-#: ../data/preferences.ui.h:13
-msgid ""
-"Marked sources have their objects included in top level searches.\n"
-"An unmarked source's contents are only available by locating its subcatalog."
-msgstr ""
-"A kijelölt források elemei mindig láthatók lesznek a kereső legfelső "
-"szintjén.\n"
-"A többi forrás tartalma a megfelelő alkatalógus kiválasztása után látható."
-
-#: ../data/preferences.ui.h:15
-msgid "Plugins"
-msgstr "Beépülők"
-
-#: ../data/preferences.ui.h:16 ../kupfer/ui/preferences.py:833
-msgid "Reset"
-msgstr "Alapállapot"
-
-#: ../data/preferences.ui.h:17
-msgid "Show icon in notification area"
-msgstr "Ikon megjelenítése az értesítési területen"
-
-#: ../data/preferences.ui.h:18
-msgid "Start automatically on login"
-msgstr "Bejelentkezés után automatikusan induljon el"
-
-#: ../data/preferences.ui.h:19
-msgid "Terminal emulator:"
-msgstr "Terminálemulátor"
-
-#: ../data/preferences.ui.h:20
-msgid "Use single keystroke commands (Space, /, period, comma etc.)"
-msgstr ""
-"Egyszerű billentyűparancsok használata (Szóköz, /, pont, / vessző stb.)"
+msgstr "Mentett Kupfer parancs"
 
 #: ../data/credentials_dialog.ui.h:1
 msgid "User credentials"
-msgstr "Felhasználói jogok"
+msgstr "Felhasználói hitelesítési adatok"
 
 #: ../data/credentials_dialog.ui.h:2
-msgid "_Change"
-msgstr "Változtatás"
+msgid "_User:"
+msgstr "_Felhasználó:"
 
 #: ../data/credentials_dialog.ui.h:3
 msgid "_Password:"
 msgstr "_Jelszó:"
 
 #: ../data/credentials_dialog.ui.h:4
-msgid "_User:"
-msgstr "_Felhasználó:"
+msgid "_Change"
+msgstr "_Módosítás"
 
 #: ../data/getkey_dialog.ui.h:1
-msgid "Keybinding could not be bound"
-msgstr "A billentyűparancs nem található"
+msgid "Set Keyboard Shortcut"
+msgstr "Gyorsbillentyű beállítása"
 
 #: ../data/getkey_dialog.ui.h:2
 msgid "Please press desired key combination"
-msgstr "Nyomd meg a kívánt billentyűkombinációt"
+msgstr "Nyomja le a kívánt billentyűkombinációt"
 
 #: ../data/getkey_dialog.ui.h:3
-msgid "Set Keyboard Shortcut"
-msgstr "Billentyűkombináció beállítása"
+msgid "Keybinding could not be bound"
+msgstr "A billentyűparancs nem köthető"
+
+#: ../data/preferences.ui.h:1 ../kupfer/plugin/core/contents.py:78
+msgid "Kupfer Preferences"
+msgstr "Kupfer beállítások"
+
+#: ../data/preferences.ui.h:2
+msgid "Start automatically on login"
+msgstr "Automatikus indulás bejelentkezéskor"
+
+#: ../data/preferences.ui.h:3
+msgid "<b>Start</b>"
+msgstr "<b>Indítás</b>"
+
+#: ../data/preferences.ui.h:4
+msgid "Show icon in notification area"
+msgstr "Ikon megjelenítése az értesítési területen"
+
+#: ../data/preferences.ui.h:5
+msgid "Icon set:"
+msgstr "Ikonkészlet:"
+
+#: ../data/preferences.ui.h:6
+msgid "Terminal emulator:"
+msgstr "Terminál emulátor:"
+
+#: ../data/preferences.ui.h:7
+msgid "Desktop Environment"
+msgstr "Asztali környezet"
+
+#: ../data/preferences.ui.h:8 ../kupfer/plugin/gmail/__init__.py:60
+msgid "General"
+msgstr "Általános"
+
+#: ../data/preferences.ui.h:9
+msgid "<b>Global Keyboard Shortcuts</b>"
+msgstr "<b>Globális gyorsbillentyűk</b>"
+
+#: ../data/preferences.ui.h:10 ../kupfer/ui/preferences.py:849
+msgid "Reset"
+msgstr "Visszaállítás"
+
+#: ../data/preferences.ui.h:11
+msgid "<b>Browser Keyboard Shortcuts</b>"
+msgstr "<b>Böngésző gyorsbillentyűk</b>"
+
+#: ../data/preferences.ui.h:12
+msgid "Use single keystroke commands (Space, /, period, comma etc.)"
+msgstr "Egyszerű billentyűparancsok használata (Szóköz, /, pont, vessző stb.)"
+
+#: ../data/preferences.ui.h:13
+msgid "Keyboard"
+msgstr "Billentyűzet"
+
+#: ../data/preferences.ui.h:14
+msgid "Plugins"
+msgstr "Bővítmények"
+
+#: ../data/preferences.ui.h:15
+msgid "Inclusion in Top Level Searches"
+msgstr "Tartalmazza a legfelső szintű kereséseket"
+
+#: ../data/preferences.ui.h:16
+msgid ""
+"Marked sources have their objects included in top level searches.\n"
+"An unmarked source's contents are only available by locating its subcatalog."
+msgstr ""
+"A kijelölt források objektumai benne lesznek a legfelső szintű keresésekben.\n"
+"A többi forrás tartalma csak az alkatalógus kiválasztásakor lesz elérhető."
+
+#: ../data/preferences.ui.h:18
+msgid "Indexed Folders"
+msgstr "Indexelt mappák"
+
+#: ../data/preferences.ui.h:19
+msgid "Folders whose files are always available in the catalog."
+msgstr "Mappák, amelyek fájljai mindig elérhetők lesznek a katalógusban."
+
+#: ../data/preferences.ui.h:20 ../kupfer/obj/sources.py:157
+msgid "Catalog"
+msgstr "Katalógus"
+
+#: ../kupfer/core/commandexec.py:239
+#, python-format
+msgid "Could not to carry out '%s'"
+msgstr "Nem hajtható végre: „%s”"
+
+#: ../kupfer/core/commandexec.py:268
+#, python-format
+msgid "\"%s\" produced a result"
+msgstr "„%s” eredményt adott"
+
+#: ../kupfer/core/execfile.py:30
+#, python-format
+msgid "No permission to run \"%s\" (not executable)"
+msgstr "Nincs jogosultság „%s” futtatására (nem végrehajtható)"
+
+#: ../kupfer/core/execfile.py:47
+#, python-format
+msgid "Command in \"%s\" is not available"
+msgstr "A parancs nem érhető el ebben: „%s”"
+
+#: ../kupfer/keyrelay.py:62
+#, python-format
+msgid "Keyboard relay is active for display %s"
+msgstr "A billentyű-továbbítás aktív a(z) %s képernyőnek"
 
 #: ../kupfer/main.py:43
 msgid "do not present main interface on launch"
-msgstr "ne jelenjen meg a főablak induláskor"
+msgstr "ne jelenjen meg a fő felület induláskor"
 
 #: ../kupfer/main.py:44
 msgid "list available plugins"
-msgstr "választható beépülők listája"
+msgstr "elérhető bővítmények listázása"
 
 #: ../kupfer/main.py:45
 msgid "enable debug info"
-msgstr "debug információ engedélyezése"
+msgstr "hibakeresési információk engedélyezése"
 
-#: ../kupfer/main.py:46
-msgid "run keyboard shortcut relay service on this display"
-msgstr "Billentyűtovábbító szolgáltatás engedélyezése ezen a képernyőn"
-
+#. TRANS: --exec-helper=HELPER is an internal command
+#. TRANS: that executes a helper program that is part of kupfer
 #: ../kupfer/main.py:49
+msgid "run plugin helper"
+msgstr "bővítménysegéd futtatása"
+
+#: ../kupfer/main.py:52
 msgid "show usage help"
-msgstr "kis segítség a használathoz"
+msgstr "használatai súgó megjelenítése"
 
-#: ../kupfer/main.py:50
+#: ../kupfer/main.py:53
 msgid "show version information"
-msgstr "verzióinformáció"
+msgstr "verzióinformációk megjelenítése"
 
-#: ../kupfer/main.py:56
+#: ../kupfer/main.py:59
 msgid "Usage: kupfer [ OPTIONS | FILE ... ]"
-msgstr "Használat: kupfer [ OPCIÓK | FÁJL ... ]"
+msgstr "Használat: kupfer [ KAPCSOLÓK | FÁJL … ]"
 
-#: ../kupfer/main.py:67
+#: ../kupfer/main.py:70
 msgid "Available plugins:"
-msgstr "Rendelkezésre álló beépülők:"
+msgstr "Elérhető bővítmények:"
 
-#: ../kupfer/main.py:114
+#: ../kupfer/main.py:121
 #, python-format
 msgid ""
 "%(PROGRAM_NAME)s: %(SHORT_DESCRIPTION)s\n"
@@ -194,7 +224,7 @@ msgstr ""
 #. TRANS: Names of accelerators in the interface
 #: ../kupfer/ui/accelerators.py:4
 msgid "Alternate Activate"
-msgstr "Alternatív aktiváló"
+msgstr "Alternatív aktiválása"
 
 #. TRANS: The "Comma Trick"/"Put Selection on Stack" allows the
 #. TRANS: user to select many objects to be used for one action
@@ -206,47 +236,47 @@ msgstr "Vesszőtrükk"
 #. TRANS: object + action (+iobject)
 #: ../kupfer/ui/accelerators.py:10
 msgid "Compose Command"
-msgstr "Parancsösszeállító"
+msgstr "Parancs összeállítása"
 
 #: ../kupfer/ui/accelerators.py:11
 msgid "Mark Default Action"
-msgstr "Alapértelmezett művelet kijelölése"
+msgstr "Alapértelmezett művelet jelölése"
 
 #: ../kupfer/ui/accelerators.py:12
 msgid "Forget Object"
-msgstr "Elem elfelejtése"
+msgstr "Objektum elfelejtése"
 
 #: ../kupfer/ui/accelerators.py:13
 msgid "Reset All"
-msgstr "Visszaállít mindent"
+msgstr "Összes visszaállítása"
 
 #: ../kupfer/ui/accelerators.py:14
 msgid "Select Quit"
-msgstr "Kilépés választása"
+msgstr "Kilépés kiválasztása"
 
 #: ../kupfer/ui/accelerators.py:15
 msgid "Select Selected File"
-msgstr "Kiválasztott fájl választása"
+msgstr "Kijelölt fájl kiválasztása"
 
 #: ../kupfer/ui/accelerators.py:16
 msgid "Select Selected Text"
-msgstr "Kijelölt szöveg válalsztása"
+msgstr "Kijelölt szöveg kiválasztása"
 
 #: ../kupfer/ui/accelerators.py:17
 msgid "Show Help"
-msgstr "Súgó"
+msgstr "Súgó megjelenítése"
 
 #: ../kupfer/ui/accelerators.py:18
 msgid "Show Preferences"
-msgstr "Beállítások"
+msgstr "Beállítások megjelenítése"
 
 #: ../kupfer/ui/accelerators.py:19
 msgid "Switch to First Pane"
-msgstr "Váltás az első panelre"
+msgstr "Váltás az első ablaktáblára"
 
 #: ../kupfer/ui/accelerators.py:20
 msgid "Toggle Text Mode"
-msgstr "Szöveges mód ki/be"
+msgstr "Szöveges mód váltása"
 
 #: ../kupfer/ui/browser.py:888
 #, python-format
@@ -256,117 +286,129 @@ msgstr "%s üres"
 #: ../kupfer/ui/browser.py:892
 #, python-format
 msgid "No matches in %(src)s for \"%(query)s\""
-msgstr "%(src)s-ben nincs illeszkedés erre: \"%(query)s\""
+msgstr "Nincs találat ebben: %(src)s erre: „%(query)s”"
 
 #: ../kupfer/ui/browser.py:898
 msgid "No matches"
-msgstr "A minta nem illeszkedik"
+msgstr "Nincs találat"
 
 #: ../kupfer/ui/browser.py:903
 msgid "Type to search"
-msgstr "Kereséshez gépelj"
+msgstr "Gépeljen a kereséshez"
 
 #: ../kupfer/ui/browser.py:909
 #, python-format
 msgid "Type to search %s"
-msgstr "%s kereséséhez gépelj"
+msgstr "Gépeljen %s kereséséhez"
 
 #: ../kupfer/ui/browser.py:924
 msgid "No action"
-msgstr "Nincs parancs"
+msgstr "Nincs művelet"
 
-#: ../kupfer/ui/browser.py:1451
+#: ../kupfer/ui/browser.py:1513
 #, python-format
 msgid "Make \"%(action)s\" Default for \"%(object)s\""
-msgstr "Legyen \"%(action)s\" az alapértelmezett ehhez: \"%(object)s\""
+msgstr "Legyen „%(action)s” az alapértelmezett ehhez: „%(object)s”"
 
 #. TRANS: Removing learned and/or configured bonus search score
-#: ../kupfer/ui/browser.py:1461
+#: ../kupfer/ui/browser.py:1523
 #, python-format
 msgid "Forget About \"%s\""
-msgstr "Felejtsd el ezt: \"%s\""
+msgstr "Felejtse el ezt: „%s”"
 
 #. TRANS: Names of global keyboard shortcuts
-#: ../kupfer/ui/browser.py:1893 ../kupfer/ui/preferences.py:58
+#: ../kupfer/ui/browser.py:1960 ../kupfer/ui/preferences.py:58
 msgid "Show Main Interface"
-msgstr "Főablak megjelenítése"
+msgstr "Fő felület megjelenítése"
 
 #: ../kupfer/ui/preferences.py:59
 msgid "Show with Selection"
-msgstr "Megjelenítés a kijelölt szöveggel"
+msgstr "Megjelenítés a kijelöléssel"
 
 #. TRANS: Plugin info fields
-#: ../kupfer/ui/preferences.py:414
+#: ../kupfer/ui/preferences.py:416
 msgid "Description"
 msgstr "Leírás"
 
-#: ../kupfer/ui/preferences.py:414
+#: ../kupfer/ui/preferences.py:416
 msgid "Author"
 msgstr "Szerző"
 
-#: ../kupfer/ui/preferences.py:431
+#: ../kupfer/ui/preferences.py:433
 msgid "Version"
 msgstr "Verzió"
 
 #. TRANS: Error message when Plugin needs a Python module to load
-#: ../kupfer/ui/preferences.py:441
+#: ../kupfer/ui/preferences.py:443
 #, python-format
 msgid "Python module '%s' is needed"
-msgstr "'%s' python modul szükséges ehhez"
+msgstr "A(z) „%s” Python modul szükséges"
 
-#: ../kupfer/ui/preferences.py:455
+#: ../kupfer/ui/preferences.py:457
 msgid "Plugin could not be read due to an error:"
-msgstr "A beépülő nem olvasható valamilyen hiba miatt:"
+msgstr "A bővítmény nem olvasható valamilyen hiba miatt:"
 
-#: ../kupfer/ui/preferences.py:463 ../kupfer/plugin/kupfer_plugins.py:80
+#: ../kupfer/ui/preferences.py:465 ../kupfer/plugin/kupfer_plugins.py:80
 msgid "disabled"
 msgstr "letiltva"
 
-#: ../kupfer/ui/preferences.py:537
+#: ../kupfer/ui/preferences.py:539
 msgid "Content of"
 msgstr "Tartalom"
 
 #. TRANS: Plugin contents header
-#: ../kupfer/ui/preferences.py:546
+#: ../kupfer/ui/preferences.py:548
 msgid "Sources"
 msgstr "Források"
 
 #. TRANS: Plugin contents header
-#: ../kupfer/ui/preferences.py:550
+#: ../kupfer/ui/preferences.py:552
 msgid "Actions"
-msgstr "Parancsok"
+msgstr "Műveletek"
+
+#: ../kupfer/ui/preferences.py:575
+#, python-format
+msgid "Using encrypted password storage: %s"
+msgstr "Titkosított jelszótároló használata: %s"
+
+#: ../kupfer/ui/preferences.py:577
+#, python-format
+msgid "Using password storage: %s"
+msgstr "Jelszótároló használata: %s"
 
 #. TRANS: Plugin-specific configuration (header)
-#: ../kupfer/ui/preferences.py:587
+#: ../kupfer/ui/preferences.py:594
 msgid "Configuration"
 msgstr "Beállítások"
 
-#: ../kupfer/ui/preferences.py:607
+#: ../kupfer/ui/preferences.py:614
 msgid "Set username and password"
-msgstr "Felhasználói név és jelszó beállítása"
+msgstr "Felhasználónév és jelszó beállítása"
 
 #. TRANS: File Chooser Title
-#: ../kupfer/ui/preferences.py:661
+#: ../kupfer/ui/preferences.py:668
 msgid "Choose a Directory"
-msgstr "Válassz mappát"
+msgstr "Válasszon könyvtárat"
 
-#: ../kupfer/ui/preferences.py:831
+#: ../kupfer/ui/preferences.py:847
 msgid "Reset all shortcuts to default values?"
-msgstr "Minden billentyűparancs alapértelmezett legyen?"
+msgstr "Visszaállít minden gyorsbillentyűt az alapértelmezett értékre?"
 
-#: ../kupfer/ui/preferences.py:839 ../kupfer/plugin/custom_terminal.py:12
+#: ../kupfer/ui/preferences.py:855 ../kupfer/plugin/custom_terminal.py:12
 msgid "Command"
 msgstr "Parancs"
 
-#: ../kupfer/ui/preferences.py:840
+#: ../kupfer/ui/preferences.py:856
 msgid "Shortcut"
-msgstr "Billentyűparancs"
+msgstr "Gyorsbillentyű"
 
 #. TRANS: Don't translate literally!
 #. TRANS: This should be a list of all translators of this language
 #: ../kupfer/version.py:73
 msgid "translator-credits"
-msgstr "Fordítók"
+msgstr ""
+"SanskritFritz <sanskritfritz@gmail.com>\n"
+"Úr Balázs <urbalazs@gmail.com>"
 
 #: ../kupfer/version.py:78
 msgid "A free software (GPLv3+) launcher"
@@ -407,32 +449,7 @@ msgstr ""
 #. follows strings used elsewhere
 #: ../kupfer/version.py:98
 msgid "Could not find running Kupfer"
-msgstr "Nem találtam aktívan futó Kupfer-t"
-
-#: ../kupfer/keyrelay.py:62
-#, python-format
-msgid "Keyboard relay is active for display %s"
-msgstr "Billentyűtovábbítás aktív a %s képernyőnek"
-
-#: ../kupfer/core/commandexec.py:239
-#, python-format
-msgid "Could not to carry out '%s'"
-msgstr "Nem tudtam végrehajtani: '%s'"
-
-#: ../kupfer/core/commandexec.py:268
-#, python-format
-msgid "\"%s\" produced a result"
-msgstr "\"%s\" adott ereményt"
-
-#: ../kupfer/core/execfile.py:30
-#, python-format
-msgid "No permission to run \"%s\" (not executable)"
-msgstr "Engedély híján nem tudom futtatni: \"%s\" (nem végrehajtható)"
-
-#: ../kupfer/core/execfile.py:47
-#, python-format
-msgid "Command in \"%s\" is not available"
-msgstr "A parancs nem áll rendelkezésre itt: \"%s\""
+msgstr "Nem található futó Kupfer"
 
 #: ../kupfer/obj/base.py:457 ../kupfer/plugin/core/text.py:22
 msgid "Text"
@@ -440,27 +457,62 @@ msgstr "Szöveg"
 
 #: ../kupfer/obj/compose.py:15
 msgid "Run after Delay..."
-msgstr "Futtatás némi szünet után..."
+msgstr "Futtatás késleltetés után…"
 
 #: ../kupfer/obj/compose.py:36
 msgid "Perform command after a specified time interval"
-msgstr "Parancs végrehajtása megadott idő után"
+msgstr "Parancs végrehajtása egy megadott időtartam után"
 
 #: ../kupfer/obj/compose.py:95
 msgid "Multiple Objects"
-msgstr "Több elem"
+msgstr "Több objektum"
 
 #: ../kupfer/obj/compose.py:126
 #, python-format
 msgid "%s object"
 msgid_plural "%s objects"
-msgstr[0] "%s elem"
-msgstr[1] "%s elem"
+msgstr[0] "%s objektum"
+msgstr[1] "%s objektum"
 
-#: ../kupfer/obj/contacts.py:87 ../kupfer/plugin/pidgin.py:156
+#: ../kupfer/obj/contacts.py:129 ../kupfer/plugin/pidgin.py:156
 #, python-format
 msgid "[%(status)s] %(userid)s/%(service)s"
 msgstr "[%(status)s] %(userid)s/%(service)s"
+
+#: ../kupfer/obj/contacts.py:131
+msgid "unknown"
+msgstr "ismeretlen"
+
+#: ../kupfer/obj/contacts.py:144
+#| msgid "Vim"
+msgid "Aim"
+msgstr "Aim"
+
+#: ../kupfer/obj/contacts.py:151
+#| msgid "Google Translate"
+msgid "Google Talk"
+msgstr "Google Talk"
+
+#: ../kupfer/obj/contacts.py:159
+msgid "ICQ"
+msgstr "ICQ"
+
+#: ../kupfer/obj/contacts.py:166
+msgid "MSN"
+msgstr "MSN"
+
+#: ../kupfer/obj/contacts.py:173
+msgid "QQ"
+msgstr "QQ"
+
+#: ../kupfer/obj/contacts.py:180
+msgid "Yahoo"
+msgstr "Yahoo"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/obj/contacts.py:187 ../kupfer/plugin/skype.py:2
+msgid "Skype"
+msgstr "Skype"
 
 #: ../kupfer/obj/exceptions.py:19
 #, python-format
@@ -469,126 +521,126 @@ msgstr "%s nem támogatja ezt a műveletet"
 
 #: ../kupfer/obj/exceptions.py:24
 msgid "Can not be used with multiple objects"
-msgstr "Nem használható több elemmel egyszerre"
+msgstr "Nem használható több objektummal"
 
-#: ../kupfer/obj/fileactions.py:30 ../kupfer/plugin/notes.py:79
-#: ../kupfer/plugin/gnome_terminal.py:36 ../kupfer/plugin/gtg.py:108
-#: ../kupfer/plugin/zim.py:107
+#: ../kupfer/obj/fileactions.py:30 ../kupfer/plugin/notes.py:89
+#: ../kupfer/plugin/gnome_terminal.py:36 ../kupfer/plugin/gtg.py:135
+#: ../kupfer/plugin/zim.py:176
 msgid "Open"
 msgstr "Megnyitás"
 
 #: ../kupfer/obj/fileactions.py:43
 #, python-format
 msgid "No default application for %(file)s (%(type)s)"
-msgstr "Nincs alapértelmezett alkalmazás %(file)s (%(type)s)-hez"
+msgstr "Nincs alapértelmezett alkalmazás ehhez: %(file)s (%(type)s)"
 
 #: ../kupfer/obj/fileactions.py:45
 #, python-format
 msgid "Please use \"%s\""
-msgstr "Kérlek használd a \"%s\"-t"
+msgstr "Kérem használja ezt: „%s”"
 
 #: ../kupfer/obj/fileactions.py:45 ../kupfer/plugin/applications.py:109
 msgid "Set Default Application..."
-msgstr "Alapértelmezett alkalmazás beállítása..."
+msgstr "Alapértelmezett alkalmazás beállítása…"
 
 #: ../kupfer/obj/fileactions.py:71
 msgid "Open with default application"
-msgstr "Megnyitás alapértelmezett alkalmazással"
+msgstr "Megnyitás az alapértelmezett alkalmazással"
 
-#: ../kupfer/obj/fileactions.py:77
+#: ../kupfer/obj/fileactions.py:74
 msgid "Reveal"
-msgstr "Megjelenítés"
+msgstr "Felfedés"
 
-#: ../kupfer/obj/fileactions.py:86
+#: ../kupfer/obj/fileactions.py:83
 msgid "Open parent folder"
-msgstr "Szülőkönyvtár megnyitása"
+msgstr "Szülőmappa megnyitása"
 
-#: ../kupfer/obj/fileactions.py:92
+#: ../kupfer/obj/fileactions.py:89
 msgid "Open Terminal Here"
 msgstr "Terminál megnyitása itt"
 
-#: ../kupfer/obj/fileactions.py:105
+#: ../kupfer/obj/fileactions.py:102
 msgid "Open this location in a terminal"
-msgstr "A hely megnyitása terminálban"
+msgstr "A hely megnyitása a terminálban"
 
-#: ../kupfer/obj/fileactions.py:113
+#: ../kupfer/obj/fileactions.py:110
 msgid "Run in Terminal"
 msgstr "Futtatás terminálban"
 
-#: ../kupfer/obj/fileactions.py:113
+#: ../kupfer/obj/fileactions.py:110
 msgid "Run (Execute)"
 msgstr "Futtatás (végrehajtás)"
 
-#: ../kupfer/obj/fileactions.py:133
+#: ../kupfer/obj/fileactions.py:130
 msgid "Run this program in a Terminal"
 msgstr "A program futtatása terminálban"
 
-#: ../kupfer/obj/fileactions.py:135
+#: ../kupfer/obj/fileactions.py:132
 msgid "Run this program"
-msgstr "Futtasd ezt a programot"
+msgstr "A program futtatása"
 
-#: ../kupfer/obj/objects.py:248 ../kupfer/plugin/windows.py:105
-#: ../kupfer/plugin/windows.py:264
+#: ../kupfer/obj/objects.py:252 ../kupfer/plugin/windows.py:105
+#: ../kupfer/plugin/windows.py:264 ../kupfer/plugin/vim/plugin.py:172
 msgid "Go To"
 msgstr "Ugrás"
 
-#: ../kupfer/obj/objects.py:274
+#: ../kupfer/obj/objects.py:278
 msgid "Open URL"
 msgstr "URL megnyitása"
 
-#: ../kupfer/obj/objects.py:285
+#: ../kupfer/obj/objects.py:289
 msgid "Open URL with default viewer"
-msgstr "URL megnyitása alapértelmezett nézővel"
+msgstr "URL megnyitása az alapértelmezett megjelenítővel"
 
-#: ../kupfer/obj/objects.py:299
+#: ../kupfer/obj/objects.py:303
 msgid "Launch"
 msgstr "Indítás"
 
-#: ../kupfer/obj/objects.py:312
+#: ../kupfer/obj/objects.py:316
 msgid "Show application window"
-msgstr "Alkalmazásablak megmutatása"
+msgstr "Alkalmazásablak megjelenítése"
 
-#: ../kupfer/obj/objects.py:313
+#: ../kupfer/obj/objects.py:317
 msgid "Launch application"
 msgstr "Alkalmazás indítása"
 
-#: ../kupfer/obj/objects.py:324
+#: ../kupfer/obj/objects.py:328
 msgid "Launch Again"
-msgstr "Indítás még egyszer"
+msgstr "Indítás újra"
 
-#: ../kupfer/obj/objects.py:331
+#: ../kupfer/obj/objects.py:335
 msgid "Launch another instance of this application"
 msgstr "Az alkalmazás még egy példányának indítása"
 
-#: ../kupfer/obj/objects.py:337 ../kupfer/plugin/windows.py:37
+#: ../kupfer/obj/objects.py:341 ../kupfer/plugin/windows.py:37
 msgid "Close"
 msgstr "Bezárás"
 
-#: ../kupfer/obj/objects.py:345
+#: ../kupfer/obj/objects.py:349
 msgid "Attempt to close all application windows"
 msgstr "Kísérlet minden alkalmazásablak bezárására"
 
 #. TRANS: 'Run' as in Perform a (saved) command
-#: ../kupfer/obj/objects.py:392
+#: ../kupfer/obj/objects.py:398
 msgid "Run"
 msgstr "Futtatás"
 
-#: ../kupfer/obj/objects.py:402
+#: ../kupfer/obj/objects.py:408
 msgid "Perform command"
 msgstr "Parancs végrehajtása"
 
-#: ../kupfer/obj/objects.py:416
+#: ../kupfer/obj/objects.py:421
 msgid "(Empty Text)"
 msgstr "(Üres szöveg)"
 
 #. TRANS: This is description for a TextLeaf, a free-text search
 #. TRANS: The plural parameter is the number of lines %(num)d
-#: ../kupfer/obj/objects.py:432
+#: ../kupfer/obj/objects.py:451
 #, python-format
 msgid "\"%(text)s\""
 msgid_plural "(%(num)d lines) \"%(text)s\""
-msgstr[0] "\"%(text)s\""
-msgstr[1] "(%(num)d sor) \"%(text)s\""
+msgstr[0] "„%(text)s”"
+msgstr[1] "(%(num)d sor) „%(text)s”"
 
 #. TRANS: Multiple artist description "Artist1 et. al. "
 #: ../kupfer/obj/sources.py:24 ../kupfer/plugin/rhythmbox.py:247
@@ -601,183 +653,40 @@ msgstr "%s et. al."
 msgid "Recursive source of %(dir)s, (%(levels)d levels)"
 msgstr "%(dir)s rekurzív forrása, (%(levels)d szint)"
 
-#: ../kupfer/obj/sources.py:103
+#: ../kupfer/obj/sources.py:108
 #, python-format
 msgid "Directory source %s"
-msgstr "Mappa forrás %s"
+msgstr "Könyvtár forrás %s"
 
-#: ../kupfer/obj/sources.py:113
+#: ../kupfer/obj/sources.py:119
 msgid "Home Folder"
 msgstr "Saját mappa"
 
-#: ../kupfer/obj/sources.py:124
+#: ../kupfer/obj/sources.py:130
 msgid "Catalog Index"
 msgstr "Katalógus-index"
 
-#: ../kupfer/obj/sources.py:139
+#: ../kupfer/obj/sources.py:145
 msgid "An index of all available sources"
-msgstr "A rendelkezésre álló források indexe"
+msgstr "Az összes elérhető forrás indexe"
 
-#: ../kupfer/obj/sources.py:170
+#: ../kupfer/obj/sources.py:177
 msgid "Root catalog"
 msgstr "Gyökérkatalógus"
 
 #: ../kupfer/obj/special.py:10
 msgid "Please Configure Plugin"
-msgstr "Kérlek konfiguráld a beépülőt"
+msgstr "Kérem állítsa be a bővítményt"
 
 #: ../kupfer/obj/special.py:11
 #, python-format
 msgid "Plugin %s is not configured"
-msgstr "A %s beépülő nincs beállítva"
+msgstr "A(z) %s bővítmény nincs beállítva"
 
 #: ../kupfer/obj/special.py:32
 #, python-format
 msgid "Invalid user credentials for %s"
-msgstr "Felhasználói jogok hiányoznak a %s-hez"
-
-#: ../kupfer/plugin/core/alternatives.py:7
-msgid "GTK+"
-msgstr "GTK+"
-
-#: ../kupfer/plugin/core/alternatives.py:13
-msgid "GNOME Terminal"
-msgstr "GNOME Terminal"
-
-#: ../kupfer/plugin/core/alternatives.py:22
-msgid "XFCE Terminal"
-msgstr "XFCE Terminal"
-
-#: ../kupfer/plugin/core/alternatives.py:31
-msgid "LXTerminal"
-msgstr "LXTerminal"
-
-#: ../kupfer/plugin/core/alternatives.py:40
-msgid "X Terminal"
-msgstr "X Terminal"
-
-#: ../kupfer/plugin/core/alternatives.py:49
-msgid "Urxvt"
-msgstr "Urxvt"
-
-#: ../kupfer/plugin/core/commands.py:13 ../kupfer/plugin/core/commands.py:32
-msgid "Save As..."
-msgstr "Mentés másként..."
-
-#: ../kupfer/plugin/core/contents.py:41
-msgid "Quit"
-msgstr "Kilépés"
-
-#: ../kupfer/plugin/core/contents.py:46
-msgid "Quit Kupfer"
-msgstr "Kilépés a Kupfer-ből"
-
-#: ../kupfer/plugin/core/contents.py:52
-msgid "About Kupfer"
-msgstr "Kupfer névjegy"
-
-#: ../kupfer/plugin/core/contents.py:59
-msgid "Show information about Kupfer authors and license"
-msgstr "Lássunk valami infót a Kupfer alkotóiról és a licenszről"
-
-#: ../kupfer/plugin/core/contents.py:65
-msgid "Kupfer Help"
-msgstr "Kupfer súgó"
-
-#: ../kupfer/plugin/core/contents.py:72
-msgid "Get help with Kupfer"
-msgstr "Némi segítség a Kupfer használatához"
-
-#: ../kupfer/plugin/core/contents.py:85
-msgid "Show preferences window for Kupfer"
-msgstr "A Kupfer beállításai"
-
-#: ../kupfer/plugin/core/__init__.py:65
-msgid "Search Contents"
-msgstr "Keresés a tartalomban"
-
-#: ../kupfer/plugin/core/__init__.py:83
-msgid "Search inside this catalog"
-msgstr "Keresés ebben a katalógusban"
-
-#: ../kupfer/plugin/core/__init__.py:91
-msgid "Copy"
-msgstr "Másolás"
-
-#: ../kupfer/plugin/core/__init__.py:106
-msgid "Copy to clipboard"
-msgstr "Másolás a vágólapra"
-
-#: ../kupfer/plugin/core/__init__.py:128
-msgid "Rescan"
-msgstr "Újrakeresés"
-
-#: ../kupfer/plugin/core/__init__.py:143
-msgid "Force reindex of this source"
-msgstr "Erőltesd a forrás újraindexelését"
-
-#: ../kupfer/plugin/core/selection.py:8 ../kupfer/plugin/core/selection.py:36
-msgid "Selected Text"
-msgstr "Kijelölt szöveg"
-
-#: ../kupfer/plugin/core/selection.py:23
-#, python-format
-msgid "Selected Text \"%s\""
-msgstr "Kijelölt szöveg \"%s\""
-
-#: ../kupfer/plugin/core/internal.py:13
-msgid "Last Command"
-msgstr "Utolsó parancs"
-
-#: ../kupfer/plugin/core/internal.py:24
-msgid "Internal Kupfer Objects"
-msgstr "Kupfer belső elemei"
-
-#: ../kupfer/plugin/core/internal.py:46 ../kupfer/plugin/core/internal.py:48
-msgid "Last Result"
-msgstr "Utolső eredmény"
-
-#: ../kupfer/plugin/core/internal.py:66
-msgid "Command Results"
-msgstr "Parancs eredményei"
-
-#: ../kupfer/plugin/archivemanager.py:1
-msgid "Archive Manager"
-msgstr "Archívumkezelő"
-
-#: ../kupfer/plugin/archivemanager.py:9
-msgid "Use Archive Manager actions"
-msgstr "Archívumkezelő parancsainak használata"
-
-#: ../kupfer/plugin/archivemanager.py:27
-msgid "Compressed archive type for 'Create Archive In'"
-msgstr "Tömörtett archívum típusa a 'Készíts archívumot ide' parancshoz"
-
-#: ../kupfer/plugin/archivemanager.py:44
-msgid "Extract Here"
-msgstr "Kibontás itt"
-
-#: ../kupfer/plugin/archivemanager.py:64
-msgid "Extract compressed archive"
-msgstr "Tömörített archívum kibontása"
-
-#: ../kupfer/plugin/archivemanager.py:70
-msgid "Create Archive"
-msgstr "Archívum készítése"
-
-#: ../kupfer/plugin/archivemanager.py:86
-#: ../kupfer/plugin/archivemanager.py:129
-msgid "Create a compressed archive from folder"
-msgstr "Tömörített archívum készítése mappából"
-
-#: ../kupfer/plugin/archivemanager.py:92
-msgid "Create Archive In..."
-msgstr "Készíts archívumot ide..."
-
-#. TRANS: Default filename (no extension) for 'Create Archive In...'
-#: ../kupfer/plugin/archivemanager.py:115
-msgid "Archive"
-msgstr "Archívum"
+msgstr "Érvénytelen felhasználói hitelesítési adatok ehhez: %s"
 
 #: ../kupfer/plugin/applications.py:2 ../kupfer/plugin/applications.py:38
 msgid "Applications"
@@ -785,7 +694,7 @@ msgstr "Alkalmazások"
 
 #: ../kupfer/plugin/applications.py:8 ../kupfer/plugin/applications.py:74
 msgid "All applications and preferences"
-msgstr "Alkalmazások és beállításaik"
+msgstr "Minden alkalmazás és beállítás"
 
 #: ../kupfer/plugin/applications.py:23
 msgid "Applications for Desktop Environment"
@@ -793,7 +702,7 @@ msgstr "Alkalmazások az asztali környezethez"
 
 #: ../kupfer/plugin/applications.py:83
 msgid "Open With..."
-msgstr "Megnyitás mással..."
+msgstr "Megnyitás ezzel…"
 
 #: ../kupfer/plugin/applications.py:105
 msgid "Open with any application"
@@ -801,7 +710,45 @@ msgstr "Megnyitás bármely alkalmazással"
 
 #: ../kupfer/plugin/applications.py:124
 msgid "Set default application to open this file type"
-msgstr "E fájltípus megnyitásához az alapértelmezett alkalmazás beállítása"
+msgstr "Alapértelmezett alkalmazás beállítása ezen fájltípus megnyitásához"
+
+#: ../kupfer/plugin/archivemanager.py:1
+msgid "Archive Manager"
+msgstr "Archívumkezelő"
+
+#: ../kupfer/plugin/archivemanager.py:9
+msgid "Use Archive Manager actions"
+msgstr "Archívumkezelő műveleteinek használata"
+
+#: ../kupfer/plugin/archivemanager.py:27
+msgid "Compressed archive type for 'Create Archive In'"
+msgstr "Tömörített archívumtípus az „Archívum létrehozása ebben” parancshoz"
+
+#: ../kupfer/plugin/archivemanager.py:44
+msgid "Extract Here"
+msgstr "Kibontás ide"
+
+#: ../kupfer/plugin/archivemanager.py:64
+msgid "Extract compressed archive"
+msgstr "Tömörített archívum kibontása"
+
+#: ../kupfer/plugin/archivemanager.py:70
+msgid "Create Archive"
+msgstr "Archívum létrehozása"
+
+#: ../kupfer/plugin/archivemanager.py:86
+#: ../kupfer/plugin/archivemanager.py:129
+msgid "Create a compressed archive from folder"
+msgstr "Tömörített archívum létrehozása a mappából"
+
+#: ../kupfer/plugin/archivemanager.py:92
+msgid "Create Archive In..."
+msgstr "Archívum létrehozása ebben…"
+
+#. TRANS: Default filename (no extension) for 'Create Archive In...'
+#: ../kupfer/plugin/archivemanager.py:115
+msgid "Archive"
+msgstr "Archívum"
 
 #: ../kupfer/plugin/calculator.py:2 ../kupfer/plugin/calculator.py:69
 msgid "Calculator"
@@ -809,46 +756,67 @@ msgstr "Számológép"
 
 #: ../kupfer/plugin/calculator.py:4
 msgid "Calculate expressions starting with '='"
-msgstr "'='-el kezdődő kifejezések eredményének kiszámolása"
+msgstr "Az „=” jellel kezdődő kifejezések számítása"
 
 #: ../kupfer/plugin/calculator.py:101
 msgid "Calculate"
-msgstr "Számolás"
+msgstr "Számítás"
 
-#: ../kupfer/plugin/clipboard.py:1 ../kupfer/plugin/clipboard.py:71
+#: ../kupfer/plugin/clipboard.py:1 ../kupfer/plugin/clipboard.py:112
 msgid "Clipboards"
 msgstr "Vágólapok"
 
-#: ../kupfer/plugin/clipboard.py:4 ../kupfer/plugin/clipboard.py:111
-msgid "Recent clipboards"
-msgstr "Legutóbbi vágólap-tartalmak"
+#: ../kupfer/plugin/clipboard.py:4
+msgid "Recent clipboards and clipboard proxy objects"
+msgstr "Legutóbbi vágólapok és vágólap proxy objektumok"
 
-#: ../kupfer/plugin/clipboard.py:20
-msgid "Number of recent clipboards"
-msgstr "Utolsó vágólapok száma"
+#: ../kupfer/plugin/clipboard.py:24
+#| msgid "Number of recent clipboards"
+msgid "Number of recent clipboards to remember"
+msgstr "A megjegyzendő legutóbbi vágólapok száma"
 
-#: ../kupfer/plugin/clipboard.py:26
-msgid "Include recent selections"
-msgstr "Legutolsó kijelölések beleszámítása"
+#: ../kupfer/plugin/clipboard.py:30
+msgid "Include selected text in clipboard history"
+msgstr "A kijelölt szöveg felvétele a vágólap előzménybe"
 
-#: ../kupfer/plugin/clipboard.py:32
-msgid "Copy selection to primary clipboard"
-msgstr "Kijelölés másolása az elsődleges vágólapra"
+#: ../kupfer/plugin/clipboard.py:36
+#| msgid "Copy selection to primary clipboard"
+msgid "Copy selected text to primary clipboard"
+msgstr "A kijelölt szöveg másolása az elsődleges vágólapra"
 
-#: ../kupfer/plugin/clipboard.py:44
+#: ../kupfer/plugin/clipboard.py:47
+msgid "Selected Text"
+msgstr "Kijelölt szöveg"
+
+#: ../kupfer/plugin/clipboard.py:57
 #, python-format
 msgid "Clipboard \"%(desc)s\""
 msgid_plural "Clipboard with %(num)d lines \"%(desc)s\""
-msgstr[0] "\"%(desc)s\" vágólap"
-msgstr[1] "\"%(desc)s\" vágólap %(num)d sorral"
+msgstr[0] "„%(desc)s” vágólap"
+msgstr[1] "„%(desc)s” vágólap %(num)d sorral"
 
-#: ../kupfer/plugin/clipboard.py:51
+#: ../kupfer/plugin/clipboard.py:64
+#| msgid "Clipboards"
+msgid "Clipboard Text"
+msgstr "Vágólap szöveg"
+
+#: ../kupfer/plugin/clipboard.py:74
+#| msgid "Clipboards"
+msgid "Clipboard File"
+msgstr "Vágólap fájl"
+
+#: ../kupfer/plugin/clipboard.py:84
+#| msgid "Clipboards"
+msgid "Clipboard Files"
+msgstr "Vágólap fájlok"
+
+#: ../kupfer/plugin/clipboard.py:92
 msgid "Clear"
 msgstr "Törlés"
 
-#: ../kupfer/plugin/clipboard.py:63
+#: ../kupfer/plugin/clipboard.py:104
 msgid "Remove all recent clipboards"
-msgstr "Töröld az összes vágólapot"
+msgstr "Minden legutóbbi vágólap eltávolítása"
 
 #: ../kupfer/plugin/commands.py:1 ../kupfer/plugin/commands.py:187
 msgid "Shell Commands"
@@ -860,8 +828,8 @@ msgid ""
 "Run command-line programs. Actions marked with the symbol %s run in a "
 "subshell."
 msgstr ""
-"Parancssoros programok futtatása. Akciók %s szimbólummal jelölve alhéjban "
-"futnak."
+"Parancssoros programok futtatása. A(z) %s szimbólummal jelölt műveletek az "
+"alhéjban futnak."
 
 #: ../kupfer/plugin/commands.py:41
 msgid "Run (Get Output)"
@@ -869,48 +837,148 @@ msgstr "Futtatás (eredmény elkapása)"
 
 #: ../kupfer/plugin/commands.py:59
 msgid "Run program and return its output"
-msgstr "Program futtatása az eredmény visszaadásával"
+msgstr "Program futtatása a kimenet visszaadásával"
 
 #. TRANS: The user starts a program (command) and the text
 #. TRANS: is an argument to the command
 #: ../kupfer/plugin/commands.py:65
 msgid "Pass to Command..."
-msgstr "Parancsnak argumentum..."
+msgstr "Átadás a parancsnak…"
 
 #: ../kupfer/plugin/commands.py:107
 msgid "Run program with object as an additional parameter"
-msgstr "Parancs futtatása objektummal, mint paraméterrel"
+msgstr "Program futtatása objektummal mint további paraméterrel"
 
 #. TRANS: The user starts a program (command) and
 #. TRANS: the text is written on stdin
 #: ../kupfer/plugin/commands.py:115
 msgid "Write to Command..."
-msgstr "Kiírás parancsként..."
+msgstr "Írás a parancsnak…"
 
 #: ../kupfer/plugin/commands.py:149 ../kupfer/plugin/commands.py:161
 msgid "Run program and supply text on the standard input"
-msgstr "Program futtatása és szöveg megadása az alapbemeneten"
+msgstr "Program futtatása és szöveg megadása az alapértelmezett bemeneten"
 
 #. TRANS: The user starts a program (command) and
 #. TRANS: the text is written on stdin, and we
 #. TRANS: present the output (stdout) to the user.
 #: ../kupfer/plugin/commands.py:157
 msgid "Filter through Command..."
-msgstr "Szűrés parancson keresztül..."
+msgstr "Szűrés parancson keresztül…"
 
-#: ../kupfer/plugin/commands.py:210
+#: ../kupfer/plugin/commands.py:215
 msgid "Run command-line programs"
 msgstr "Parancssoros programok futtatása"
 
-#: ../kupfer/plugin/dictionary.py:1 ../kupfer/plugin/dictionary.py:20
+#: ../kupfer/plugin/core/alternatives.py:7
+msgid "GTK+"
+msgstr "GTK+"
+
+#: ../kupfer/plugin/core/alternatives.py:13
+msgid "GNOME Terminal"
+msgstr "GNOME Terminál"
+
+#: ../kupfer/plugin/core/alternatives.py:22
+msgid "XFCE Terminal"
+msgstr "XFCE Terminál"
+
+#: ../kupfer/plugin/core/alternatives.py:31
+msgid "LXTerminal"
+msgstr "LXTerminal"
+
+#: ../kupfer/plugin/core/alternatives.py:40
+msgid "X Terminal"
+msgstr "X Terminál"
+
+#: ../kupfer/plugin/core/alternatives.py:49
+msgid "Urxvt"
+msgstr "Urxvt"
+
+#: ../kupfer/plugin/core/alternatives.py:58
+msgid "Konsole"
+msgstr "Konsole"
+
+#: ../kupfer/plugin/core/commands.py:13 ../kupfer/plugin/core/commands.py:32
+msgid "Save As..."
+msgstr "Mentés másként…"
+
+#: ../kupfer/plugin/core/contents.py:41
+msgid "Quit"
+msgstr "Kilépés"
+
+#: ../kupfer/plugin/core/contents.py:46
+msgid "Quit Kupfer"
+msgstr "Kilépés a Kupferből"
+
+#: ../kupfer/plugin/core/contents.py:52
+msgid "About Kupfer"
+msgstr "A Kupfer névjegye"
+
+#: ../kupfer/plugin/core/contents.py:59
+msgid "Show information about Kupfer authors and license"
+msgstr "Információk megjelenítése a Kupfer szerzőiről és a licencről"
+
+#: ../kupfer/plugin/core/contents.py:65
+msgid "Kupfer Help"
+msgstr "Kupfer súgó"
+
+#: ../kupfer/plugin/core/contents.py:72
+msgid "Get help with Kupfer"
+msgstr "Segítség a Kupfer használatához"
+
+#: ../kupfer/plugin/core/contents.py:85
+msgid "Show preferences window for Kupfer"
+msgstr "A Kupfer beállítások ablakának megjelenítése"
+
+#: ../kupfer/plugin/core/__init__.py:64
+msgid "Search Contents"
+msgstr "Tartalmak keresése"
+
+#: ../kupfer/plugin/core/__init__.py:82
+msgid "Search inside this catalog"
+msgstr "Keresés ebben a katalógusban"
+
+#: ../kupfer/plugin/core/__init__.py:90
+msgid "Copy"
+msgstr "Másolás"
+
+#: ../kupfer/plugin/core/__init__.py:105
+msgid "Copy to clipboard"
+msgstr "Másolás a vágólapra"
+
+#: ../kupfer/plugin/core/__init__.py:127
+msgid "Rescan"
+msgstr "Újrakeresés"
+
+#: ../kupfer/plugin/core/__init__.py:142
+msgid "Force reindex of this source"
+msgstr "A forrás újraindexelésének erőltetése"
+
+#: ../kupfer/plugin/core/internal.py:13
+msgid "Last Command"
+msgstr "Utolsó parancs"
+
+#: ../kupfer/plugin/core/internal.py:24
+msgid "Internal Kupfer Objects"
+msgstr "Belső Kupfer objektumok"
+
+#: ../kupfer/plugin/core/internal.py:46 ../kupfer/plugin/core/internal.py:48
+msgid "Last Result"
+msgstr "Utolsó eredmény"
+
+#: ../kupfer/plugin/core/internal.py:66
+msgid "Command Results"
+msgstr "Parancs eredményei"
+
+#: ../kupfer/plugin/dictionary.py:1 ../kupfer/plugin/dictionary.py:21
 msgid "Dictionary"
 msgstr "Szótár"
 
-#: ../kupfer/plugin/dictionary.py:3 ../kupfer/plugin/dictionary.py:46
+#: ../kupfer/plugin/dictionary.py:3 ../kupfer/plugin/dictionary.py:47
 msgid "Look up word in dictionary"
-msgstr "Szó keresése szótárban"
+msgstr "Szó keresése a szótárban"
 
-#: ../kupfer/plugin/dictionary.py:29
+#: ../kupfer/plugin/dictionary.py:30
 msgid "Look Up"
 msgstr "Keresés"
 
@@ -924,7 +992,7 @@ msgstr "Nemrég használt dokumentumok és könyvjelzővel jelölt mappák"
 
 #: ../kupfer/plugin/documents.py:22
 msgid "Max recent document days"
-msgstr "Nemrég használt dokumentumok legfeljebb ennyi napja"
+msgstr "Nemrég használt dokumentum maximális napjai"
 
 #: ../kupfer/plugin/documents.py:32
 msgid "Recent Items"
@@ -942,7 +1010,7 @@ msgstr "%s dokumentum"
 #: ../kupfer/plugin/documents.py:113
 #, python-format
 msgid "Recently used documents for %s"
-msgstr "Nemrég használt dokumentumok a %s-hez"
+msgstr "Nemrég használt dokumentumok ehhez: %s"
 
 #: ../kupfer/plugin/documents.py:132
 msgid "Places"
@@ -966,11 +1034,13 @@ msgstr "Kedvencek"
 
 #: ../kupfer/plugin/favorites.py:4
 msgid "Mark commonly used items and store objects for later use"
-msgstr "Gyakran használt elemek megjelölése és tárolása későbbi felhasználásra"
+msgstr ""
+"Gyakran használt elemek megjelölése és objektumok tárolása későbbi "
+"felhasználásra"
 
 #: ../kupfer/plugin/favorites.py:127
 msgid "Shelf of \"Favorite\" items"
-msgstr "A \"kedvenc\" elemek polca"
+msgstr "A „kedvenc” elemek polca"
 
 #: ../kupfer/plugin/favorites.py:140
 msgid "Add to Favorites"
@@ -982,46 +1052,46 @@ msgstr "Elem hozzáadása a kedvencek polcára"
 
 #: ../kupfer/plugin/favorites.py:155
 msgid "Remove from Favorites"
-msgstr "Törlés a kedvencek közül"
+msgstr "Eltávolítás a kedvencek közül"
 
 #: ../kupfer/plugin/favorites.py:163
 msgid "Remove item from favorites shelf"
-msgstr "Elem törlése a kedvencek polcáról"
+msgstr "Elem eltávolítása a kedvencek polcáról"
 
 #: ../kupfer/plugin/fileactions.py:1
 msgid "File Actions"
-msgstr "Fájl akciók"
+msgstr "Fájlműveletek"
 
 #: ../kupfer/plugin/fileactions.py:9
 msgid "More file actions"
-msgstr "Még több fáljparancs"
+msgstr "További fájlműveletek"
 
 #: ../kupfer/plugin/fileactions.py:40 ../kupfer/plugin/windows.py:122
-#: ../kupfer/plugin/thunar.py:210
+#: ../kupfer/plugin/thunar.py:211
 msgid "Move To..."
-msgstr "Mozgatás..."
+msgstr "Áthelyezés ide…"
 
-#: ../kupfer/plugin/fileactions.py:67 ../kupfer/plugin/thunar.py:252
+#: ../kupfer/plugin/fileactions.py:67 ../kupfer/plugin/thunar.py:253
 msgid "Move file to new location"
-msgstr "Fájl új helyre mozgatása"
+msgstr "Fájl áthelyezése új helyre"
 
 #: ../kupfer/plugin/fileactions.py:80 ../kupfer/plugin/fileactions.py:103
 msgid "Rename To..."
-msgstr "Átnevezés..."
+msgstr "Átnevezés erre…"
 
-#: ../kupfer/plugin/fileactions.py:145 ../kupfer/plugin/thunar.py:165
+#: ../kupfer/plugin/fileactions.py:145 ../kupfer/plugin/thunar.py:166
 msgid "Copy To..."
-msgstr "Másolás..."
+msgstr "Másolás ide…"
 
-#: ../kupfer/plugin/fileactions.py:186 ../kupfer/plugin/thunar.py:206
+#: ../kupfer/plugin/fileactions.py:186 ../kupfer/plugin/thunar.py:207
 msgid "Copy file to a chosen location"
-msgstr "Fájl másolása más helyre"
+msgstr "Fájl másolása a kiválasztott helyre"
 
-#: ../kupfer/plugin/firefox.py:4 ../kupfer/plugin/firefox.py:36
+#: ../kupfer/plugin/firefox.py:4 ../kupfer/plugin/firefox.py:61
 msgid "Firefox Bookmarks"
 msgstr "Firefox könyvjelzők"
 
-#: ../kupfer/plugin/firefox.py:6 ../kupfer/plugin/firefox.py:120
+#: ../kupfer/plugin/firefox.py:6 ../kupfer/plugin/firefox.py:147
 msgid "Index of Firefox bookmarks"
 msgstr "Firefox könyvjelzők indexe"
 
@@ -1029,28 +1099,20 @@ msgstr "Firefox könyvjelzők indexe"
 msgid "Include visited sites"
 msgstr "A látogatott oldalak is"
 
-#: ../kupfer/plugin/nautilusselection.py:1
-#: ../kupfer/plugin/nautilusselection.py:46
-msgid "Selected File"
-msgstr "Kiválasztott fájl"
+#: ../kupfer/plugin/firefox.py:44
+#| msgid "Firefox Bookmarks"
+msgid "Firefox tag"
+msgstr "Firefox címke"
 
-#: ../kupfer/plugin/nautilusselection.py:3
-msgid "Provides current nautilus selection, using Kupfer's Nautilus Extension"
-msgstr ""
-"Hozzáférés a Nautilusban kiválasztott elemhez, a Kupfer Nautilus kiegészítő "
-"segítségével"
+#. TRANS: Multihead refers to support for multiple computer displays
+#. TRANS: In this case, it only concerns the special configuration
+#. TRANS: with multiple X "screens"
+#: ../kupfer/plugin/multihead.py:4
+msgid "Multihead Support"
+msgstr "Több kijelző támogatása"
 
-#: ../kupfer/plugin/nautilusselection.py:25
-#, python-format
-msgid "Selected File \"%s\""
-msgstr "Kiválasztott fájl \"%s\""
-
-#: ../kupfer/plugin/nautilusselection.py:34
-msgid "Selected Files"
-msgstr "Kiválasztott fájlok"
-
-#: ../kupfer/plugin/notes.py:6 ../kupfer/plugin/notes.py:165
-#: ../kupfer/plugin/notes.py:217
+#: ../kupfer/plugin/notes.py:6 ../kupfer/plugin/notes.py:178
+#: ../kupfer/plugin/notes.py:230
 msgid "Notes"
 msgstr "Jegyzetek"
 
@@ -1060,63 +1122,63 @@ msgstr "Gnote vagy Tomboy jegyzetek"
 
 #: ../kupfer/plugin/notes.py:35
 msgid "Work with application"
-msgstr "Alkalmazással való együttműködés"
+msgstr "Munka az alkalmazással"
 
-#: ../kupfer/plugin/notes.py:85
+#: ../kupfer/plugin/notes.py:95
 msgid "Open with notes application"
 msgstr "Megnyitás jegyzetelő alkalmazással"
 
-#: ../kupfer/plugin/notes.py:92
+#: ../kupfer/plugin/notes.py:102
 msgid "Append to Note..."
-msgstr "Hozzáadás jegyzethez..."
+msgstr "Hozzáfűzés a jegyzethez…"
 
-#: ../kupfer/plugin/notes.py:115
+#: ../kupfer/plugin/notes.py:125
 msgid "Add text to existing note"
-msgstr "Szöveg hozzáadása létező jegyzethez"
+msgstr "Szöveg hozzáadása meglévő jegyzethez"
 
-#: ../kupfer/plugin/notes.py:127
+#: ../kupfer/plugin/notes.py:140
 msgid "Create Note"
 msgstr "Jegyzet létrehozása"
 
-#: ../kupfer/plugin/notes.py:141
+#: ../kupfer/plugin/notes.py:154
 msgid "Create a new note from this text"
-msgstr "Jegyzet létrehozása ebből a szövegből"
-
-#: ../kupfer/plugin/notes.py:147
-msgid "Get Note Search Results..."
-msgstr "Jegyzetek keresési eredményei..."
+msgstr "Új jegyzet létrehozása ebből a szövegből"
 
 #: ../kupfer/plugin/notes.py:160
-msgid "Show search results for this query"
-msgstr "A lekérdezés keresési eredményei"
+msgid "Get Note Search Results..."
+msgstr "Jegyzetkeresési eredmények megszerzése…"
 
-#: ../kupfer/plugin/notes.py:200
+#: ../kupfer/plugin/notes.py:173
+msgid "Show search results for this query"
+msgstr "A lekérdezés keresési eredményeinek megjelenítése"
+
+#: ../kupfer/plugin/notes.py:213
 #, python-format
 msgid "today, %s"
 msgstr "ma, %s"
 
-#: ../kupfer/plugin/notes.py:202
+#: ../kupfer/plugin/notes.py:215
 #, python-format
 msgid "yesterday, %s"
 msgstr "tegnap, %s"
 
 #. TRANS: Note description, %s is last changed time in locale format
-#: ../kupfer/plugin/notes.py:206
+#: ../kupfer/plugin/notes.py:219
 #, python-format
 msgid "Last updated %s"
 msgstr "Utoljára frissítve %s"
 
-#: ../kupfer/plugin/rhythmbox.py:1 ../kupfer/plugin/rhythmbox.py:398
+#: ../kupfer/plugin/rhythmbox.py:1 ../kupfer/plugin/rhythmbox.py:399
 msgid "Rhythmbox"
 msgstr "Rhythmbox"
 
-#: ../kupfer/plugin/rhythmbox.py:3 ../kupfer/plugin/rhythmbox.py:432
+#: ../kupfer/plugin/rhythmbox.py:3 ../kupfer/plugin/rhythmbox.py:433
 msgid "Play and enqueue tracks and browse the music library"
-msgstr "Számok lejátszása és sorbaállítása és a zenekönyvtár böngészése"
+msgstr "Számok lejátszása és sorba állítása és a zenekönyvtár böngészése"
 
 #: ../kupfer/plugin/rhythmbox.py:22
 msgid "Include artists in top level"
-msgstr "Művészek láthatók a felső szinten is"
+msgstr "Előadók láthatók a felső szinten is"
 
 #: ../kupfer/plugin/rhythmbox.py:28
 msgid "Include albums in top level"
@@ -1133,7 +1195,7 @@ msgstr "Lejátszás"
 
 #: ../kupfer/plugin/rhythmbox.py:67
 msgid "Resume playback in Rhythmbox"
-msgstr "Lejátszás visszakapcsolása Rhythmbox-ban"
+msgstr "Lejátszás folytatása a Rhythmboxban"
 
 #: ../kupfer/plugin/rhythmbox.py:73 ../kupfer/plugin/audacious.py:102
 #: ../kupfer/plugin/virtualbox/__init__.py:93
@@ -1142,7 +1204,7 @@ msgstr "Szünet"
 
 #: ../kupfer/plugin/rhythmbox.py:77
 msgid "Pause playback in Rhythmbox"
-msgstr "Lejátszás szüneteltetése  Rhythmbox-ban"
+msgstr "Lejátszás szüneteltetése a Rhythmboxban"
 
 #: ../kupfer/plugin/rhythmbox.py:83 ../kupfer/plugin/audacious.py:112
 msgid "Next"
@@ -1150,7 +1212,7 @@ msgstr "Következő"
 
 #: ../kupfer/plugin/rhythmbox.py:87
 msgid "Jump to next track in Rhythmbox"
-msgstr "Ugrás a következő számra Rhythmbox-ban"
+msgstr "Ugrás a következő számra a Rhythmboxban"
 
 #: ../kupfer/plugin/rhythmbox.py:93 ../kupfer/plugin/audacious.py:122
 msgid "Previous"
@@ -1158,23 +1220,23 @@ msgstr "Előző"
 
 #: ../kupfer/plugin/rhythmbox.py:97
 msgid "Jump to previous track in Rhythmbox"
-msgstr "Ugrás az előző számra Rhythmbox-ban"
+msgstr "Ugrás az előző számra a Rhythmboxban"
 
 #: ../kupfer/plugin/rhythmbox.py:103
 msgid "Show Playing"
-msgstr "Mit játszik épp"
+msgstr "Lejátszás megjelenítése"
 
 #: ../kupfer/plugin/rhythmbox.py:107
 msgid "Tell which song is currently playing"
-msgstr "Megmutatja, milyen számot játszik épp le"
+msgstr "Megmondja, hogy jelenleg melyik szám szól"
 
 #: ../kupfer/plugin/rhythmbox.py:115 ../kupfer/plugin/audacious.py:132
 msgid "Clear Queue"
-msgstr "Sor ürítése"
+msgstr "Sor törlése"
 
 #: ../kupfer/plugin/rhythmbox.py:155
 msgid "Play tracks in Rhythmbox"
-msgstr "Számok lejátszása Rhythmbox-ban"
+msgstr "Számok lejátszása a Rhythmboxban"
 
 #: ../kupfer/plugin/rhythmbox.py:161 ../kupfer/plugin/audacious.py:58
 msgid "Enqueue"
@@ -1197,76 +1259,76 @@ msgid "by %s"
 msgstr "%s"
 
 #. TRANS: Artist songs collection description
-#: ../kupfer/plugin/rhythmbox.py:310
+#: ../kupfer/plugin/rhythmbox.py:311
 #, python-format
 msgid "Tracks by %s"
 msgstr "%s számai"
 
-#: ../kupfer/plugin/rhythmbox.py:320
+#: ../kupfer/plugin/rhythmbox.py:321
 #: ../kupfer/plugin/google_picasa/__init__.py:444
 msgid "Albums"
 msgstr "Albumok"
 
-#: ../kupfer/plugin/rhythmbox.py:330
+#: ../kupfer/plugin/rhythmbox.py:331
 msgid "Music albums in Rhythmbox Library"
-msgstr "Rhythmbox könyvtár zenei albumai"
+msgstr "Zene albumok a Rhythmbox könyvtárban"
 
-#: ../kupfer/plugin/rhythmbox.py:341
+#: ../kupfer/plugin/rhythmbox.py:342
 msgid "Artists"
-msgstr "Művészek"
+msgstr "Előadók"
 
-#: ../kupfer/plugin/rhythmbox.py:351
+#: ../kupfer/plugin/rhythmbox.py:352
 msgid "Music artists in Rhythmbox Library"
-msgstr "Rhythmbox könyvtár zenei művészei"
+msgstr "Zene előadók a Rhythmbox könyvtárban"
 
-#: ../kupfer/plugin/rhythmbox.py:378
+#: ../kupfer/plugin/rhythmbox.py:379
 msgid "Songs"
-msgstr "Számok"
+msgstr "Dalok"
 
-#: ../kupfer/plugin/rhythmbox.py:388
+#: ../kupfer/plugin/rhythmbox.py:389
 msgid "Songs in Rhythmbox library"
-msgstr "Rhythmbox könyvtár zeneszámai"
+msgstr "Dalok a Rhythmbox könyvtárban"
 
 #: ../kupfer/plugin/session_gnome.py:1 ../kupfer/plugin/session_gnome.py:20
 msgid "GNOME Session Management"
-msgstr "GNOME munkafolyamat-menedzsment"
+msgstr "GNOME munkamenet-kezelés"
 
 #: ../kupfer/plugin/session_gnome.py:3
 msgid "Special items and actions for GNOME environment"
-msgstr "Speciális elemek és parancsok a GNOME környezethez"
+msgstr "Speciális elemek és műveletek a GNOME környezethez"
 
 #: ../kupfer/plugin/session_support.py:31
 msgid "Log Out..."
-msgstr "Kilépés..."
+msgstr "Kijelentkezés…"
 
 #: ../kupfer/plugin/session_support.py:34
 msgid "Log out or change user"
-msgstr "Kilépés vagy felhasználóváltás"
+msgstr "Kijelentkezés vagy felhasználóváltás"
 
 #: ../kupfer/plugin/session_support.py:41
 msgid "Shut Down..."
-msgstr "Kikapcsolás..."
+msgstr "Leállítás…"
 
 #: ../kupfer/plugin/session_support.py:44
 msgid "Shut down, restart or suspend computer"
-msgstr "Kikapcsolás, újraindítás, vagy felfüggesztés"
+msgstr "Leállítás, újraindítás vagy a számítógép felfüggesztése"
 
 #: ../kupfer/plugin/session_support.py:51
 msgid "Lock Screen"
-msgstr "Képernyő lezárása"
+msgstr "Képernyő zárolása"
 
 #: ../kupfer/plugin/session_support.py:54
 msgid "Enable screensaver and lock"
-msgstr "Képernyővédő engedélyezése és lezárás"
+msgstr "Képernyővédő engedélyezése és zárolás"
 
 #. -*- coding: utf-8 -*
 #: ../kupfer/plugin/session_xfce.py:3 ../kupfer/plugin/session_xfce.py:20
 msgid "XFCE Session Management"
-msgstr "XFCE munkafolyamat-menedzsment"
+msgstr "XFCE munkamenet-kezelés"
 
 #: ../kupfer/plugin/session_xfce.py:5
 msgid "Special items and actions for XFCE environment"
-msgstr "Speciális elemek és parancsok az XFCE környezethez"
+msgstr "Speciális elemek és műveletek az XFCE környezethez"
 
 #: ../kupfer/plugin/show_text.py:1 ../kupfer/plugin/show_text.py:18
 #: ../kupfer/plugin/show_text.py:25
@@ -1274,33 +1336,33 @@ msgid "Show Text"
 msgstr "Szöveg megjelenítése"
 
 #: ../kupfer/plugin/show_text.py:7 ../kupfer/plugin/show_text.py:31
-#: ../kupfer/plugin/show_text.py:52
+#: ../kupfer/plugin/show_text.py:58
 msgid "Display text in a window"
 msgstr "Szöveg megjelenítése egy ablakban"
 
 #: ../kupfer/plugin/show_text.py:37
 msgid "Large Type"
-msgstr "Nagy betűméret"
+msgstr "Nagy típus"
 
-#: ../kupfer/plugin/show_text.py:60
+#: ../kupfer/plugin/show_text.py:66
 msgid "Show Notification"
 msgstr "Értesítés megjelenítése"
 
 #: ../kupfer/plugin/trash.py:1 ../kupfer/plugin/trash.py:173
 msgid "Trash"
-msgstr "Szemétkosár"
+msgstr "Kuka"
 
 #: ../kupfer/plugin/trash.py:4
 msgid "Access trash contents"
-msgstr "Hozzáférés a szemétkosár elemeihez"
+msgstr "Hozzáférés a kuka tartalmához"
 
 #: ../kupfer/plugin/trash.py:23
 msgid "Move to Trash"
-msgstr "Kidobás a szemétkosárba"
+msgstr "Áthelyezés a Kukába"
 
 #: ../kupfer/plugin/trash.py:39
 msgid "Move this file to trash"
-msgstr "A fájl kidobása a szemétkosárba"
+msgstr "A fájl áthelyezése a Kukába"
 
 #: ../kupfer/plugin/trash.py:48
 msgid "Restore"
@@ -1312,39 +1374,39 @@ msgstr "A fájl visszaállítása az eredeti helyére"
 
 #: ../kupfer/plugin/trash.py:161
 msgid "Trash is empty"
-msgstr "A szemétkosár üres"
+msgstr "A kuka üres"
 
 #. proper translation of plural
 #: ../kupfer/plugin/trash.py:163
 #, python-format
 msgid "Trash contains one file"
 msgid_plural "Trash contains %(num)s files"
-msgstr[0] "A szemétkosárban egy fájl van"
-msgstr[1] "A szemétkosárban %(num)s fájl van"
+msgstr[0] "A kukában egy fájl van"
+msgstr[1] "A kukában %(num)s fájl van"
 
 #: ../kupfer/plugin/triggers.py:1 ../kupfer/plugin/triggers.py:50
 msgid "Triggers"
-msgstr "Gyorsindítók"
+msgstr "Aktiválók"
 
 #: ../kupfer/plugin/triggers.py:6
 msgid ""
 "Assign global keybindings (triggers) to objects created with 'Compose "
 "Command'."
 msgstr ""
-"Globális billenyűparancs hozzárendelése a 'Parancsösszeállító'-val "
-"létrehozott elemekhez."
+"Globális gyorsbillentyűk (aktiválók) hozzárendelése a „Parancs összeállítása” "
+"művelettel létrehozott objektumokhoz."
 
 #: ../kupfer/plugin/triggers.py:161
 msgid "Add Trigger..."
-msgstr "Hozzáadás a gyorsindítókhoz..."
+msgstr "Aktiváló hozzáadása…"
 
 #: ../kupfer/plugin/triggers.py:180
 msgid "Remove Trigger"
-msgstr "Gyorsindító törlése"
+msgstr "Aktiváló eltávolítása"
 
 #: ../kupfer/plugin/urlactions.py:1 ../kupfer/plugin/urlactions.py:8
 msgid "URL Actions"
-msgstr "URL akciók"
+msgstr "URL műveletek"
 
 #: ../kupfer/plugin/urlactions.py:63
 msgid "Download and Open"
@@ -1352,57 +1414,57 @@ msgstr "Letöltés és megnyitás"
 
 #: ../kupfer/plugin/urlactions.py:83
 msgid "Download To..."
-msgstr "Letöltés máshova..."
+msgstr "Letöltés ide…"
 
 #: ../kupfer/plugin/urlactions.py:104
 msgid "Download URL to a chosen location"
-msgstr "URL letöltése egy kiválasztott mappába"
+msgstr "URL letöltése egy kiválasztott helyre"
 
 #: ../kupfer/plugin/volumes.py:1 ../kupfer/plugin/volumes.py:91
 msgid "Volumes and Disks"
-msgstr "Kötegek és lemezek"
+msgstr "Kötetek és lemezek"
 
 #: ../kupfer/plugin/volumes.py:3 ../kupfer/plugin/volumes.py:101
 msgid "Mounted volumes and disks"
-msgstr "Felcsatolt kötegek és lemezek"
+msgstr "Csatolt kötetek és lemezek"
 
 #: ../kupfer/plugin/volumes.py:42
 #, python-format
 msgid "Volume mounted at %s"
-msgstr "Köteg ide csatolva: %s"
+msgstr "A kötet ide van csatolva: %s"
 
 #: ../kupfer/plugin/volumes.py:51
 msgid "Unmount"
-msgstr "Lecsatolás"
+msgstr "Leválasztás"
 
 #: ../kupfer/plugin/volumes.py:78
 msgid "Unmount this volume"
-msgstr "A köteg lecsatolása"
+msgstr "A kötet leválasztása"
 
 #: ../kupfer/plugin/volumes.py:85
 msgid "Eject"
-msgstr "Kilökés"
+msgstr "Kiadás"
 
 #: ../kupfer/plugin/volumes.py:88
 msgid "Unmount and eject this media"
-msgstr "Az adathordozó lecsatolása és kilökése"
+msgstr "Az adathordozó leválasztása és kiadása"
 
 #: ../kupfer/plugin/websearch.py:1
 msgid "Search the Web"
-msgstr "Keresés a Web-en"
+msgstr "Keresés a világhálón"
 
 #: ../kupfer/plugin/websearch.py:8 ../kupfer/plugin/websearch.py:63
 #: ../kupfer/plugin/websearch.py:90
 msgid "Search the web with OpenSearch search engines"
-msgstr "Keresés a Web-en OpenSearch keresőmotorokkal"
+msgstr "Keresés a világhálón az OpenSearch keresőmotorokkal"
 
 #: ../kupfer/plugin/websearch.py:44
 msgid "Search With..."
-msgstr "Keresés mással..."
+msgstr "Keresés ezzel…"
 
 #: ../kupfer/plugin/websearch.py:73
 msgid "Search For..."
-msgstr "Keresés..."
+msgstr "Keresés erre…"
 
 #: ../kupfer/plugin/websearch.py:114
 msgid "Search Engines"
@@ -1410,15 +1472,15 @@ msgstr "Keresőmotorok"
 
 #: ../kupfer/plugin/wikipedia.py:5
 msgid "Wikipedia"
-msgstr "Wikipedia"
+msgstr "Wikipédia"
 
 #: ../kupfer/plugin/wikipedia.py:8 ../kupfer/plugin/wikipedia.py:31
 msgid "Search in Wikipedia"
-msgstr "Keresés a Wikipedia-n"
+msgstr "Keresés a Wikipédián"
 
 #: ../kupfer/plugin/wikipedia.py:21
 msgid "Wikipedia language"
-msgstr "Wikipedia nyelv"
+msgstr "Wikipédia nyelv"
 
 #. TRANS: Default wikipedia language code
 #: ../kupfer/plugin/wikipedia.py:24
@@ -1428,7 +1490,7 @@ msgstr "hu"
 #: ../kupfer/plugin/wikipedia.py:44
 #, python-format
 msgid "Search for this term in %s.wikipedia.org"
-msgstr "A kifejezés keresése itt: %s.wikipedia.org"
+msgstr "A kifejezés keresése a %s.wikipedia.org oldalon"
 
 #: ../kupfer/plugin/windows.py:1 ../kupfer/plugin/windows.py:210
 msgid "Window List"
@@ -1436,7 +1498,7 @@ msgstr "Ablaklista"
 
 #: ../kupfer/plugin/windows.py:3 ../kupfer/plugin/windows.py:233
 msgid "All windows on all workspaces"
-msgstr "Minden ablak minden munkaterületen"
+msgstr "Minden ablak az összes munkaterületen"
 
 #: ../kupfer/plugin/windows.py:18
 msgid "Activate"
@@ -1444,35 +1506,35 @@ msgstr "Aktiválás"
 
 #: ../kupfer/plugin/windows.py:22
 msgid "Shade"
-msgstr "Ablak felgördítés"
+msgstr "Felgördítés"
 
 #: ../kupfer/plugin/windows.py:22
 msgid "Unshade"
-msgstr "Ablak legördítés"
+msgstr "Legördítés"
 
 #: ../kupfer/plugin/windows.py:25
 msgid "Minimize"
-msgstr "Kicsinyítés"
+msgstr "Minimalizálás"
 
 #: ../kupfer/plugin/windows.py:25
 msgid "Unminimize"
-msgstr "Visszaállítás"
+msgstr "Minimalizálás megszüntetése"
 
 #: ../kupfer/plugin/windows.py:29
 msgid "Maximize"
-msgstr "Teljes méretre"
+msgstr "Maximalizálás"
 
 #: ../kupfer/plugin/windows.py:29
 msgid "Unmaximize"
-msgstr "Visszaállítás"
+msgstr "Maximalizálás megszüntetése"
 
 #: ../kupfer/plugin/windows.py:33
 msgid "Maximize Vertically"
-msgstr "Teljes magasságra méretez"
+msgstr "Függőleges maximalizálás"
 
 #: ../kupfer/plugin/windows.py:33
 msgid "Unmaximize Vertically"
-msgstr "Visszaállítás"
+msgstr "Függőleges maximalizálás megszüntetése"
 
 #. TRANS: Window on (Workspace name), window description
 #: ../kupfer/plugin/windows.py:48
@@ -1517,11 +1579,11 @@ msgstr "Abiword"
 
 #: ../kupfer/plugin/abiword.py:3 ../kupfer/plugin/abiword.py:88
 msgid "Recently used documents in Abiword"
-msgstr "Nemrég használt dokumentumok Abiword-ben"
+msgstr "Nemrég használt dokumentumok az Abiwordben"
 
 #: ../kupfer/plugin/abiword.py:34
 msgid "Abiword Recent Items"
-msgstr "Legutóbbi elemek Abiword-ben"
+msgstr "Legutóbbi elemek az Abiwordben"
 
 #: ../kupfer/plugin/apt_tools.py:1
 msgid "APT"
@@ -1529,7 +1591,7 @@ msgstr "APT"
 
 #: ../kupfer/plugin/apt_tools.py:9
 msgid "Interface with the package manager APT"
-msgstr "Kapcsolódás az APT csomagkezelőhöz"
+msgstr "Felület az APT csomagkezelővel"
 
 #: ../kupfer/plugin/apt_tools.py:25
 msgid "Installation method"
@@ -1545,16 +1607,16 @@ msgstr "Telepítés"
 
 #: ../kupfer/plugin/apt_tools.py:103
 msgid "Install package using the configured method"
-msgstr "Csomag telepítése a belállított módon"
+msgstr "Csomag telepítése a beállított módon"
 
 #: ../kupfer/plugin/apt_tools.py:122
 #, python-format
 msgid "Packages matching \"%s\""
-msgstr "\"%s\" mintájú csomagok"
+msgstr "Erre illeszkedő csomagok: „%s”"
 
 #: ../kupfer/plugin/apt_tools.py:154
 msgid "Search Package Name..."
-msgstr "Keresés csomagnévre..."
+msgstr "Csomagnév keresése…"
 
 #: ../kupfer/plugin/archiveinside.py:8
 msgid "Deep Archives"
@@ -1562,7 +1624,7 @@ msgstr "Mély archívumok"
 
 #: ../kupfer/plugin/archiveinside.py:10
 msgid "Allow browsing inside compressed archive files"
-msgstr "Lehetővé teszi tömörített archívumok böngészését"
+msgstr "Lehetővé teszi a tömörített archívumfájlokon belüli böngészést"
 
 #: ../kupfer/plugin/archiveinside.py:49
 #, python-format
@@ -1573,15 +1635,15 @@ msgstr "%s tartalma"
 #. don't panic! This is just because it's crazy and fun! ツ
 #: ../kupfer/plugin/asciiunicodeiconset.py:3
 msgid "Ascii & Unicode Icon Set"
-msgstr "Ascii & Unicode ikonkészlet"
+msgstr "Ascii és Unicode ikonkészlet"
 
 #: ../kupfer/plugin/asciiunicodeiconset.py:5
 msgid ""
 "Provides the Ascii and Unicode icon sets that use letters and symbols to "
 "produce icons for the objects found in Kupfer."
 msgstr ""
-"Ascii & Unicode ikonkészlet, betű- és szimbólumikonok használata a Kupfer "
-"objektumaihoz."
+"Az Ascii és Unicode ikonkészlet biztosítja, amelyek betűket és szimbólumokat "
+"használnak ikonok készítéséhez a Kupferben található objektumokhoz."
 
 #: ../kupfer/plugin/asciiunicodeiconset.py:21
 msgid "Ascii"
@@ -1597,51 +1659,51 @@ msgstr "Audacious"
 
 #: ../kupfer/plugin/audacious.py:3
 msgid "Control Audacious playback and playlist"
-msgstr "Audacious lejátszás és lejátszási lista"
+msgstr "Audacious lejátszás és lejátszólista vezérlése"
 
 #: ../kupfer/plugin/audacious.py:62
 msgid "Add track to the Audacious play queue"
-msgstr "Szám hozzáadása az Audacious lejátszási sorhoz"
+msgstr "Szám hozzáadása az Audacious lejátszási sorához"
 
 #: ../kupfer/plugin/audacious.py:70
 msgid "Dequeue"
-msgstr "Elvétel a sorból"
+msgstr "Kivétel a sorból"
 
 #: ../kupfer/plugin/audacious.py:74
 msgid "Remove track from the Audacious play queue"
-msgstr "Szám elvétele az Audacious lejátszási sorból"
+msgstr "Szám eltávolítása az Audacious lejátszási sorából"
 
 #: ../kupfer/plugin/audacious.py:86
 msgid "Jump to track in Audacious"
-msgstr "Számhoz ugrás az Audacious-ban"
+msgstr "Számhoz ugrás az Audaciousban"
 
 #: ../kupfer/plugin/audacious.py:96
 msgid "Resume playback in Audacious"
-msgstr "Lejátszás folytatása Audacious-ban"
+msgstr "Lejátszás folytatása az Audaciousban"
 
 #: ../kupfer/plugin/audacious.py:106
 msgid "Pause playback in Audacious"
-msgstr "Lejátszás szüneteltetése Audacious-ban"
+msgstr "Lejátszás szüneteltetése az Audaciousban"
 
 #: ../kupfer/plugin/audacious.py:116
 msgid "Jump to next track in Audacious"
-msgstr "Következő szám Audacious-ban"
+msgstr "Ugrás a következő számhoz az Audaciousban"
 
 #: ../kupfer/plugin/audacious.py:126
 msgid "Jump to previous track in Audacious"
-msgstr "Előző szám Audacious-ban"
+msgstr "Ugrás az előző számhoz az Audaciousban"
 
 #: ../kupfer/plugin/audacious.py:136
 msgid "Clear the Audacious play queue"
-msgstr "Audacious lejátszási sor kiürítése"
+msgstr "Az Audacious lejátszási sorának törlése"
 
 #: ../kupfer/plugin/audacious.py:142
 msgid "Shuffle"
-msgstr "Véletlenszerűen"
+msgstr "Keverés"
 
 #: ../kupfer/plugin/audacious.py:146
 msgid "Toggle shuffle in Audacious"
-msgstr "Véletlenszerű lejátszás ki/be az Audacious-ban"
+msgstr "Keverés váltása az Audaciousban"
 
 #: ../kupfer/plugin/audacious.py:152
 msgid "Repeat"
@@ -1649,11 +1711,11 @@ msgstr "Ismétlés"
 
 #: ../kupfer/plugin/audacious.py:156
 msgid "Toggle repeat in Audacious"
-msgstr "Ismétlés ki/be az Audacious-ban"
+msgstr "Ismétlés váltása az Audaciousban"
 
 #: ../kupfer/plugin/audacious.py:171
 msgid "Playlist"
-msgstr "Lejátszási lista"
+msgstr "Lejátszólista"
 
 #: ../kupfer/plugin/chromium.py:1 ../kupfer/plugin/chromium.py:16
 msgid "Chromium Bookmarks"
@@ -1670,39 +1732,39 @@ msgstr "Claws Mail"
 
 #: ../kupfer/plugin/clawsmail.py:5
 msgid "Claws Mail Contacts and Actions"
-msgstr "Claws Mail címtár és akciók"
+msgstr "Claws Mail címtár és műveletek"
 
 #: ../kupfer/plugin/clawsmail.py:26 ../kupfer/plugin/evolution.py:24
-#: ../kupfer/plugin/operamail.py:26 ../kupfer/plugin/thunderbird.py:29
+#: ../kupfer/plugin/operamail.py:26 ../kupfer/plugin/thunderbird.py:31
 msgid "Compose New Email"
 msgstr "Új levél írása"
 
 #: ../kupfer/plugin/clawsmail.py:32
 msgid "Compose a new message in Claws Mail"
-msgstr "Új levél írása Claws Mail-ben"
+msgstr "Új levél írása a Claws Mailben"
 
 #: ../kupfer/plugin/clawsmail.py:41
 msgid "Receive All Email"
-msgstr "Levelek fogadása"
+msgstr "Minden levél fogadása"
 
 #: ../kupfer/plugin/clawsmail.py:47
 msgid "Receive new messages from all accounts in ClawsMail"
-msgstr "Levelek fogadása a Claws Mail mindegyik postafiókjába"
+msgstr "Új üzenetek fogadása a Claws Mail minden fiókjába"
 
 #: ../kupfer/plugin/clawsmail.py:56 ../kupfer/plugin/defaultmail.py:18
 #: ../kupfer/plugin/evolution.py:40 ../kupfer/plugin/operamail.py:41
-#: ../kupfer/plugin/thunderbird.py:45
+#: ../kupfer/plugin/thunderbird.py:47
 msgid "Compose Email"
 msgstr "Levél írása"
 
 #: ../kupfer/plugin/clawsmail.py:81 ../kupfer/plugin/defaultmail.py:43
 #: ../kupfer/plugin/evolution.py:65
 msgid "Send in Email To..."
-msgstr "Elküldés levélben valakinek..."
+msgstr "Küldés levélben…"
 
 #: ../kupfer/plugin/clawsmail.py:107
 msgid "Compose new message in Claws Mail and attach file"
-msgstr "Új levél írása és fájl csatolása Claws Mail-ben"
+msgstr "Új üzenet írása és fájl csatolása a Claws Mailben"
 
 #: ../kupfer/plugin/clawsmail.py:116
 msgid "Claws Mail Address Book"
@@ -1710,28 +1772,28 @@ msgstr "Claws Mail címjegyzék"
 
 #: ../kupfer/plugin/clawsmail.py:164
 msgid "Contacts from Claws Mail Address Book"
-msgstr "Címek a Claws Mail címjegyzékéből"
+msgstr "Partnerek a Claws Mail címjegyzékéből"
 
 #: ../kupfer/plugin/custom_terminal.py:1
 #: ../kupfer/plugin/custom_terminal.py:39
 msgid "Custom Terminal"
-msgstr "Egyedi terminál"
+msgstr "Egyéni terminál"
 
 #: ../kupfer/plugin/custom_terminal.py:2
 msgid "Configure a custom terminal emulator"
-msgstr "Egyedi terminálemulátor beállítása"
+msgstr "Egyéni terminálemulátor beállítása"
 
 #: ../kupfer/plugin/custom_terminal.py:18
 msgid "Execute flag"
-msgstr "'Futtatható' jelölés"
+msgstr "Végrehajtás zászló"
 
 #: ../kupfer/plugin/customtheme.py:1
 msgid "Custom Theme"
-msgstr "Egyedi téma"
+msgstr "Egyéni téma"
 
 #: ../kupfer/plugin/customtheme.py:3
 msgid "Use a custom color theme"
-msgstr "Egyedi színtéma használata"
+msgstr "Egyéni színtéma használata"
 
 #: ../kupfer/plugin/customtheme.py:110
 msgid "Theme:"
@@ -1739,11 +1801,12 @@ msgstr "Téma:"
 
 #: ../kupfer/plugin/defaultmail.py:1
 msgid "Default Email Client"
-msgstr "Alapértelmezett email-kliens"
+msgstr "Alapértelmezett e-mail kliens"
 
 #: ../kupfer/plugin/defaultmail.py:6
 msgid "Compose email using the system's default mailto: handler"
-msgstr "Új levél írása a rendszer alapértelmezett 'mailto:' kezelőjével"
+msgstr ""
+"Levél írása a rendszer alapértelmezett „mailto:” kezelőjének használatával"
 
 #: ../kupfer/plugin/devhelp.py:1
 msgid "Devhelp"
@@ -1751,7 +1814,16 @@ msgstr "Devhelp"
 
 #: ../kupfer/plugin/devhelp.py:3 ../kupfer/plugin/devhelp.py:13
 msgid "Search in Devhelp"
-msgstr "Keresés a Devhelp-ben"
+msgstr "Keresés a Devhelpben"
+
+#: ../kupfer/plugin/duckduckgo.py:5 ../kupfer/plugin/duckduckgo.py:19
+#| msgid "Google Search"
+msgid "DuckDuckGo Search"
+msgstr "DuckDuckGo keresés"
+
+#: ../kupfer/plugin/duckduckgo.py:8 ../kupfer/plugin/duckduckgo.py:30
+msgid "Search the web securely with DuckDuckGo"
+msgstr "Keresés a világhálón biztonságosan a DuckDuckGo szolgáltatással"
 
 #. -*- coding: UTF-8 -*-
 #. vim: set noexpandtab ts=8 sw=8:
@@ -1761,59 +1833,59 @@ msgstr "Empathy"
 
 #: ../kupfer/plugin/empathy.py:6
 msgid "Access to Empathy Contacts"
-msgstr "Hozzáférés az Empathy címtárhoz"
+msgstr "Hozzáférés az Empathy partnerekhez"
 
-#: ../kupfer/plugin/empathy.py:25 ../kupfer/plugin/pidgin.py:29
+#: ../kupfer/plugin/empathy.py:26 ../kupfer/plugin/pidgin.py:29
 msgid "Show offline contacts"
-msgstr "Kijelentkezett címek megjelenítése"
+msgstr "Kilépett partnerek megjelenítése"
 
-#: ../kupfer/plugin/empathy.py:34 ../kupfer/plugin/gajim.py:26
+#: ../kupfer/plugin/empathy.py:35 ../kupfer/plugin/gajim.py:26
 #: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:30
 msgid "Available"
 msgstr "Elérhető"
 
-#: ../kupfer/plugin/empathy.py:35 ../kupfer/plugin/gajim.py:28
+#: ../kupfer/plugin/empathy.py:36 ../kupfer/plugin/gajim.py:28
 #: ../kupfer/plugin/pidgin.py:158 ../kupfer/plugin/skype.py:32
 msgid "Away"
 msgstr "Távol"
 
-#: ../kupfer/plugin/empathy.py:36 ../kupfer/plugin/gajim.py:30
+#: ../kupfer/plugin/empathy.py:37 ../kupfer/plugin/gajim.py:30
 #: ../kupfer/plugin/skype.py:34
 msgid "Busy"
 msgstr "Elfoglalt"
 
-#: ../kupfer/plugin/empathy.py:37 ../kupfer/plugin/gajim.py:29
+#: ../kupfer/plugin/empathy.py:38 ../kupfer/plugin/gajim.py:29
 #: ../kupfer/plugin/skype.py:33
 msgid "Not Available"
-msgstr "Nem elérhető"
+msgstr "Nem érhető el"
 
-#: ../kupfer/plugin/empathy.py:38 ../kupfer/plugin/gajim.py:31
+#: ../kupfer/plugin/empathy.py:39 ../kupfer/plugin/gajim.py:31
 #: ../kupfer/plugin/skype.py:35
 msgid "Invisible"
 msgstr "Láthatatlan"
 
-#: ../kupfer/plugin/empathy.py:39 ../kupfer/plugin/gajim.py:32
+#: ../kupfer/plugin/empathy.py:40 ../kupfer/plugin/gajim.py:32
 #: ../kupfer/plugin/skype.py:36
 msgid "Offline"
-msgstr "Kijelentkezve"
+msgstr "Kilépett"
 
-#: ../kupfer/plugin/empathy.py:96 ../kupfer/plugin/gajim.py:90
-#: ../kupfer/plugin/pidgin.py:97 ../kupfer/plugin/skype.py:204
+#: ../kupfer/plugin/empathy.py:100 ../kupfer/plugin/gajim.py:93
+#: ../kupfer/plugin/pidgin.py:97 ../kupfer/plugin/skype.py:197
 msgid "Open Chat"
 msgstr "Csevegés megnyitása"
 
-#: ../kupfer/plugin/empathy.py:129 ../kupfer/plugin/gajim.py:118
-#: ../kupfer/plugin/skype.py:250
+#: ../kupfer/plugin/empathy.py:133 ../kupfer/plugin/gajim.py:121
+#: ../kupfer/plugin/skype.py:243
 msgid "Change Global Status To..."
-msgstr "Globális státusz megváltozatása..."
+msgstr "Globális állapot megváltoztatása…"
 
-#: ../kupfer/plugin/empathy.py:171
+#: ../kupfer/plugin/empathy.py:175
 msgid "Empathy Contacts"
-msgstr "Empathy címtár"
+msgstr "Empathy partnerek"
 
-#: ../kupfer/plugin/empathy.py:237
+#: ../kupfer/plugin/empathy.py:249
 msgid "Empathy Account Status"
-msgstr "Empathy fiók státusz"
+msgstr "Empathy fiók állapot"
 
 #: ../kupfer/plugin/evolution.py:4
 msgid "Evolution"
@@ -1821,15 +1893,15 @@ msgstr "Evolution"
 
 #: ../kupfer/plugin/evolution.py:7 ../kupfer/plugin/evolution.py:119
 msgid "Evolution contacts"
-msgstr "Evolution címtár"
+msgstr "Evolution partnerek"
 
 #: ../kupfer/plugin/evolution.py:31
 msgid "Compose a new message in Evolution"
-msgstr "Új levél írása Evolution-ban"
+msgstr "Új üzenet írása az Evolutionben"
 
 #: ../kupfer/plugin/evolution.py:92
 msgid "Compose new message in Evolution and attach file"
-msgstr "Új levél írása és fájl csatolása Evolution-ban"
+msgstr "Új üzenet írása és fájl csatolása az Evolutionben"
 
 #: ../kupfer/plugin/evolution.py:100
 msgid "Evolution Address Book"
@@ -1842,19 +1914,19 @@ msgstr "Filezilla"
 
 #: ../kupfer/plugin/filezilla.py:6
 msgid "Show sites and handle ftp addresses by Filezilla"
-msgstr "Weboldalak és ftp címek kezelése Filezilla-val"
+msgstr "Oldalak megjelenítése és FTP-címek kezelése a Filezillával"
 
 #: ../kupfer/plugin/filezilla.py:42
 msgid "Open Site with Filezilla"
-msgstr "Weboldal megnyitása Filezilla-val"
+msgstr "Oldal megnyitása a Filezillával"
 
 #: ../kupfer/plugin/filezilla.py:87
 msgid "Filezilla Sites"
-msgstr "Filezilla weboldalak"
+msgstr "Filezilla oldalak"
 
 #: ../kupfer/plugin/filezilla.py:122
 msgid "Sites from Filezilla"
-msgstr "Filezilla weboldalak"
+msgstr "Oldalak a Filezillából"
 
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/gajim.py:2
@@ -1863,24 +1935,132 @@ msgstr "Gajim"
 
 #: ../kupfer/plugin/gajim.py:5
 msgid "Access to Gajim Contacts"
-msgstr "Hozzáférés a Gajim címtárhoz"
+msgstr "Hozzáférés a Gajim partnerekhez"
 
 #: ../kupfer/plugin/gajim.py:27
 msgid "Free for Chat"
 msgstr "Csevegésre kész"
 
-#: ../kupfer/plugin/gajim.py:146
+#: ../kupfer/plugin/gajim.py:149
 msgid "Gajim Contacts"
-msgstr "Gajim címtár"
+msgstr "Gajim partnerek"
 
-#: ../kupfer/plugin/gajim.py:210
+#: ../kupfer/plugin/gajim.py:213
 msgid "Gajim Account Status"
-msgstr "Gajim fiók státusz"
+msgstr "Gajim fiók állapot"
 
 #. TRANS: "Glob" is the matching files like a shell with "*.py" etc.
 #: ../kupfer/plugin/glob.py:3 ../kupfer/plugin/glob.py:17
 msgid "Glob"
 msgstr "Minta"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/gmail/__init__.py:2 ../kupfer/plugin/gmail/__init__.py:234
+msgid "Gmail"
+msgstr "Gmail"
+
+#: ../kupfer/plugin/gmail/__init__.py:5
+msgid "Load contacts and compose new email in Gmail"
+msgstr "Partnerek betöltése és új levél írása Gmailben"
+
+#: ../kupfer/plugin/gmail/__init__.py:33
+msgid "Load contacts' pictures"
+msgstr "Partnerek képeinek betöltése"
+
+#: ../kupfer/plugin/gmail/__init__.py:39
+#| msgid "show version information"
+msgid "Load additional information"
+msgstr "További információk betöltése"
+
+#: ../kupfer/plugin/gmail/__init__.py:50
+msgid "Work email"
+msgstr "Munkahelyi e-mail"
+
+#: ../kupfer/plugin/gmail/__init__.py:51
+#| msgid "Compose Email"
+msgid "Home email"
+msgstr "Otthoni e-mail"
+
+#: ../kupfer/plugin/gmail/__init__.py:52
+msgid "Other email"
+msgstr "Egyéb e-mail"
+
+#: ../kupfer/plugin/gmail/__init__.py:54
+#| msgid "Workspaces"
+msgid "Work address"
+msgstr "Munkahelyi cím"
+
+#: ../kupfer/plugin/gmail/__init__.py:55
+#| msgid "Home Folder"
+msgid "Home address"
+msgstr "Otthoni cím"
+
+#: ../kupfer/plugin/gmail/__init__.py:56
+msgid "Other address"
+msgstr "Egyéb cím"
+
+#: ../kupfer/plugin/gmail/__init__.py:58
+msgid "Car phone"
+msgstr "Autótelefon"
+
+#: ../kupfer/plugin/gmail/__init__.py:59
+msgid "Fax"
+msgstr "Fax"
+
+#: ../kupfer/plugin/gmail/__init__.py:61
+#| msgid "Home Folder"
+msgid "Home phone"
+msgstr "Otthoni telefon"
+
+#: ../kupfer/plugin/gmail/__init__.py:62
+msgid "Home fax"
+msgstr "Otthoni fax"
+
+#: ../kupfer/plugin/gmail/__init__.py:63
+msgid "Internal phone"
+msgstr "Belső telefon"
+
+#: ../kupfer/plugin/gmail/__init__.py:64
+msgid "Mobile"
+msgstr "Mobiltelefon"
+
+#: ../kupfer/plugin/gmail/__init__.py:65
+msgid "Other"
+msgstr "Egyéb"
+
+#: ../kupfer/plugin/gmail/__init__.py:66
+msgid "VOIP"
+msgstr "VOIP"
+
+#: ../kupfer/plugin/gmail/__init__.py:67
+#| msgid "Workspaces"
+msgid "Work phone"
+msgstr "Munkahelyi telefon"
+
+#: ../kupfer/plugin/gmail/__init__.py:68
+msgid "Work fax"
+msgstr "Munkahelyi fax"
+
+#: ../kupfer/plugin/gmail/__init__.py:93
+msgid "Compose Email in Gmail"
+msgstr "Levél írása a Gmailben"
+
+#: ../kupfer/plugin/gmail/__init__.py:117
+msgid "Open web browser and compose new email in Gmail"
+msgstr "Webböngésző megnyitása és új levél írása a Gmailben"
+
+#: ../kupfer/plugin/gmail/__init__.py:123
+msgid "Edit Contact in Gmail"
+msgstr "Partner szerkesztése a Gmailben"
+
+#: ../kupfer/plugin/gmail/__init__.py:133
+#| msgid "Open web browser and compose new email in Gmail"
+msgid "Open web browser and edit contact in Gmail"
+msgstr "Webböngésző megnyitása és partner szerkesztése a Gmailben"
+
+#: ../kupfer/plugin/gmail/__init__.py:263
+msgid "Contacts from Google services (Gmail)"
+msgstr "Partnerek a Google szolgáltatásokból (Gmail)"
 
 #: ../kupfer/plugin/gnome_terminal.py:1 ../kupfer/plugin/gnome_terminal.py:56
 msgid "GNOME Terminal Profiles"
@@ -1888,32 +2068,7 @@ msgstr "GNOME terminál profilok"
 
 #: ../kupfer/plugin/gnome_terminal.py:3
 msgid "Launch GNOME Terminal profiles"
-msgstr "GNOME terminálprofilok megtekintése"
-
-#. -*- coding: UTF-8 -*-
-#: ../kupfer/plugin/gmail/__init__.py:2 ../kupfer/plugin/gmail/__init__.py:144
-msgid "Gmail"
-msgstr "Gmail"
-
-#: ../kupfer/plugin/gmail/__init__.py:5
-msgid "Load contacts and compose new email in Gmail"
-msgstr "Címek betöltése és új levél írása Gmail-ben"
-
-#: ../kupfer/plugin/gmail/__init__.py:32
-msgid "Load contacts' pictures"
-msgstr "Kapcsolatok képeinek betöltése"
-
-#: ../kupfer/plugin/gmail/__init__.py:51
-msgid "Compose Email in Gmail"
-msgstr "Levél írása Gmail-ben"
-
-#: ../kupfer/plugin/gmail/__init__.py:74
-msgid "Open web browser and compose new email in Gmail"
-msgstr "Webböngészó indítása és új levél írása Gmail-ben"
-
-#: ../kupfer/plugin/gmail/__init__.py:177
-msgid "Contacts from Google services (Gmail)"
-msgstr "Címtár betöltése a Google szolgáltatásokból (Gmail)"
+msgstr "GNOME terminálprofilok indítása"
 
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/google_picasa/__init__.py:2
@@ -1922,15 +2077,15 @@ msgstr "Google Picasa"
 
 #: ../kupfer/plugin/google_picasa/__init__.py:5
 msgid "Show albums and upload files to Picasa"
-msgstr "Albumok megjelenítése és képek feltöltése a Picasa-ra"
+msgstr "Albumok megjelenítése és fájlok feltöltése a Picasára"
 
 #: ../kupfer/plugin/google_picasa/__init__.py:35
 msgid "Users to show: (,-separated)"
-msgstr "Megjelenítendő felhasználók (vesszővel elválasztva)"
+msgstr "Megjelenítendő felhasználók: (vesszővel elválasztva)"
 
 #: ../kupfer/plugin/google_picasa/__init__.py:41
 msgid "Load user and album icons"
-msgstr "Felhasználói és album ikonok betöltése"
+msgstr "Felhasználó és album ikonok betöltése"
 
 #: ../kupfer/plugin/google_picasa/__init__.py:92
 msgid "Uploading Pictures"
@@ -1938,15 +2093,15 @@ msgstr "Képek feltöltése"
 
 #: ../kupfer/plugin/google_picasa/__init__.py:93
 msgid "Uploading pictures to Picasa Web Album"
-msgstr "Képek feltöltése Picasa webalbumba"
+msgstr "Képek feltöltése a Picasa webalbumba"
 
 #: ../kupfer/plugin/google_picasa/__init__.py:102
 msgid "Creating album:"
-msgstr "Album létrehozása"
+msgstr "Album létrehozása:"
 
 #: ../kupfer/plugin/google_picasa/__init__.py:105
 msgid "Album created by Kupfer"
-msgstr "Az albumot a Kupfer hozta létre"
+msgstr "Kupfer által létrehozott album"
 
 #: ../kupfer/plugin/google_picasa/__init__.py:112
 msgid "File:"
@@ -1963,24 +2118,24 @@ msgstr[1] "%(num)d album"
 #, python-format
 msgid "one photo"
 msgid_plural "%(num)s photos"
-msgstr[0] "egy kép"
-msgstr[1] "%(num)s kép"
+msgstr[0] "egy fénykép"
+msgstr[1] "%(num)s fénykép"
 
 #: ../kupfer/plugin/google_picasa/__init__.py:299
 msgid "Upload to Picasa Album..."
-msgstr "Feltöltés Picasa albumba..."
+msgstr "Feltöltés a Picasa albumba…"
 
 #: ../kupfer/plugin/google_picasa/__init__.py:343
 msgid "Upload files to Picasa album"
-msgstr "Fájlok feltöltése Picasa albumba"
+msgstr "Fájlok feltöltése a Picasa albumba"
 
 #: ../kupfer/plugin/google_picasa/__init__.py:349
 msgid "Upload to Picasa as New Album"
-msgstr "Feltöltés a Picasa-ra új albumba"
+msgstr "Feltöltés a Picasára új albumként"
 
 #: ../kupfer/plugin/google_picasa/__init__.py:377
 msgid "Create album from selected local directory"
-msgstr "Album létrehozása a kijelölt mappából"
+msgstr "Album létrehozása a kijelölt helyi könyvtárból"
 
 #: ../kupfer/plugin/google_picasa/__init__.py:381
 #: ../kupfer/plugin/google_picasa/__init__.py:404
@@ -1989,7 +2144,7 @@ msgstr "Picasa albumok"
 
 #: ../kupfer/plugin/google_picasa/__init__.py:436
 msgid "User albums in Picasa"
-msgstr "Felhasználói albumok a Picasa-ban"
+msgstr "Felhasználói albumok a Picasában"
 
 #: ../kupfer/plugin/google_search.py:1 ../kupfer/plugin/google_search.py:30
 msgid "Google Search"
@@ -1997,67 +2152,23 @@ msgstr "Google keresés"
 
 #: ../kupfer/plugin/google_search.py:3
 msgid "Search Google with results shown directly"
-msgstr "Keresés a Google-ban az eredmények átvételével"
+msgstr "Google keresés a közvetlenül megjelenített eredményekkel"
 
 #: ../kupfer/plugin/google_search.py:58 ../kupfer/plugin/locate.py:46
-#: ../kupfer/plugin/tracker.py:72 ../kupfer/plugin/tracker.py:113
 #: ../kupfer/plugin/tracker1.py:168 ../kupfer/plugin/tracker1.py:179
 #, python-format
 msgid "Results for \"%s\""
-msgstr "\"%s\" keresés eredményei"
+msgstr "„%s” keresési eredményei"
 
 #: ../kupfer/plugin/google_search.py:91
 #, python-format
 msgid "Show More Results For \"%s\""
-msgstr "Még több eredmény megjelenítése ehhez: \"%s\""
+msgstr "További eredmények megjelenítése ehhez: „%s”"
 
 #: ../kupfer/plugin/google_search.py:92
 #, python-format
 msgid "%s total found"
 msgstr "%s találat összesen"
-
-#: ../kupfer/plugin/google_translate.py:6
-msgid "Google Translate"
-msgstr "Google fordító"
-
-#: ../kupfer/plugin/google_translate.py:8
-#: ../kupfer/plugin/google_translate.py:153
-msgid "Translate text with Google Translate"
-msgstr "Szöveg lefordítása Google fordítóval"
-
-#: ../kupfer/plugin/google_translate.py:83
-msgid "Google Translate connection timed out"
-msgstr "Google fordítóval a kapcsolat megszakadt"
-
-#: ../kupfer/plugin/google_translate.py:86
-msgid "Error connecting to Google Translate"
-msgstr "Nem sikerült kapcsolódni a Google fordítóhoz"
-
-#: ../kupfer/plugin/google_translate.py:136
-#: ../kupfer/plugin/google_translate.py:223
-msgid "Translate To..."
-msgstr "Fordítás..."
-
-#: ../kupfer/plugin/google_translate.py:179
-#, python-format
-msgid "Translate into %s"
-msgstr "Fordítás %s-ra"
-
-#: ../kupfer/plugin/google_translate.py:203
-msgid "Languages"
-msgstr "Nyelvek"
-
-#: ../kupfer/plugin/google_translate.py:238
-msgid "Show translated page in browser"
-msgstr "A lefordított szöveg megjelenítése böngészőben"
-
-#: ../kupfer/plugin/google_translate.py:255
-msgid "Show Translation To..."
-msgstr "Szöveg lefordítása erre..."
-
-#: ../kupfer/plugin/google_translate.py:271
-msgid "Show translation in browser"
-msgstr "Fordítás megjelenítése böngészőben"
 
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/gtg.py:2
@@ -2066,58 +2177,58 @@ msgstr "Getting Things GNOME"
 
 #: ../kupfer/plugin/gtg.py:5
 msgid "Browse and create new tasks in GTG"
-msgstr "Böngészés és új feladatok létrehozása GTG-ben"
+msgstr "Böngészés és új feladatok létrehozása a GTG-ben"
 
-#: ../kupfer/plugin/gtg.py:87
+#: ../kupfer/plugin/gtg.py:114
 #, python-format
 msgid "due: %s"
 msgstr "határidő: %s"
 
-#: ../kupfer/plugin/gtg.py:89
+#: ../kupfer/plugin/gtg.py:116
 #, python-format
 msgid "start: %s"
 msgstr "kezdés: %s"
 
-#: ../kupfer/plugin/gtg.py:91
+#: ../kupfer/plugin/gtg.py:118
 #, python-format
 msgid "tags: %s"
-msgstr "cimkék: %s"
+msgstr "címkék: %s"
 
-#: ../kupfer/plugin/gtg.py:118
+#: ../kupfer/plugin/gtg.py:148
 msgid "Open task in Getting Things GNOME!"
-msgstr "Feladat megnyitása a 'Getting Things GNOME'-ban"
+msgstr "Feladat megnyitása a „Getting Things GNOME!”-ban"
 
-#: ../kupfer/plugin/gtg.py:125
+#: ../kupfer/plugin/gtg.py:155
 msgid "Delete"
 msgstr "Törlés"
 
-#: ../kupfer/plugin/gtg.py:135
+#: ../kupfer/plugin/gtg.py:168
 msgid "Permanently remove this task"
-msgstr "Feladat végleges törlése"
+msgstr "Feladat végleges eltávolítása"
 
-#: ../kupfer/plugin/gtg.py:140
+#: ../kupfer/plugin/gtg.py:173
 msgid "Mark Done"
 msgstr "Készre jelölés"
 
-#: ../kupfer/plugin/gtg.py:149
+#: ../kupfer/plugin/gtg.py:182
 msgid "Mark this task as done"
 msgstr "A feladat készre jelölése"
 
-#: ../kupfer/plugin/gtg.py:154
+#: ../kupfer/plugin/gtg.py:187
 msgid "Dismiss"
-msgstr "Eldobás"
+msgstr "Eltüntetés"
 
-#: ../kupfer/plugin/gtg.py:163
+#: ../kupfer/plugin/gtg.py:196
 msgid "Mark this task as not to be done anymore"
-msgstr "Feladat megjelölése 'nem szükséges'-ként"
+msgstr "Feladat megjelölése „többé nem kell elvégezni”-ként"
 
-#: ../kupfer/plugin/gtg.py:168
+#: ../kupfer/plugin/gtg.py:201
 msgid "Create Task"
 msgstr "Feladat létrehozása"
 
-#: ../kupfer/plugin/gtg.py:182
+#: ../kupfer/plugin/gtg.py:218
 msgid "Create new task in Getting Things GNOME"
-msgstr "Feladat létrehozása a 'Getting Things GNOME'-ban"
+msgstr "Feladat létrehozása a „Getting Things GNOME”-ban"
 
 #: ../kupfer/plugin/gwibber.py:3
 msgid "Gwibber"
@@ -2129,13 +2240,14 @@ msgid ""
 "social networks like Twitter, Identi.ca etc. Requires the package 'gwibber-"
 "service'."
 msgstr ""
-"Mikroblogolás Gwibber-rel. Küldeni és fogadni lehet üzeneteket közösségi "
-"hálózatokon, mint a Twitter vagy Identi.ca, stb. A 'gwibber-service' csomag "
+"Mikroblogolás a Gwibberrel. Lehetővé teszi üzenetek küldését és fogadását a "
+"közösségi hálózatokról mint a Twitter, Identi.ca, stb. A „gwibber-service” "
+"csomag "
 "szükséges hozzá."
 
 #: ../kupfer/plugin/gwibber.py:45
 msgid "Maximum number of messages to show"
-msgstr "Megjeleneített üzenetek maximális száma"
+msgstr "Megjelenítendő üzenetek maximális száma"
 
 #. TRANS: Account description, similar to "John on Identi.ca"
 #: ../kupfer/plugin/gwibber.py:98
@@ -2157,11 +2269,11 @@ msgstr "Üzenet küldése"
 
 #: ../kupfer/plugin/gwibber.py:205
 msgid "Send message to all Gwibber accounts"
-msgstr "Üzenet küldése mindegyik Gwibber fiókra"
+msgstr "Üzenet küldése minden Gwibber fiókra"
 
 #: ../kupfer/plugin/gwibber.py:210
 msgid "Send Message To..."
-msgstr "Üzenet küldése valakinek..."
+msgstr "Üzenet küldése…"
 
 #: ../kupfer/plugin/gwibber.py:238
 msgid "Send message to a Gwibber account"
@@ -2169,7 +2281,7 @@ msgstr "Üzenet küldése egy Gwibber fiókra"
 
 #: ../kupfer/plugin/gwibber.py:243 ../kupfer/plugin/pidgin.py:120
 msgid "Send Message..."
-msgstr "Üzenet küldése..."
+msgstr "Üzenet küldése…"
 
 #: ../kupfer/plugin/gwibber.py:273
 msgid "Send message to selected Gwibber account"
@@ -2177,7 +2289,7 @@ msgstr "Üzenet küldése a kijelölt Gwibber fiókra"
 
 #: ../kupfer/plugin/gwibber.py:278
 msgid "Reply..."
-msgstr "Válasz..."
+msgstr "Válasz…"
 
 #: ../kupfer/plugin/gwibber.py:314
 msgid "Delete Message"
@@ -2185,27 +2297,27 @@ msgstr "Üzenet törlése"
 
 #: ../kupfer/plugin/gwibber.py:337
 msgid "Send Private Message..."
-msgstr "Magánüzenet küldése..."
+msgstr "Magánüzenet küldése…"
 
 #: ../kupfer/plugin/gwibber.py:370
 msgid "Send direct message to user"
-msgstr "Közvetlen üzenet küldése egy felhasználónak"
+msgstr "Közvetlen üzenet küldése a felhasználónak"
 
 #: ../kupfer/plugin/gwibber.py:376
 msgid "Retweet"
-msgstr "Retweet"
+msgstr "Újratweetelés"
 
 #: ../kupfer/plugin/gwibber.py:376
 msgid "Retweet To..."
-msgstr "Retweet valakinek..."
+msgstr "Újratweetelés…"
 
 #: ../kupfer/plugin/gwibber.py:407
 msgid "Retweet message to all Gwibber accounts"
-msgstr "Retweet mindegyik Gwibber fiókra"
+msgstr "Üzenet újratweetelése minden Gwibber fiókra"
 
 #: ../kupfer/plugin/gwibber.py:408
 msgid "Retweet message to a Gwibber account"
-msgstr "Retweet egy Gwibber fiókra"
+msgstr "Üzenet újratweetelése egy Gwibber fiókra"
 
 #: ../kupfer/plugin/gwibber.py:413
 msgid "Open in Browser"
@@ -2221,7 +2333,7 @@ msgstr "Gwibber fiókok"
 
 #: ../kupfer/plugin/gwibber.py:456
 msgid "Accounts configured in Gwibber"
-msgstr "Gwibber-ben beállított fiókok"
+msgstr "A Gwibberben beállított fiókok"
 
 #: ../kupfer/plugin/gwibber.py:495
 msgid "Gwibber Messages"
@@ -2229,13 +2341,13 @@ msgstr "Gwibber üzenetek"
 
 #: ../kupfer/plugin/gwibber.py:518
 msgid "Recent messages received by Gwibber"
-msgstr "Legfrissebb Gwibber üzenetek"
+msgstr "A Gwibberrel legutóbb fogadott üzenetek"
 
 #. TRANS:  %s is a service name
 #: ../kupfer/plugin/gwibber.py:527
 #, python-format
 msgid "Gwibber Messages for %s"
-msgstr "Gwibber üzenetek a %s szolgáltatáson"
+msgstr "Gwibber üzenetek ehhez: %s"
 
 #: ../kupfer/plugin/gwibber.py:543
 msgid "Gwibber Streams"
@@ -2243,13 +2355,13 @@ msgstr "Gwibber folyamok"
 
 #: ../kupfer/plugin/gwibber.py:566
 msgid "Streams configured in Gwibber"
-msgstr "Gwibber-ben beállított folyamok"
+msgstr "A Gwibberben beállított folyamok"
 
 #. TRANS: Gwibber messages in %s :: %s is a Stream name
 #: ../kupfer/plugin/gwibber.py:574
 #, python-format
 msgid "Gwibber Messages in %s"
-msgstr "Gwibber üzenetek a %s folyamon"
+msgstr "Gwibber üzenetek ebben: %s"
 
 #: ../kupfer/plugin/gwibber_simple.py:3
 msgid "Gwibber (Simple)"
@@ -2257,7 +2369,7 @@ msgstr "Gwibber (egyszerű)"
 
 #: ../kupfer/plugin/gwibber_simple.py:7
 msgid "Send updates via the microblogging client Gwibber"
-msgstr "Frissítések küldése a Gwibber mikroblogoló kliensen"
+msgstr "Frissítések küldése a Gwibber mikroblogoló kliensen keresztül"
 
 #: ../kupfer/plugin/gwibber_simple.py:45
 msgid "Send Update"
@@ -2265,60 +2377,60 @@ msgstr "Frissítés küldése"
 
 #: ../kupfer/plugin/gwibber_simple.py:65
 msgid "Unable to activate Gwibber service"
-msgstr "Nem sikerült aktiválni a Gwibber szolgáltatást"
+msgstr "Nem aktiválható a Gwibber szolgáltatás"
 
 #: ../kupfer/plugin/higherorder.py:1
 msgid "Higher-order Actions"
-msgstr "Magasabbrendű akciók"
+msgstr "Magasabb rendű műveletek"
 
 #: ../kupfer/plugin/higherorder.py:7
 msgid "Tools to work with commands as objects"
-msgstr "Eszközök, amik paracsokat objektumként használnak"
+msgstr "Eszközök, amelyek parancsokat objektumokként használnak"
 
 #: ../kupfer/plugin/higherorder.py:20
 msgid "Select in Kupfer"
-msgstr "Kijelölés Kupfer-ben"
+msgstr "Kijelölés a Kupferben"
 
 #: ../kupfer/plugin/higherorder.py:59
 #, python-format
 msgid "Result of %s (%s)"
-msgstr "%s (%s) eredménye"
+msgstr "%s eredménye (%s)"
 
 #: ../kupfer/plugin/higherorder.py:75
 msgid "Run (Take Result)"
-msgstr "Futtatás (az eredmény átvételével)"
+msgstr "Futtatás (eredmény átvétele)"
 
 #: ../kupfer/plugin/higherorder.py:90
 msgid "Take the command result as a proxy object"
-msgstr "A parancs eredményét helyettes objektumként kezelje"
+msgstr "A parancs eredményének átvétele proxy objektumként"
 
 #: ../kupfer/plugin/higherorder.py:95
 msgid "Run (Discard Result)"
-msgstr "Futtatás (az eredmény eldobásával)"
+msgstr "Futtatás (eredmény eldobása)"
 
 #: ../kupfer/plugin/image.py:1
 msgid "Image Tools"
-msgstr "Eszközök képek kezeléséhez"
+msgstr "Képeszközök"
 
 #: ../kupfer/plugin/image.py:10
 msgid "Image transformation tools"
-msgstr "Eszközök képek átalakításához és kezeléséhez"
+msgstr "Képátalakítási eszközök"
 
 #: ../kupfer/plugin/image.py:25
 msgid "Scale..."
-msgstr "Átméretezés..."
+msgstr "Méretezés…"
 
 #: ../kupfer/plugin/image.py:77
 msgid "Scale image to fit inside given pixel measure(s)"
-msgstr "Kép átméretezése bizonyos méretre"
+msgstr "Kép méretezése a belül megadott képpontméretekre való illesztésre"
 
 #: ../kupfer/plugin/image.py:112
 msgid "Rotate Clockwise"
-msgstr "Forgatás az óra szerint"
+msgstr "Forgatás az óra járásával egyező irányba"
 
 #: ../kupfer/plugin/image.py:119
 msgid "Rotate Counter-Clockwise"
-msgstr "Forgatás az órával ellentétesen"
+msgstr "Forgatás az óra járásával ellentétes irányba"
 
 #: ../kupfer/plugin/image.py:126
 msgid "Autorotate"
@@ -2326,19 +2438,19 @@ msgstr "Automatikus forgatás"
 
 #: ../kupfer/plugin/image.py:155
 msgid "Rotate JPEG (in-place) according to its EXIF metadata"
-msgstr "JPEG képek forgatása az EXIF adatoknak megfelelően"
+msgstr "JPEG képek forgatása (helyben) az EXIF metaadatok alapján"
 
 #: ../kupfer/plugin/kupfer_plugins.py:1 ../kupfer/plugin/kupfer_plugins.py:86
 msgid "Kupfer Plugins"
-msgstr "Kupfer beépülők"
+msgstr "Kupfer bővítmények"
 
 #: ../kupfer/plugin/kupfer_plugins.py:3
 msgid "Access Kupfer's plugin list in Kupfer"
-msgstr "Beépülők listájának elérése Kupfer-ben"
+msgstr "Hozzáférés a Kupfer bővítménylistájához a Kupferben"
 
 #: ../kupfer/plugin/kupfer_plugins.py:19
 msgid "Show Information"
-msgstr "Információ megjelenítése"
+msgstr "Információk megjelenítése"
 
 #: ../kupfer/plugin/kupfer_plugins.py:35
 msgid "Show Source Code"
@@ -2346,32 +2458,53 @@ msgstr "Forráskód megjelenítése"
 
 #: ../kupfer/plugin/kupfer_plugins.py:80
 msgid "enabled"
-msgstr "engedélyezett"
+msgstr "engedélyezve"
 
 #: ../kupfer/plugin/locate.py:1 ../kupfer/plugin/locate.py:28
 msgid "Locate Files"
-msgstr "Fájlok keresése (locate)"
+msgstr "Fájlok keresése"
 
 #: ../kupfer/plugin/locate.py:5 ../kupfer/plugin/locate.py:38
 msgid "Search filesystem using locate"
-msgstr "Fájlok keresése a locate segítségével"
+msgstr "Keresés a fájlrendszerben a locate használatával"
 
 #: ../kupfer/plugin/locate.py:20
 msgid "Ignore case distinctions when searching files"
-msgstr "Kis- és nagybetű ne számítson a keresésnél"
+msgstr "Kis- és nagybetűk megkülönböztetésének mellőzése fájlok keresésekor"
 
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/openoffice.py:3
 msgid "OpenOffice / LibreOffice"
 msgstr "OpenOffice / LibreOffice"
 
-#: ../kupfer/plugin/openoffice.py:5 ../kupfer/plugin/openoffice.py:128
+#: ../kupfer/plugin/openoffice.py:5 ../kupfer/plugin/openoffice.py:136
 msgid "Recently used documents in OpenOffice/LibreOffice"
-msgstr "Legutóbb használt dokumentumok OpenOffice/LibreOffice-ban"
+msgstr "Legutóbb használt dokumentumok az OpenOffice-ban/LibreOffice-ban"
 
-#: ../kupfer/plugin/openoffice.py:74
+#: ../kupfer/plugin/openoffice.py:84
 msgid "OpenOffice/LibreOffice Recent Items"
 msgstr "OpenOffice/LibreOffice legutóbbi elemek"
+
+#. -*- coding: UTF-8 -*-
+#: ../kupfer/plugin/operamail.py:2
+msgid "Opera Mail"
+msgstr "Opera Mail"
+
+#: ../kupfer/plugin/operamail.py:5
+msgid "Opera Mail contacts and actions"
+msgstr "Opera Mail partnerek és műveletek"
+
+#: ../kupfer/plugin/operamail.py:32
+msgid "Compose a new message in Opera Mail"
+msgstr "Új üzenet írása az Opera Mailben"
+
+#: ../kupfer/plugin/operamail.py:64
+msgid "Opera Mail Contacts"
+msgstr "Opera Mail partnerek"
+
+#: ../kupfer/plugin/operamail.py:120
+msgid "Contacts from Opera Mail"
+msgstr "Partnerek az Opera Mailből"
 
 #: ../kupfer/plugin/opera.py:4 ../kupfer/plugin/opera.py:22
 msgid "Opera Bookmarks"
@@ -2381,34 +2514,13 @@ msgstr "Opera könyvjelzők"
 msgid "Index of Opera bookmarks"
 msgstr "Opera könyvjelzők indexe"
 
-#. -*- coding: UTF-8 -*-
-#: ../kupfer/plugin/operamail.py:2
-msgid "Opera Mail"
-msgstr "Opera Mail"
-
-#: ../kupfer/plugin/operamail.py:5
-msgid "Opera Mail contacts and actions"
-msgstr "Opera Mail címtár és parancsok"
-
-#: ../kupfer/plugin/operamail.py:32
-msgid "Compose a new message in Opera Mail"
-msgstr "Új levél írása Opera Mail-ben"
-
-#: ../kupfer/plugin/operamail.py:64
-msgid "Opera Mail Contacts"
-msgstr "Opera Mail címtár"
-
-#: ../kupfer/plugin/operamail.py:120
-msgid "Contacts from Opera Mail"
-msgstr "Opera Mail címjegyzéke"
-
 #: ../kupfer/plugin/pidgin.py:3
 msgid "Pidgin"
 msgstr "Pidgin"
 
 #: ../kupfer/plugin/pidgin.py:9
 msgid "Access to Pidgin Contacts"
-msgstr "Pidgin címtár elérése"
+msgstr "Hozzáférés a Pidgin partnerekhez"
 
 #: ../kupfer/plugin/pidgin.py:111
 #, python-format
@@ -2419,23 +2531,27 @@ msgstr[1] "%s (%d karakter)"
 
 #: ../kupfer/plugin/pidgin.py:192
 msgid "Pidgin Contacts"
-msgstr "Pidgin címtár"
+msgstr "Pidgin partnerek"
 
 #: ../kupfer/plugin/putty.py:5 ../kupfer/plugin/putty.py:80
 msgid "PuTTY Sessions"
-msgstr "PuTTY munkafolyamatok"
+msgstr "PuTTY munkamenetek"
 
 #: ../kupfer/plugin/putty.py:8
 msgid "Quick access to PuTTY Sessions"
-msgstr "PuTTY munkafolyamatok elérése"
+msgstr "Gyors hozzáférés a PuTTY munkamenetekhez"
 
 #: ../kupfer/plugin/putty.py:46 ../kupfer/plugin/tsclient.py:50
 msgid "Start Session"
-msgstr "Munkafolyamat indítása"
+msgstr "Munkamenet indítása"
+
+#: ../kupfer/plugin/qsicons/__init__.py:24
+msgid "Quicksilver Icons"
+msgstr "Quicksilver ikonok"
 
 #: ../kupfer/plugin/quickview.py:1
 msgid "Quick Image Viewer"
-msgstr "Gyors képnéző"
+msgstr "Gyors képnézegető"
 
 #: ../kupfer/plugin/quickview.py:53
 msgid "View Image"
@@ -2447,7 +2563,7 @@ msgstr "reStructuredText"
 
 #: ../kupfer/plugin/rst.py:3
 msgid "Render reStructuredText and show the result"
-msgstr "reStructuredText formázása és megjelenítése"
+msgstr "reStructuredText renderelése és az eredmény megjelenítése"
 
 #: ../kupfer/plugin/rst.py:18
 msgid "View as HTML Document"
@@ -2457,58 +2573,59 @@ msgstr "Megtekintés HTML dokumentumként"
 msgid "GNU Screen"
 msgstr "GNU Screen"
 
-#: ../kupfer/plugin/screen.py:3 ../kupfer/plugin/screen.py:81
+#: ../kupfer/plugin/screen.py:3 ../kupfer/plugin/screen.py:89
 msgid "Active GNU Screen sessions"
-msgstr "Aktív GNU Screen munkafolyamatok"
+msgstr "Aktív GNU Screen munkamenetek"
 
-#: ../kupfer/plugin/screen.py:50
+#: ../kupfer/plugin/screen.py:57
 msgid "Attached"
-msgstr "Kapcsolódva"
+msgstr "Csatolva"
 
-#: ../kupfer/plugin/screen.py:51
+#: ../kupfer/plugin/screen.py:58
 msgid "Detached"
 msgstr "Leválasztva"
 
-#: ../kupfer/plugin/screen.py:54
+#: ../kupfer/plugin/screen.py:61
 #, python-format
 msgid "%(status)s session (%(pid)s) created %(time)s"
-msgstr "%(status)s munkafolyamat (%(pid)s) létrehozva: %(time)s"
+msgstr "%(status)s munkamenet (%(pid)s) létrehozva: %(time)s"
 
-#: ../kupfer/plugin/screen.py:63
+#: ../kupfer/plugin/screen.py:70
 msgid "Screen Sessions"
-msgstr "Screen munkafolyamatok"
+msgstr "Screen munkamenetek"
 
-#: ../kupfer/plugin/screen.py:91
+#: ../kupfer/plugin/screen.py:99
 msgid "Attach"
-msgstr "Kapcsolás"
+msgstr "Csatolás"
 
-#: ../kupfer/plugin/sendkeys.py:2 ../kupfer/plugin/sendkeys.py:49
+#: ../kupfer/plugin/sendkeys.py:2 ../kupfer/plugin/sendkeys.py:52
 msgid "Send Keys"
 msgstr "Billentyűk küldése"
 
 #: ../kupfer/plugin/sendkeys.py:8
 msgid "Send synthetic keyboard events using xautomation"
-msgstr "Billentyűnyomás szimulálása xautomation segítségével"
+msgstr ""
+"Szintetikus billentyűzet események küldése az xautomation használatával"
 
-#: ../kupfer/plugin/sendkeys.py:25
+#: ../kupfer/plugin/sendkeys.py:28
 msgid "Paste to Foreground Window"
 msgstr "Beillesztés a legelső ablakba"
 
-#: ../kupfer/plugin/sendkeys.py:43
+#: ../kupfer/plugin/sendkeys.py:46
 msgid "Copy to clipboard and send Ctrl+V to foreground window"
-msgstr "Másolás a vágólapra és ctrl-v küldése a legelső ablakba"
+msgstr "Másolás a vágólapra és Ctrl+V küldése a legelső ablaknak"
 
-#: ../kupfer/plugin/sendkeys.py:85
+#: ../kupfer/plugin/sendkeys.py:101
 msgid "Send keys to foreground window"
-msgstr "Billentyűnyomás küldése a legelső ablakba"
+msgstr "Billentyűk küldése a legelső ablaknak"
 
-#: ../kupfer/plugin/sendkeys.py:90
+#: ../kupfer/plugin/sendkeys.py:106
 msgid "Type Text"
-msgstr "Szöveg beírása"
+msgstr "Szöveg begépelése"
 
-#: ../kupfer/plugin/sendkeys.py:111
+#: ../kupfer/plugin/sendkeys.py:127
 msgid "Type the text to foreground window"
-msgstr "Szöveg beírása a legelső ablakba"
+msgstr "Szöveg begépelése a legelső ablakba"
 
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/services.py:2 ../kupfer/plugin/services.py:96
@@ -2517,28 +2634,30 @@ msgstr "Rendszerszolgáltatások"
 
 #: ../kupfer/plugin/services.py:4
 msgid "Start, stop or restart system services via init scripts"
-msgstr "Rendszerszolgáltatások (újra)indítása, leállítása az init szkriptekkel"
+msgstr ""
+"Rendszerszolgáltatások indítása, leállítása vagy újraindítása az init "
+"parancsfájlokkal"
 
 #: ../kupfer/plugin/services.py:18
 msgid "Sudo-like Command"
-msgstr "Sudo-féle parancs"
+msgstr "Sudo-szerű parancs"
 
 #: ../kupfer/plugin/services.py:78
 msgid "Start Service"
-msgstr "Rendszerszolgáltatás indítása"
+msgstr "Szolgáltatás indítása"
 
 #: ../kupfer/plugin/services.py:84
 msgid "Restart Service"
-msgstr "Rendszerszolgáltatás újraindítása"
+msgstr "Szolgáltatás újraindítása"
 
 #: ../kupfer/plugin/services.py:90
 msgid "Stop Service"
-msgstr "Rendszerszolgáltatás leállítása"
+msgstr "Szolgáltatás leállítása"
 
 #: ../kupfer/plugin/services.py:126
 #, python-format
 msgid "%s Service"
-msgstr "%s rendszerszolgáltatás"
+msgstr "%s szolgáltatás"
 
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/shorten_links.py:2
@@ -2547,7 +2666,7 @@ msgstr "Linkek rövidítése"
 
 #: ../kupfer/plugin/shorten_links.py:4
 msgid "Create short aliases of long URLs"
-msgstr "Hosszú URL-ek helyettesítése rövid változattal"
+msgstr "Hosszú URL-ek rövid álnevének létrehozása"
 
 #: ../kupfer/plugin/shorten_links.py:48
 msgid "Error"
@@ -2555,7 +2674,7 @@ msgstr "Hiba"
 
 #: ../kupfer/plugin/shorten_links.py:121
 msgid "Shorten With..."
-msgstr "Rövidítés..."
+msgstr "Rövidítés ezzel…"
 
 #: ../kupfer/plugin/shorten_links.py:151
 msgid "Services"
@@ -2569,56 +2688,51 @@ msgstr "QRCode megjelenítése"
 msgid "Display text as QRCode in a window"
 msgstr "Szöveg megjelenítése QRCode-ként egy ablakban"
 
-#. -*- coding: UTF-8 -*-
-#: ../kupfer/plugin/skype.py:2
-msgid "Skype"
-msgstr "Skype"
-
 #: ../kupfer/plugin/skype.py:5
 msgid "Access to Skype contacts"
-msgstr "Skype címtár elérése"
+msgstr "Hozzáférés a Skype partnerekhez"
 
 #: ../kupfer/plugin/skype.py:31
 msgid "Skype Me"
-msgstr "Skype me"
+msgstr "Skype Me"
 
 #: ../kupfer/plugin/skype.py:37
 msgid "Logged Out"
 msgstr "Kijelentkezve"
 
-#: ../kupfer/plugin/skype.py:183
+#: ../kupfer/plugin/skype.py:179
 #, python-format
 msgid "[%(status)s] %(userid)s"
 msgstr "[%(status)s] %(userid)s"
 
-#: ../kupfer/plugin/skype.py:225
+#: ../kupfer/plugin/skype.py:218
 msgid "Call"
 msgstr "Hívás"
 
-#: ../kupfer/plugin/skype.py:239
+#: ../kupfer/plugin/skype.py:232
 msgid "Place a call to contact"
 msgstr "Partner hívása"
 
-#: ../kupfer/plugin/skype.py:274
+#: ../kupfer/plugin/skype.py:267
 msgid "Skype Contacts"
-msgstr "Skype címtár"
+msgstr "Skype partnerek"
 
-#: ../kupfer/plugin/skype.py:294
+#: ../kupfer/plugin/skype.py:287
 msgid "Skype Statuses"
-msgstr "Skype státuszok"
+msgstr "Skype állapotok"
 
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/ssh_hosts.py:2 ../kupfer/plugin/ssh_hosts.py:70
 msgid "SSH Hosts"
-msgstr "SSH kiszolgálók"
+msgstr "SSH gépek"
 
 #: ../kupfer/plugin/ssh_hosts.py:3
 msgid "Adds the SSH hosts found in ~/.ssh/config."
-msgstr "SSH kiszolgálók listázása innen: ~/.ssh/config."
+msgstr "Hozzáadja a ~/.ssh/config helyen található SSH gépeket."
 
 #: ../kupfer/plugin/ssh_hosts.py:32
 msgid "SSH host"
-msgstr "SSH kiszolgáló"
+msgstr "SSH gép"
 
 #: ../kupfer/plugin/ssh_hosts.py:43
 msgid "Connect"
@@ -2626,15 +2740,29 @@ msgstr "Kapcsolódás"
 
 #: ../kupfer/plugin/ssh_hosts.py:49
 msgid "Connect to SSH host"
-msgstr "Kapcsolódás egy SSH kiszolgálóhoz"
+msgstr "Kapcsolódás SSH géphez"
 
 #: ../kupfer/plugin/ssh_hosts.py:102
 msgid "SSH hosts as specified in ~/.ssh/config"
-msgstr "SSH kiszolgálók, ahogy ~/.ssh/config tartalmazza"
+msgstr "SSH gépek a ~/.ssh/config helyen megadottak szerint"
 
 #: ../kupfer/plugin_support.py:144
 msgid "No D-Bus connection to desktop session"
-msgstr "Nincs D-Bus kapcsolat az asztali munkafolyamattal"
+msgstr "Nincs D-Bus kapcsolat az asztali munkamenettel"
+
+#: ../kupfer/plugin_support.py:171
+#| msgid "GNOME Terminal"
+msgid "GNOME Keyring"
+msgstr "GNOME kulcstartó"
+
+#: ../kupfer/plugin_support.py:172
+msgid "KWallet"
+msgstr "KWallet"
+
+#: ../kupfer/plugin_support.py:173
+#| msgid "Selected File"
+msgid "Unencrypted File"
+msgstr "Titkosítatlan fájl"
 
 #: ../kupfer/plugin/templates.py:1 ../kupfer/plugin/templates.py:107
 msgid "Document Templates"
@@ -2642,7 +2770,7 @@ msgstr "Dokumentumsablonok"
 
 #: ../kupfer/plugin/templates.py:4
 msgid "Create new documents from your templates"
-msgstr "Új dokumentum létrehozása sablonból"
+msgstr "Új dokumentumok létrehozása sablonokból"
 
 #: ../kupfer/plugin/templates.py:24
 #, python-format
@@ -2659,7 +2787,7 @@ msgstr "Új mappa"
 
 #: ../kupfer/plugin/templates.py:57
 msgid "Create New Document..."
-msgstr "Új dokumentum létrehozása..."
+msgstr "Új dokumentum létrehozása…"
 
 #: ../kupfer/plugin/templates.py:96
 msgid "Create a new document from template"
@@ -2667,7 +2795,7 @@ msgstr "Új dokumentum létrehozása sablonból"
 
 #: ../kupfer/plugin/templates.py:103
 msgid "Create Document In..."
-msgstr "Dokumentum létrehozása máshol..."
+msgstr "Dokumentum létrehozása itt…"
 
 #: ../kupfer/plugin/textfiles.py:13
 msgid "Textfiles"
@@ -2675,52 +2803,62 @@ msgstr "Szövegfájlok"
 
 #: ../kupfer/plugin/textfiles.py:51
 msgid "Append To..."
-msgstr "Hozzáfűzés másikhoz..."
+msgstr "Hozzáfűzés ehhez…"
 
 #: ../kupfer/plugin/textfiles.py:75
 msgid "Append..."
-msgstr "Hozzáfűzés..."
+msgstr "Hozzáfűzés…"
 
 #: ../kupfer/plugin/textfiles.py:79
 msgid "Write To..."
-msgstr "Mentés máshova..."
+msgstr "Írás ide…"
 
 #: ../kupfer/plugin/textfiles.py:111
 msgid "Get Text Contents"
-msgstr "Szöveg tartalmának átemelése"
+msgstr "Szöveg tartalmának megszerzése"
 
-#: ../kupfer/plugin/thunar.py:1 ../kupfer/plugin/thunar.py:184
-#: ../kupfer/plugin/thunar.py:224 ../kupfer/plugin/thunar.py:283
+#: ../kupfer/plugin/thunar.py:1 ../kupfer/plugin/thunar.py:185
+#: ../kupfer/plugin/thunar.py:225 ../kupfer/plugin/thunar.py:278
+#: ../kupfer/plugin/thunar.py:329
 msgid "Thunar"
 msgstr "Thunar"
 
-#: ../kupfer/plugin/thunar.py:10
+#: ../kupfer/plugin/thunar.py:11
 msgid "File manager Thunar actions"
-msgstr "Thunar fáljkezelő parancsok"
+msgstr "Thunar fájlkezelő műveletek"
 
-#: ../kupfer/plugin/thunar.py:66
+#: ../kupfer/plugin/thunar.py:67
 msgid "Select in File Manager"
-msgstr "Kijelölés fáljkezelőben"
+msgstr "Kijelölés a fájlkezelőben"
 
-#: ../kupfer/plugin/thunar.py:94
+#: ../kupfer/plugin/thunar.py:95
 msgid "Show Properties"
 msgstr "Tulajdonságok megjelenítése"
 
-#: ../kupfer/plugin/thunar.py:117
+#: ../kupfer/plugin/thunar.py:118
 msgid "Show information about file in file manager"
-msgstr "A fájl tulajdonságainak megjelenítése a fáljkezelőben"
+msgstr "A fájl információinak megjelenítése a fájlkezelőben"
 
-#: ../kupfer/plugin/thunar.py:126
+#: ../kupfer/plugin/thunar.py:127
 msgid "Send To..."
-msgstr "Küldés máshova..."
+msgstr "Küldés ide…"
 
-#: ../kupfer/plugin/thunar.py:258
+#: ../kupfer/plugin/thunar.py:259
+msgid "Symlink In..."
+msgstr "Szimbolikus link ebben…"
+
+#: ../kupfer/plugin/thunar.py:300
+#| msgid "Copy file to a chosen location"
+msgid "Create a symlink to file in a chosen location"
+msgstr "Szimbolikus link létrehozása a fájlra a kiválasztott helyen"
+
+#: ../kupfer/plugin/thunar.py:304
 msgid "Empty Trash"
-msgstr "Szemétkosár kiürítése"
+msgstr "Kuka ürítése"
 
-#: ../kupfer/plugin/thunar.py:298
+#: ../kupfer/plugin/thunar.py:344
 msgid "Thunar Send To Objects"
-msgstr "Thunar küldés objektumok"
+msgstr "Thunar „küldés ide” objektumok"
 
 #: ../kupfer/plugin/thunderbird.py:4
 msgid "Thunderbird"
@@ -2728,19 +2866,19 @@ msgstr "Thunderbird"
 
 #: ../kupfer/plugin/thunderbird.py:7
 msgid "Thunderbird/Icedove Contacts and Actions"
-msgstr "Thunderbird/Icedove címtár és akciók"
+msgstr "Thunderbird/Icedove partnerek és műveletek"
 
-#: ../kupfer/plugin/thunderbird.py:36
+#: ../kupfer/plugin/thunderbird.py:38
 msgid "Compose a new message in Thunderbird"
-msgstr "Új levél írása Thunderbird-ben"
+msgstr "Új üzenet írása a Thunderbirdben"
 
-#: ../kupfer/plugin/thunderbird.py:69
+#: ../kupfer/plugin/thunderbird.py:74
 msgid "Thunderbird Address Book"
 msgstr "Thunderbird címjegyzék"
 
-#: ../kupfer/plugin/thunderbird.py:93
+#: ../kupfer/plugin/thunderbird.py:99
 msgid "Contacts from Thunderbird Address Book"
-msgstr "Címek a Thunderbird címtárából"
+msgstr "Partnerek a Thunderbird címjegyzékből"
 
 #: ../kupfer/plugin/top.py:4
 msgid "Top"
@@ -2748,11 +2886,11 @@ msgstr "Top"
 
 #: ../kupfer/plugin/top.py:6
 msgid "Show running tasks and allow sending signals to them"
-msgstr "Futó taszkok megjelenítése és szignálok küldése"
+msgstr "Futó feladatok megjelenítése és szignálok küldésének lehetővé tétele"
 
 #: ../kupfer/plugin/top.py:23
 msgid "Sort Order"
-msgstr "Sorrend"
+msgstr "Rendezési sorrend"
 
 #: ../kupfer/plugin/top.py:25 ../kupfer/plugin/top.py:26
 #: ../kupfer/plugin/top.py:115
@@ -2761,7 +2899,7 @@ msgstr "Parancssor"
 
 #: ../kupfer/plugin/top.py:26
 msgid "CPU usage (descending)"
-msgstr "CPU használat"
+msgstr "CPU használat (csökkenő)"
 
 #. sort processes (top don't allow to sort via cmd line)
 #: ../kupfer/plugin/top.py:27 ../kupfer/plugin/top.py:112
@@ -2770,7 +2908,7 @@ msgstr "Memóriahasználat (csökkenő)"
 
 #: ../kupfer/plugin/top.py:49
 msgid "Send Signal..."
-msgstr "Szignál küldése..."
+msgstr "Szignál küldése…"
 
 #: ../kupfer/plugin/top.py:79
 msgid "Signals"
@@ -2778,7 +2916,7 @@ msgstr "Szignálok"
 
 #: ../kupfer/plugin/top.py:91
 msgid "Running Tasks"
-msgstr "Futó taszkok"
+msgstr "Futó feladatok"
 
 #. default: by cpu
 #: ../kupfer/plugin/top.py:119
@@ -2788,73 +2926,31 @@ msgstr "pid: %(pid)s  cpu: %(cpu)g%%  mem: %(mem)g%%  idő: %(time)s"
 
 #: ../kupfer/plugin/top.py:139
 msgid "Running tasks for current user"
-msgstr "Aktív felhasználó futó taszkjai"
-
-#: ../kupfer/plugin/tracker.py:5
-msgid "Tracker 0.6"
-msgstr "Tracker 0.6"
-
-#: ../kupfer/plugin/tracker.py:15 ../kupfer/plugin/tracker1.py:18
-msgid "Tracker desktop search integration"
-msgstr "Tracker asztali kereső integráció"
-
-#: ../kupfer/plugin/tracker.py:41 ../kupfer/plugin/tracker1.py:49
-msgid "Search in Tracker"
-msgstr "Keresés a Tracker-ben"
-
-#: ../kupfer/plugin/tracker.py:46 ../kupfer/plugin/tracker1.py:54
-msgid "Open Tracker Search Tool and search for this term"
-msgstr "Tracker megnyitása és keresés a megadott kifejezésre"
-
-#: ../kupfer/plugin/tracker.py:55 ../kupfer/plugin/tracker1.py:62
-msgid "Get Tracker Results..."
-msgstr "Tracker eredményeinek beemelése..."
-
-#: ../kupfer/plugin/tracker.py:64 ../kupfer/plugin/tracker1.py:71
-msgid "Show Tracker results for query"
-msgstr "A Tracker keresés eredményének megjelenítése"
-
-#: ../kupfer/plugin/tracker.py:165 ../kupfer/plugin/tracker.py:171
-msgid "Tracker tags"
-msgstr "Tracker cimkék"
-
-#: ../kupfer/plugin/tracker.py:180
-msgid "Tracker Tags"
-msgstr "Tracker cimkék"
-
-#: ../kupfer/plugin/tracker.py:186
-msgid "Browse Tracker's tags"
-msgstr "Tracker cimkék böngészése"
-
-#: ../kupfer/plugin/tracker.py:197 ../kupfer/plugin/tracker.py:204
-#, python-format
-msgid "Tag %s"
-msgstr "%s cimke"
-
-#: ../kupfer/plugin/tracker.py:211
-#, python-format
-msgid "Objects tagged %s with Tracker"
-msgstr "Elemek, Tracker-ben %s cimkével"
-
-#: ../kupfer/plugin/tracker.py:223
-msgid "Add Tag..."
-msgstr "Cimke hozzáadása..."
-
-#: ../kupfer/plugin/tracker.py:249
-msgid "Add tracker tag to file"
-msgstr "Tracker cimke hozzáadása fájlhoz"
-
-#: ../kupfer/plugin/tracker.py:255
-msgid "Remove Tag..."
-msgstr "Cimke eltávolítása..."
-
-#: ../kupfer/plugin/tracker.py:274
-msgid "Remove tracker tag from file"
-msgstr "Cimke eltávolítása fájlból"
+msgstr "A jelenlegi felhasználó futó feladatai"
 
 #: ../kupfer/plugin/tracker1.py:10
 msgid "Tracker"
 msgstr "Tracker"
+
+#: ../kupfer/plugin/tracker1.py:18
+msgid "Tracker desktop search integration"
+msgstr "Tracker asztali kereső integráció"
+
+#: ../kupfer/plugin/tracker1.py:49
+msgid "Search in Tracker"
+msgstr "Keresés a Trackerben"
+
+#: ../kupfer/plugin/tracker1.py:54
+msgid "Open Tracker Search Tool and search for this term"
+msgstr "Tracker keresőeszköz megnyitása és keresés erre a kifejezésre"
+
+#: ../kupfer/plugin/tracker1.py:62
+msgid "Get Tracker Results..."
+msgstr "Tracker eredményeinek megszerzése…"
+
+#: ../kupfer/plugin/tracker1.py:71
+msgid "Show Tracker results for query"
+msgstr "A Tracker eredményeinek megjelenítése a lekérdezéshez"
 
 #. FIXME: Port tracker tag sources and actions
 #. to the new, much more powerful sparql + dbus API
@@ -2866,48 +2962,89 @@ msgstr "TrueCrypt"
 
 #: ../kupfer/plugin/truecrypt.py:6 ../kupfer/plugin/truecrypt.py:140
 msgid "Volumes from TrueCrypt history"
-msgstr "Korábban használt kötegek a TrueCrypt-ben"
+msgstr "Kötetek a TrueCrypt előzményeiből"
 
 #: ../kupfer/plugin/truecrypt.py:44
 #, python-format
 msgid "TrueCrypt volume: %(file)s"
-msgstr "TrueCrypt köteg: %(file)s"
+msgstr "TrueCrypt kötet: %(file)s"
 
 #: ../kupfer/plugin/truecrypt.py:52
 msgid "Mount Volume"
-msgstr "Köteg csatolása"
+msgstr "Kötet csatolása"
 
 #: ../kupfer/plugin/truecrypt.py:63
 msgid "Mount in Truecrypt"
-msgstr "Felcsatolás TrueCrypt-ben"
+msgstr "Csatolás a TrueCryptben"
 
 #: ../kupfer/plugin/truecrypt.py:72
 msgid "Try to mount file as Truecrypt volume"
-msgstr "Fájl felcsatolása TrueCrypt kötegként"
+msgstr "Fájl csatolásának próbája TrueCrypt kötetként"
 
 #: ../kupfer/plugin/truecrypt.py:80
 msgid "Dismount All Volumes"
-msgstr "Minden köteg leválasztása"
+msgstr "Minden kötet leválasztása"
 
 #: ../kupfer/plugin/truecrypt.py:98
 msgid "TrueCrypt Volumes"
-msgstr "TrueCrypt kötegek"
+msgstr "TrueCrypt kötetek"
 
 #: ../kupfer/plugin/tsclient.py:4
 msgid "Terminal Server Client"
-msgstr "Terminal Server Client"
+msgstr "Terminálkiszolgáló kliens"
 
 #: ../kupfer/plugin/tsclient.py:7
 msgid "Session saved in Terminal Server Client"
-msgstr "Terminal Server Client-ben tárolt munkafolyamat"
+msgstr "A terminálkiszolgáló kliensben elmentett munkamenet"
 
 #: ../kupfer/plugin/tsclient.py:72
 msgid "TSClient sessions"
-msgstr "TSClient munkafolyamatok"
+msgstr "TSClient munkamenetek"
 
 #: ../kupfer/plugin/tsclient.py:94
 msgid "Saved sessions in Terminal Server Client"
-msgstr "Terminal Server Client-ben tárolt munkafolyamatok"
+msgstr "A terminálkiszolgáló kliensben elmentett munkamenetek"
+
+#: ../kupfer/plugin/vim/__init__.py:1
+msgid "Vim"
+msgstr "Vim"
+
+#: ../kupfer/plugin/vim/__init__.py:4
+msgid "Recently used documents in Vim"
+msgstr "Nemrég használt dokumentumok a Vim-ben"
+
+#: ../kupfer/plugin/vim/plugin.py:56
+msgid "Vim Recent Documents"
+msgstr "Vim legutóbbi dokumentumok"
+
+#: ../kupfer/plugin/vim/plugin.py:219
+msgid "Close (Save All)"
+msgstr "Bezárás (Összes mentése)"
+
+#: ../kupfer/plugin/vim/plugin.py:237
+#| msgid "Send To..."
+msgid "Send..."
+msgstr "Küldés…"
+
+#: ../kupfer/plugin/vim/plugin.py:264
+#| msgid "Saved Kupfer Command"
+msgid "Send ex command"
+msgstr "Ex parancs küldése"
+
+#: ../kupfer/plugin/vim/plugin.py:272
+msgid "Insert in Vim..."
+msgstr "Beszúrás a Vim-be…"
+
+#: ../kupfer/plugin/vim/plugin.py:309
+#| msgid "Active GNU Screen sessions"
+msgid "Active Vim Sessions"
+msgstr "Aktív Vim munkamenetek"
+
+#: ../kupfer/plugin/vim/plugin.py:338
+#, python-format
+#| msgid "PuTTY Sessions"
+msgid "Vim Session %s"
+msgstr "Vim munkamenet %s"
 
 #: ../kupfer/plugin/vinagre.py:4
 msgid "Vinagre"
@@ -2915,27 +3052,15 @@ msgstr "Vinagre"
 
 #: ../kupfer/plugin/vinagre.py:7
 msgid "Vinagre bookmarks and actions"
-msgstr "Vinagre könyvjelzők és parancsok"
+msgstr "Vinagre könyvjelzők és műveletek"
 
 #: ../kupfer/plugin/vinagre.py:34
 msgid "Start Vinagre Session"
-msgstr "Vinagre munkafolyamat indítása"
+msgstr "Vinagre munkamenet indítása"
 
 #: ../kupfer/plugin/vinagre.py:72
 msgid "Vinagre Bookmarks"
 msgstr "Vinagre könyvjelzők"
-
-#: ../kupfer/plugin/vim.py:1
-msgid "Vim"
-msgstr "Vim"
-
-#: ../kupfer/plugin/vim.py:3
-msgid "Recently used documents in Vim"
-msgstr "Nemrég használt dokumentumok a Vim-ben"
-
-#: ../kupfer/plugin/vim.py:46
-msgid "Vim Recent Documents"
-msgstr "Vim legutóbbi dokumentumok"
 
 #. -*- coding: UTF-8 -*-
 #: ../kupfer/plugin/virtualbox/__init__.py:3
@@ -2947,12 +3072,12 @@ msgid ""
 "Control VirtualBox Virtual Machines. Supports both Sun VirtualBox and Open "
 "Source Edition."
 msgstr ""
-"VirtualBox virtuális gépek használata. Támogatja mind a Sun és az Open "
-"Source Edition-t"
+"VirtualBox virtuális gépek vezérlése. Támogatja a Sun Virtualboxot és a nyílt "
+"forrású változatot is."
 
 #: ../kupfer/plugin/virtualbox/__init__.py:22
 msgid "Force use CLI interface"
-msgstr "Parancssori környezet kényszerítése"
+msgstr "Parancssori felület használatának erőltetése"
 
 #: ../kupfer/plugin/virtualbox/__init__.py:86
 #: ../kupfer/plugin/virtualbox/__init__.py:97
@@ -2962,7 +3087,7 @@ msgstr "Bekapcsolás"
 #: ../kupfer/plugin/virtualbox/__init__.py:88
 #: ../kupfer/plugin/virtualbox/__init__.py:99
 msgid "Power On Headless"
-msgstr "Bekapcsolás felület nélküli üzemben"
+msgstr "Bekapcsolás felület nélkül"
 
 #: ../kupfer/plugin/virtualbox/__init__.py:91
 msgid "Send Power Off Signal"
@@ -2993,43 +3118,156 @@ msgstr "VirtualBox gépek"
 msgid "Zim"
 msgstr "Zim"
 
-#: ../kupfer/plugin/zim.py:10
+#: ../kupfer/plugin/zim.py:11
 msgid "Access to Pages stored in Zim - A Desktop Wiki and Outliner"
-msgstr "Hozzárérés Zim - Asztali Wiki-ben tárolt oldalakhoz"
+msgstr ""
+"Hozzáférés a „Zim - egy asztali Wiki és vázlatkészítőben” tárolt oldalakhoz"
 
-#: ../kupfer/plugin/zim.py:28
+#: ../kupfer/plugin/zim.py:30
 msgid "Page names start with :colon"
-msgstr "Az oldalak neve ezzel kezdődik: :colon"
+msgstr "Az oldalak neve :colon-nal kezdődik"
 
-#: ../kupfer/plugin/zim.py:58
+#: ../kupfer/plugin/zim.py:36
+msgid "Default page name for quick notes"
+msgstr "Alapértelmezett oldalnév a gyors jegyzetekhez"
+
+#: ../kupfer/plugin/zim.py:38
+#, python-format
+msgid "Note %x %X"
+msgstr "Jegyzet %x %X"
+
+#: ../kupfer/plugin/zim.py:39
+msgid ""
+"Strftime tags can be used: %H - hour, %M - minutes, etc\n"
+"Please check python documentation for details.\n"
+"NOTE: comma will be replaced by _"
+msgstr ""
+"Az strftime címkék használhatók: %H - óra, %M - perc, stb.\n"
+"Nézze meg a python dokumentációját a részletekért.\n"
+"MEGJEGYZÉS: a vessző _ jellel lesz helyettesítve"
+
+#: ../kupfer/plugin/zim.py:45
+msgid "Default namespace for quick notes"
+msgstr "Alapértelmezett névtér a gyors jegyzetekhez"
+
+#: ../kupfer/plugin/zim.py:80
 #, python-format
 msgid "Zim Page from Notebook \"%s\""
-msgstr "Zim oldal a \"%s\" jegyzettömbből"
+msgstr "Zim oldal a(z) „%s” jegyzettömbből"
 
-#: ../kupfer/plugin/zim.py:67
+#: ../kupfer/plugin/zim.py:89
 msgid "Create Zim Page"
 msgstr "Zim oldal létrehozása"
 
-#: ../kupfer/plugin/zim.py:74
+#: ../kupfer/plugin/zim.py:96
 msgid "Create page in default notebook"
-msgstr "Új oldal létrehozása az alapértelmezett jegyzettömbben"
+msgstr "Oldal létrehozása az alapértelmezett jegyzettömbben"
 
-#: ../kupfer/plugin/zim.py:84
+#: ../kupfer/plugin/zim.py:108
 msgid "Create Zim Page In..."
-msgstr "Zim oldal létrehozása máshol..."
+msgstr "Zim oldal létrehozása itt…"
 
-#: ../kupfer/plugin/zim.py:122
+#: ../kupfer/plugin/zim.py:132
+msgid "Insert QuickNote into Zim"
+msgstr "QuickNote beszúrása a Zimbe"
+
+#: ../kupfer/plugin/zim.py:142
+msgid "Quick note selected text into Zim notebook"
+msgstr "Gyors jegyzet a kijelölt szövegből a Zim jegyzettömbbe"
+
+#: ../kupfer/plugin/zim.py:191
 msgid "Create Subpage..."
-msgstr "Aloldal létrehozása..."
+msgstr "Aloldal létrehozása…"
 
-#: ../kupfer/plugin/zim.py:243
+#: ../kupfer/plugin/zim.py:370
 msgid "Zim Notebooks"
 msgstr "Zim jegyzettömbök"
 
-#: ../kupfer/plugin/zim.py:259
+#: ../kupfer/plugin/zim.py:387
 msgid "Zim Pages"
 msgstr "Zim oldalak"
 
-#: ../kupfer/plugin/zim.py:287
+#: ../kupfer/plugin/zim.py:415
 msgid "Pages stored in Zim Notebooks"
 msgstr "Zim jegyzettömbben tárolt oldalak"
+
+#~ msgid "run keyboard shortcut relay service on this display"
+#~ msgstr "Billentyűtovábbító szolgáltatás engedélyezése ezen a képernyőn"
+
+#~ msgid "Selected Text \"%s\""
+#~ msgstr "Kijelölt szöveg \"%s\""
+
+#~ msgid "Recent clipboards"
+#~ msgstr "Legutóbbi vágólap-tartalmak"
+
+#~ msgid "Include recent selections"
+#~ msgstr "Legutolsó kijelölések beleszámítása"
+
+#~ msgid ""
+#~ "Provides current nautilus selection, using Kupfer's Nautilus Extension"
+#~ msgstr ""
+#~ "Hozzáférés a Nautilusban kiválasztott elemhez, a Kupfer Nautilus "
+#~ "kiegészítő segítségével"
+
+#~ msgid "Selected File \"%s\""
+#~ msgstr "Kiválasztott fájl \"%s\""
+
+#~ msgid "Selected Files"
+#~ msgstr "Kiválasztott fájlok"
+
+#~ msgid "Translate text with Google Translate"
+#~ msgstr "Szöveg lefordítása Google fordítóval"
+
+#~ msgid "Google Translate connection timed out"
+#~ msgstr "Google fordítóval a kapcsolat megszakadt"
+
+#~ msgid "Error connecting to Google Translate"
+#~ msgstr "Nem sikerült kapcsolódni a Google fordítóhoz"
+
+#~ msgid "Translate To..."
+#~ msgstr "Fordítás..."
+
+#~ msgid "Translate into %s"
+#~ msgstr "Fordítás %s-ra"
+
+#~ msgid "Languages"
+#~ msgstr "Nyelvek"
+
+#~ msgid "Show translated page in browser"
+#~ msgstr "A lefordított szöveg megjelenítése böngészőben"
+
+#~ msgid "Show Translation To..."
+#~ msgstr "Szöveg lefordítása erre..."
+
+#~ msgid "Show translation in browser"
+#~ msgstr "Fordítás megjelenítése böngészőben"
+
+#~ msgid "Tracker 0.6"
+#~ msgstr "Tracker 0.6"
+
+#~ msgid "Tracker tags"
+#~ msgstr "Tracker cimkék"
+
+#~ msgid "Tracker Tags"
+#~ msgstr "Tracker cimkék"
+
+#~ msgid "Browse Tracker's tags"
+#~ msgstr "Tracker cimkék böngészése"
+
+#~ msgid "Tag %s"
+#~ msgstr "%s cimke"
+
+#~ msgid "Objects tagged %s with Tracker"
+#~ msgstr "Elemek, Tracker-ben %s cimkével"
+
+#~ msgid "Add Tag..."
+#~ msgstr "Cimke hozzáadása..."
+
+#~ msgid "Add tracker tag to file"
+#~ msgstr "Tracker cimke hozzáadása fájlhoz"
+
+#~ msgid "Remove Tag..."
+#~ msgstr "Cimke eltávolítása..."
+
+#~ msgid "Remove tracker tag from file"
+#~ msgstr "Cimke eltávolítása fájlból"


### PR DESCRIPTION
Instead of invoking the screensaver for locking the screen, the script `xflock4` is called now. This should work on all systems, no matter if they use a screensaver such as xscreensaver or another tool to lock the screen (e.g. lightlocker in Xubuntu 14.04).
