### PR TITLE
use modern Ayatana Indicators

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,8 +84,8 @@ known to work.
 Opportunistic dependencies
 
 * If available, 'setproctitle' is used to set the process name
-* If available, you can use AppIndicator3. On debian the package name
-  needed for the dependency is ``gir1.2-appindicator3-0.1`` (g-i bindings).
+* If available, you can use AyatanaAppIndicator3. On debian the package name
+  needed for the dependency is ``gir1.2-ayatanaappindicator3-0.1`` (g-i bindings).
 
 Recommended dependencies
 

--- a/kupfer/__init__.py
+++ b/kupfer/__init__.py
@@ -8,4 +8,4 @@ with suppress(ValueError):
     gi.require_version("Wnck", "3.0")
 
 with suppress(ValueError):
-    gi.require_version("AppIndicator3", "0.1")
+    gi.require_version("AyatanaAppIndicator3", "0.1")

--- a/kupfer/core/settings.py
+++ b/kupfer/core/settings.py
@@ -526,7 +526,7 @@ class SettingsController(GObject.GObject, pretty.OutputMixin):  # type: ignore
         return self.set_config("Kupfer", "showstatusicon", enabled)
 
     def get_show_status_icon_ai(self) -> bool:
-        """Convenience: Show icon in notification area as bool (AppIndicator3)"""
+        """Convenience: Show icon in notification area as bool (AyatanaAppIndicator3)"""
         return _strbool(self.get_config("Kupfer", "showstatusicon_ai"))
 
     def set_show_status_icon_ai(self, enabled: bool) -> bool:

--- a/kupfer/main.py
+++ b/kupfer/main.py
@@ -182,7 +182,7 @@ def _gtkmain(
         gi.require_version("Wnck", "3.0")
 
     with suppress(ValueError):
-        gi.require_version("AppIndicator3", "0.1")
+        gi.require_version("AyatanaAppIndicator3", "0.1")
 
     return run_function(*args, **kwargs)
 

--- a/kupfer/ui/browser.py
+++ b/kupfer/ui/browser.py
@@ -9,7 +9,7 @@ import cairo
 from gi.repository import Gdk, GLib, Gtk
 
 try:
-    from gi.repository import AppIndicator3
+    from gi.repository import AyatanaAppIndicator3 as AppIndicator3
 except ImportError:
     AppIndicator3 = None
 
@@ -206,7 +206,7 @@ class WindowController(pretty.OutputMixin):
                 self._statusicon = None
 
     def _show_statusicon_ai(self) -> None:
-        """Show (create if not exists) status icon using AppIndicator3."""
+        """Show (create if not exists) status icon using AyatanaAppIndicator3."""
         if AppIndicator3 is None:
             return
 

--- a/kupfer/ui/preferences.py
+++ b/kupfer/ui/preferences.py
@@ -1329,7 +1329,7 @@ class _SourceListController:
 
 def _supports_app_indicator() -> bool:
     try:
-        gi.require_version("AppIndicator3", "0.1")
+        gi.require_version("AyatanaAppIndicator3", "0.1")
     except ValueError:
         return False
 


### PR DESCRIPTION
To make your great launcher more functional I have just switched it to Ayatana Indicators.

Please note that according to `rmadison gir1.2-appindicator3-0.1`

```
$ rmadison gir1.2-appindicator3-0.1
gir1.2-appindicator3-0.1 | 0.4.92-7      | oldoldstable | amd64, arm64, armhf, i386
```

the mentioned package was last available in Debian 10, which reached EOL and is supported by ELTS, so it is probably not popular today.