### PR TITLE
launch: update for renamed org.gnome.Yelp.desktop

### DIFF
--- a/kupfer/launch.py
+++ b/kupfer/launch.py
@@ -771,7 +771,7 @@ def show_help_url(url: str) -> bool:
     if not default:
         return False
 
-    help_viewer_id = "yelp.desktop"
+    help_viewer_id = "org.gnome.Yelp.desktop"
 
     try:
         yelp = Gio.DesktopAppInfo.new(help_viewer_id)


### PR DESCRIPTION
GNOME's help viewer, Yelp, changed its .desktop name with the Yelp 49.0 release.