### PR TITLE
port chromium plugin to Python 3, change UrlLeaf icon to web-browser

### DIFF
--- a/kupfer/obj/objects.py
+++ b/kupfer/obj/objects.py
@@ -440,7 +440,7 @@ class UrlLeaf (Leaf, TextRepresentation):
         return self.object
 
     def get_icon_name(self):
-        return "text-html"
+        return "web-browser"
 
 class RunnableLeaf (Leaf):
     """Leaf where the Leaf is basically the action itself,

--- a/kupfer/plugin/chromium.py
+++ b/kupfer/plugin/chromium.py
@@ -1,6 +1,6 @@
-__kupfer_name__ = _("Chromium Bookmarks")
+__kupfer_name__ = ("Chromium Bookmarks")
 __kupfer_sources__ = ("BookmarksSource", )
-__description__ = _("Index of Chromium bookmarks")
+__description__ = ("Index of Chromium bookmarks")
 __version__ = ""
 __author__ = "Francesco Marella <francesco.marella@gmail.com>"
 
@@ -13,7 +13,7 @@ from kupfer.obj.apps import AppLeafContentMixin
 class BookmarksSource (AppLeafContentMixin, Source):
     appleaf_content_id = ("chromium-browser")
     def __init__(self):
-        super(BookmarksSource, self).__init__(_("Chromium Bookmarks"))
+        super(BookmarksSource, self).__init__(("Chromium Bookmarks"))
 
     def _get_chromium_items(self, fpath):
         """Parse Chromium' bookmarks backups"""
@@ -40,7 +40,7 @@ class BookmarksSource (AppLeafContentMixin, Source):
         return []
 
     def get_description(self):
-        return _("Index of Chromium bookmarks")
+        return ("Index of Chromium bookmarks")
     def get_icon_name(self):
         return "chromium-browser"
     def provides(self):

--- a/kupfer/plugin/chromium_support.py
+++ b/kupfer/plugin/chromium_support.py
@@ -17,7 +17,7 @@ def get_bookmarks(bookmarks_file):
         return []
 
     with open(bookmarks_file) as f:
-        content = f.read().decode("UTF-8")
+        content = f.read()
         root = json_decoder(content)
 
     # make a dictionary of unique bookmarks
@@ -52,5 +52,5 @@ def get_bookmarks(bookmarks_file):
     return list(bmap.values())
 
 if __name__ == "__main__":
-    fpath = os.path.expanduser("~/.config/chromium/Default/")
+    fpath = os.path.expanduser("~/.config/chromium/Default/Bookmarks")
     print("Parsed # bookmarks:", len(list(get_bookmarks(fpath))))


### PR DESCRIPTION
Not many changes were necessary to make the plugin run on Python 3. For me the bookmark file is `~/.config/chromium/Default/Bookmarks`. I just changed this path, removed the UTF-8 decode, as Python 3 is UTF-8 default and some unnecessary `_` that were not accepted by Python 3.

A second change I made is to switch the icon of `UrlLeaf` to web-browser. For me this looks much more intuitive to open the web-browser instead of showing the html icon.
